### PR TITLE
ARGO-895 Create Metric Timelines

### DIFF
--- a/flink_jobs/batch_ar/src/main/java/argo/batch/ArgoArBatch.java
+++ b/flink_jobs/batch_ar/src/main/java/argo/batch/ArgoArBatch.java
@@ -10,7 +10,6 @@ import com.mongodb.hadoop.mapred.MongoOutputFormat;
 import com.mongodb.hadoop.io.BSONWritable;
 import com.mongodb.hadoop.util.MongoConfigUtil;
 
-
 import argo.avro.GroupEndpoint;
 import argo.avro.GroupGroup;
 import argo.avro.MetricData;
@@ -59,6 +58,60 @@ public class ArgoArBatch {
 		// set up the execution environment
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 
+		// make parameters available in the web interface
+		env.getConfig().setGlobalJobParameters(params);
+		env.setParallelism(1);
+		// sync data for input
+		Path mps = new Path(params.getRequired("mps"));
+		Path egp = new Path(params.getRequired("egp"));
+		Path ggp = new Path(params.getRequired("ggp"));
+
+		DataSource<String> opsDS = env.readTextFile(params.getRequired("ops"));
+		DataSource<String> aprDS = env.readTextFile(params.getRequired("apr"));
+		DataSource<String> recDS = env.readTextFile(params.getRequired("rec"));
+
+		// sync data input: metric profile in avro format
+		AvroInputFormat<MetricProfile> mpsAvro = new AvroInputFormat<MetricProfile>(mps, MetricProfile.class);
+		DataSet<MetricProfile> mpsDS = env.createInput(mpsAvro);
+
+		// sync data input: endpoint group topology data in avro format
+		AvroInputFormat<GroupEndpoint> egpAvro = new AvroInputFormat<GroupEndpoint>(egp, GroupEndpoint.class);
+		DataSet<GroupEndpoint> egpDS = env.createInput(egpAvro);
+
+		// sync data input: group of group topology data in avro format
+		AvroInputFormat<GroupGroup> ggpAvro = new AvroInputFormat<GroupGroup>(ggp, GroupGroup.class);
+		DataSet<GroupGroup> ggpDS = env.createInput(ggpAvro);
+
+		// todays metric data
+		Path in = new Path(params.getRequired("mdata"));
+		AvroInputFormat<MetricData> mdataAvro = new AvroInputFormat<MetricData>(in, MetricData.class);
+		DataSet<MetricData> mdataDS = env.createInput(mdataAvro);
+
+		// previous metric data
+		Path pin = new Path(params.getRequired("pdata"));
+		AvroInputFormat<MetricData> pdataAvro = new AvroInputFormat<MetricData>(pin, MetricData.class);
+		DataSet<MetricData> pdataDS = env.createInput(pdataAvro);
+
+		// Find the latest day
+		DataSet<MetricData> pdataMin = pdataDS.groupBy("service", "hostname", "metric")
+				.sortGroup("timestamp", Order.DESCENDING).first(1);
+
+		DataSet<MetricData> mdataTotalDS = mdataDS.union(pdataMin);
+
+		// Discard unused data and attach endpoint group as information
+		DataSet<MetricData> mdataTrimDS = mdataTotalDS.flatMap(new PickEndpoints(params)).withBroadcastSet(mpsDS, "mps")
+				.withBroadcastSet(egpDS, "egp").withBroadcastSet(ggpDS, "ggp").withBroadcastSet(aprDS, "apr")
+				.withBroadcastSet(recDS, "rec");
+
+		// Create a dataset of metric timelines
+		DataSet<MonTimeline> metricTimelinesDS = mdataTrimDS.groupBy("service", "hostname","metric")
+				.sortGroup("timestamp", Order.ASCENDING)
+				.reduceGroup(new CreateMetricTimeline(params)).withBroadcastSet(mpsDS, "mps")
+				.withBroadcastSet(egpDS, "egp").withBroadcastSet(ggpDS, "ggp").withBroadcastSet(opsDS, "ops")
+				.withBroadcastSet(aprDS, "aps");
+		
+		metricTimelinesDS.writeAsText("/tmp/batch-ar-output01");
+	 
 
 		env.execute("Flink Ar Batch Job");
 

--- a/flink_jobs/batch_ar/src/main/java/argo/batch/CreateMetricTimeline.java
+++ b/flink_jobs/batch_ar/src/main/java/argo/batch/CreateMetricTimeline.java
@@ -1,0 +1,167 @@
+package argo.batch;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map.Entry;
+
+import org.apache.flink.api.common.functions.RichGroupReduceFunction;
+
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.esotericsoftware.minlog.Log;
+
+import argo.avro.GroupEndpoint;
+import argo.avro.GroupGroup;
+import argo.avro.MetricData;
+import argo.avro.MetricProfile;
+import ops.DTimeline;
+import ops.OpsManager;
+import sync.AggregationProfileManager;
+import sync.EndpointGroupManager;
+import sync.GroupGroupManager;
+import sync.MetricProfileManager;
+
+/**
+ * Accepts a list of metric data grouped by the fields: endpoint group, service,
+ * endpoint, metric and produces a mon timeline
+ */
+public class CreateMetricTimeline extends RichGroupReduceFunction<MetricData, MonTimeline> {
+
+	private static final long serialVersionUID = 1L;
+
+	final ParameterTool params;
+
+	public CreateMetricTimeline(ParameterTool params) {
+		this.params = params;
+	}
+
+	static Logger LOG = LoggerFactory.getLogger(ArgoArBatch.class);
+
+	private List<MetricProfile> mps;
+	private List<String> aps;
+	private List<String> ops;
+	private List<GroupEndpoint> egp;
+	private List<GroupGroup> ggp;
+	private MetricProfileManager mpsMgr;
+	private AggregationProfileManager apsMgr;
+	private EndpointGroupManager egpMgr;
+	private GroupGroupManager ggpMgr;
+	private OpsManager opsMgr;
+	private String runDate;
+	private String egroupType;
+
+	private boolean fillMissing;
+
+	@Override
+	public void open(Configuration parameters) throws IOException {
+
+		this.runDate = params.getRequired("run.date");
+		// Get data from broadcast variables
+		this.mps = getRuntimeContext().getBroadcastVariable("mps");
+		this.aps = getRuntimeContext().getBroadcastVariable("aps");
+		this.ops = getRuntimeContext().getBroadcastVariable("ops");
+		this.egp = getRuntimeContext().getBroadcastVariable("egp");
+		this.ggp = getRuntimeContext().getBroadcastVariable("ggp");
+		// Initialize metric profile manager
+		this.mpsMgr = new MetricProfileManager();
+		this.mpsMgr.loadFromList(mps);
+		// Initialize aggregation profile manager
+		this.apsMgr = new AggregationProfileManager();
+
+		this.apsMgr.loadJsonString(aps);
+		// Initialize operations manager
+		this.opsMgr = new OpsManager();
+		this.opsMgr.loadJsonString(ops);
+
+		// Initialize endpoint group manager
+		this.egpMgr = new EndpointGroupManager();
+		this.egpMgr.loadFromList(egp);
+
+		this.ggpMgr = new GroupGroupManager();
+		this.ggpMgr.loadFromList(ggp);
+
+		this.runDate = params.getRequired("run.date");
+		this.egroupType = params.getRequired("egroup.type");
+
+		fillMissing = true;
+
+	}
+
+	@Override
+	public void reduce(Iterable<MetricData> in, Collector<MonTimeline> out) throws Exception {
+
+	
+
+		
+		String prevMetricName = "";
+
+		// Only 1 profile per job
+		String mProfile = this.mpsMgr.getProfiles().get(0);
+		// Get default missing state
+		int defMissing = this.opsMgr.getDefaultMissingInt();
+		// Iterate all metric names of profile and initiate timelines
+
+		String aprofile = this.apsMgr.getAvProfiles().get(0);
+
+		String service ="";
+		String endpointGroup ="";
+		String hostname ="";
+		String metric="";
+		
+		
+		DTimeline dtl = new DTimeline();
+		
+		
+		
+		for (MetricData item : in) {
+			if (fillMissing) {
+				// Before reading metric messages, init expected metric
+				// timelines
+
+				service = item.getService();
+				hostname = item.getHostname();
+				metric = item.getMetric();
+
+				// Filter By endpoint group if belongs to supergroup
+				ArrayList<String> groupnames = egpMgr.getGroup(egroupType, hostname, service);
+				
+				for (String groupname : groupnames) {
+					if (ggpMgr.checkSubGroup(groupname) == true){
+						endpointGroup = groupname;
+					}
+						
+						
+				}
+				this.mpsMgr.getProfileServiceMetrics(mProfile, item.getService());
+				fillMissing = false;
+			}
+
+			service = item.getService();
+			hostname = item.getHostname();
+			metric = item.getMetric();
+			String ts = item.getTimestamp();
+			String status = item.getStatus();
+			// insert monitoring point (ts,status) into the discrete timeline
+			dtl.insert(ts, opsMgr.getIntStatus(status));
+			
+
+			
+
+		}
+		// Create a new MonTimeline object
+		MonTimeline mtl = new MonTimeline(endpointGroup,service,hostname,metric);
+		// Add Discrete Timeline samples int array to the MonTimeline 
+		mtl.setTimeline(dtl.samples);
+		// Output MonTimeline object
+		out.collect(mtl);
+
+	}
+
+}

--- a/flink_jobs/batch_ar/src/main/java/argo/batch/MonTimeline.java
+++ b/flink_jobs/batch_ar/src/main/java/argo/batch/MonTimeline.java
@@ -1,0 +1,82 @@
+package argo.batch;
+
+import java.util.Arrays;
+
+public class MonTimeline {
+
+	private String group;
+	private String service;
+	private String hostname;
+	private String metric;
+	private int[] timeline;
+
+	public MonTimeline() {
+		this.group = "";
+		this.service = "";
+		this.hostname = "";
+		this.metric = "";
+		this.timeline = new int[1440];
+	}
+
+	public MonTimeline(String _group, String _service, String _hostname, String _metric) {
+		this.group = _group;
+		this.service = _service;
+		this.hostname = _hostname;
+		this.metric = _metric;
+		this.timeline = new int[1440];
+
+	}
+
+	public MonTimeline(String _group, String _service, String _hostname, String _metric, int n) {
+		this.group = _group;
+		this.service = _service;
+		this.hostname = _hostname;
+		this.metric = _metric;
+		this.timeline = new int[n];
+	}
+
+	public String getGroup() {
+		return group;
+	}
+
+	public void setGroup(String group) {
+		this.group = group;
+	}
+
+	public String getService() {
+		return service;
+	}
+
+	public void setService(String service) {
+		this.service = service;
+	}
+
+	public String getHostname() {
+		return hostname;
+	}
+
+	public void setHostname(String hostname) {
+		this.hostname = hostname;
+	}
+
+	public String getMetric() {
+		return metric;
+	}
+
+	public void setMetric(String metric) {
+		this.metric = metric;
+	}
+
+	public int[] getTimeline() {
+		return timeline;
+	}
+
+	public void setTimeline(int[] timeline) {
+		this.timeline = timeline;
+	}
+
+	public String toString() {
+		return "(" + this.group + "," + this.service + "," + this.hostname + "," + this.metric + "," + Arrays.toString(this.timeline) + ")";
+	}
+
+}

--- a/flink_jobs/batch_ar/src/main/java/argo/batch/PickEndpoints.java
+++ b/flink_jobs/batch_ar/src/main/java/argo/batch/PickEndpoints.java
@@ -1,0 +1,131 @@
+package argo.batch;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.List;
+
+
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import argo.avro.GroupEndpoint;
+import argo.avro.GroupGroup;
+import argo.avro.MetricData;
+import argo.avro.MetricProfile;
+
+import sync.AggregationProfileManager;
+import sync.EndpointGroupManager;
+import sync.GroupGroupManager;
+import sync.MetricProfileManager;
+import sync.RecomputationManager;
+
+/**
+ * Accepts a metric data entry and converts it to a status metric object by appending endpoint group information
+ * Filters out entries that do not appear in topology and metric profiles
+ */
+public class PickEndpoints extends RichFlatMapFunction<MetricData,MetricData> {
+
+	private static final long serialVersionUID = 1L;
+
+	
+	final ParameterTool params;
+	
+	public PickEndpoints(ParameterTool params){
+		this.params = params;
+	}
+	
+	static Logger LOG = LoggerFactory.getLogger(ArgoArBatch.class);
+
+	private List<MetricProfile> mps;
+	private List<GroupEndpoint> egp;
+	private List<GroupGroup> ggp;
+	private List<String> apr;
+	private List<String> rec;
+	private MetricProfileManager mpsMgr;
+	private EndpointGroupManager egpMgr;
+	private GroupGroupManager ggpMgr;
+	private AggregationProfileManager aprMgr;
+	private RecomputationManager recMgr;
+	
+	private String egroupType;
+
+	@Override
+	public void open(Configuration parameters) throws IOException, ParseException {
+		// Get data from broadcast variable
+		this.mps = getRuntimeContext().getBroadcastVariable("mps");
+		this.egp = getRuntimeContext().getBroadcastVariable("egp");
+		this.ggp = getRuntimeContext().getBroadcastVariable("ggp");
+		this.apr = getRuntimeContext().getBroadcastVariable("apr");
+		this.rec = getRuntimeContext().getBroadcastVariable("rec");
+		
+		// Initialize metric profile manager
+		this.mpsMgr = new MetricProfileManager();
+		this.mpsMgr.loadFromList(mps);
+		// Initialize endpoint group manager
+		this.egpMgr = new EndpointGroupManager();
+		this.egpMgr.loadFromList(egp);
+		
+		this.ggpMgr = new GroupGroupManager();
+		this.ggpMgr.loadFromList(ggp);
+		
+		// Initialize Aggregation Profile Manager ;
+		this.aprMgr = new AggregationProfileManager();
+		this.aprMgr.loadJsonString(apr);
+		
+		// Initialize Recomputations Manager;
+		this.recMgr = new RecomputationManager();
+		this.recMgr.loadJsonString(rec);
+		
+		// Initialize endpoint group type
+		this.egroupType = params.getRequired("egroup.type");
+	}
+
+	
+
+	@Override
+	public void flatMap(MetricData md, Collector<MetricData> out) throws Exception {
+
+		String prof = mpsMgr.getProfiles().get(0);
+		String aprof = aprMgr.getAvProfiles().get(0);
+		String hostname = md.getHostname();
+		String service = md.getService();
+		String metric = md.getMetric();
+		String monHost = md.getMonitoringHost();
+		String ts = md.getTimestamp();
+		
+		// Filter by monitoring engine 
+		if (recMgr.isMonExcluded(monHost, ts) == true) return;
+
+		// Filter By aggregation profile
+		if (aprMgr.checkService(aprof, service) == false) return;
+		
+		// Filter By metric profile
+		if (mpsMgr.checkProfileServiceMetric(prof, service, metric) == false) return;
+		
+	
+		// Filter by endpoint group 
+		if (egpMgr.checkEndpoint(hostname, service) == false) return;
+		
+		// Filter By endpoint group if belongs to supergroup
+		ArrayList<String> groupnames = egpMgr.getGroup(egroupType, hostname, service);
+		
+		for (String groupname : groupnames) {
+			if (ggpMgr.checkSubGroup(groupname) == true){
+				out.collect(md);
+			}
+				
+				
+		}
+		
+	}
+
+
+
+	
+}

--- a/flink_jobs/batch_ar/src/main/java/sync/RecomputationManager.java
+++ b/flink_jobs/batch_ar/src/main/java/sync/RecomputationManager.java
@@ -22,15 +22,15 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
-public class RecomputationsManager {
+public class RecomputationManager {
 
-	private static final Logger LOG = Logger.getLogger(RecomputationsManager.class.getName());
+	private static final Logger LOG = Logger.getLogger(RecomputationManager.class.getName());
 
 	public Map<String,ArrayList<Map<String,String>>> groups;
 	// Recomputations for filtering monitoring engine results
 	public Map<String,ArrayList<Map<String,Date>>> monEngines; 
 	
-	public RecomputationsManager() {
+	public RecomputationManager() {
 		this.groups = new HashMap<String,ArrayList<Map<String,String>>>();
 		this.monEngines = new HashMap<String,ArrayList<Map<String,Date>>>();
 	}
@@ -199,7 +199,14 @@ public class RecomputationsManager {
 			
 
 			JsonParser jsonParser = new JsonParser();
+			
+			if (recJson.get(0).equalsIgnoreCase("{}")) return;
+			
+			
 			JsonElement jRootElement = jsonParser.parse(recJson.get(0));
+			
+	
+			
 			JsonArray jRootObj = jRootElement.getAsJsonArray();
 
 			for (JsonElement item : jRootObj) {

--- a/flink_jobs/batch_ar/src/test/java/argo/batch/MonTimelineTest.java
+++ b/flink_jobs/batch_ar/src/test/java/argo/batch/MonTimelineTest.java
@@ -1,0 +1,36 @@
+package argo.batch;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class MonTimelineTest {
+
+	@Test
+	public void test() {
+		MonTimeline monA = new MonTimeline();
+		assertEquals("timeline size init",1440,monA.getTimeline().length);
+		assertEquals("group name init","",monA.getGroup());
+		assertEquals("service name init","",monA.getService());
+		assertEquals("hostname name init","",monA.getHostname());
+		assertEquals("metric name init","",monA.getMetric());
+		
+		MonTimeline monB = new MonTimeline("fooGroup","fooService","fooHost","fooMetric",1445);
+		
+		assertEquals("timeline size set",1445,monB.getTimeline().length);
+		assertEquals("group name set","fooGroup",monB.getGroup());
+		assertEquals("service name set","fooService",monB.getService());
+		assertEquals("hostname name set","fooHost",monB.getHostname());
+		assertEquals("metric name set","fooMetric",monB.getMetric());
+		
+		MonTimeline monC = new MonTimeline("fooGroup2","fooService2","fooHost2","fooMetric2");
+		
+		assertEquals("timeline size set",1440,monC.getTimeline().length);
+		assertEquals("group name set","fooGroup2",monC.getGroup());
+		assertEquals("service name set","fooService2",monC.getService());
+		assertEquals("hostname name set","fooHost2",monC.getHostname());
+		assertEquals("metric name set","fooMetric2",monC.getMetric());
+		
+	}
+
+}

--- a/flink_jobs/batch_ar/src/test/java/sync/RecomputationManagerTest.java
+++ b/flink_jobs/batch_ar/src/test/java/sync/RecomputationManagerTest.java
@@ -31,7 +31,7 @@ public class RecomputationManagerTest {
 		URL resJsonFile = RecomputationManagerTest.class.getResource("/ops/recomp.json");
 		File jsonFile = new File(resJsonFile.toURI());
 
-		RecomputationsManager recMgr = new RecomputationsManager();
+		RecomputationManager recMgr = new RecomputationManager();
 		recMgr.loadJson(jsonFile);
 		
 


### PR DESCRIPTION
- [x] Add MonTimeline object to hold monitoring data in timeline form
- [x] Add PickEndpoints Operator to filter out metric data by aggregation, metric and topology profiles 
- [x] Add CreateMetricTimeline Operator to group monitoring data from the same metric into a metric timeline object
- [x] Update ArgoBatch Flink Job dataflow