### PR TITLE
ARGO-970 Fix Avro ClassCast Issue

### DIFF
--- a/flink_jobs/stream_status/pom.xml
+++ b/flink_jobs/stream_status/pom.xml
@@ -23,7 +23,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<flink.version>1.3.0</flink.version>
+		<flink.version>1.1.3</flink.version>
 	</properties>
 
 	<repositories>
@@ -63,11 +63,6 @@
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-avro_2.10</artifactId>
 			<version>${flink.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.avro</groupId>
-			<artifactId>avro</artifactId>
-			<version>1.7.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -190,7 +185,6 @@
 					<artifactId>gson</artifactId>
 					<version>2.7</version>
 				</dependency>
-
 			</dependencies>
 
 			<build>

--- a/flink_jobs/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
+++ b/flink_jobs/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
@@ -16,6 +16,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.commons.codec.binary.Base64;
 
@@ -272,7 +273,7 @@ public class AmsStreamStatus {
 			// Decode from base64
 			byte[] decoded64 = Base64.decodeBase64(data.getBytes("UTF-8"));
 			// Decode from avro
-			DatumReader<MetricData> avroReader = new SpecificDatumReader<MetricData>(MetricData.getClassSchema());
+			DatumReader<MetricData> avroReader = new SpecificDatumReader<MetricData>(MetricData.getClassSchema(),MetricData.getClassSchema(),new SpecificData());
 			Decoder decoder = DecoderFactory.get().binaryDecoder(decoded64, null);
 			MetricData item;
 			item = avroReader.read(null, decoder);

--- a/flink_jobs/stream_status/src/main/java/argo/streaming/SyncData.java
+++ b/flink_jobs/stream_status/src/main/java/argo/streaming/SyncData.java
@@ -14,6 +14,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumReader;
+import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -26,14 +27,25 @@ import argo.avro.MetricData;
 import argo.avro.MetricProfile;
 import argo.avro.Weight;
 
+/**
+ * Utility class that can target text or connector avro encoded files (metric data,
+ * metric profiles, topology, weights, downtimes etc). 
+ */
 public class SyncData {
 
+	/**
+	 * Convert a string url (mostly hdfs://) to URI object
+	 */
 	private URI toURI(String url) throws URISyntaxException {
 
 		return new URI(url);
 
 	}
 
+	/**
+	 * Utility class that can target text or connector avro encoded files (metric data,
+	 * metric profiles, topology, weights, downtimes etc). 
+	 */
 	public String readText(String url) throws URISyntaxException, IOException {
 
 		URI uri;
@@ -51,6 +63,9 @@ public class SyncData {
 
 	}
 
+	/**
+	 * Read a plain text file
+	 */
 	public String readTextFile(BufferedReader bfr) throws IOException {
 		String line = null;
 		String full = "";
@@ -61,6 +76,9 @@ public class SyncData {
 		return full;
 	}
 
+	/**
+	 * Read a list of GroupEndpoint Avro Objects from url
+	 */
 	public ArrayList<GroupEndpoint> readGroupEndpoint(String url) throws URISyntaxException, IOException {
 		URI uri;
 
@@ -76,8 +94,11 @@ public class SyncData {
 		return new ArrayList<GroupEndpoint>();
 	}
 
+	/**
+	 * Read a list of GroupEndpoint Avro Objects from an InputStream
+	 */
 	public ArrayList<GroupEndpoint> readGroupEndpointFile(BufferedInputStream bis) throws IOException {
-		DatumReader<GroupEndpoint> datumReader = new SpecificDatumReader<GroupEndpoint>(GroupEndpoint.getClassSchema());
+		DatumReader<GroupEndpoint> datumReader = new SpecificDatumReader<GroupEndpoint>(GroupEndpoint.getClassSchema(),GroupEndpoint.getClassSchema(),new SpecificData());
 		DataFileStream<GroupEndpoint> dataFileStream = new DataFileStream<GroupEndpoint>(bis, datumReader);
 
 		ArrayList<GroupEndpoint> list = new ArrayList<GroupEndpoint>();
@@ -93,6 +114,9 @@ public class SyncData {
 		return list;
 	}
 
+	/**
+	 * Read a list of GroupGroup Avro Objects from a url
+	 */
 	public ArrayList<GroupGroup> readGroupGroup(String url) throws URISyntaxException, IOException {
 		URI uri;
 
@@ -108,8 +132,11 @@ public class SyncData {
 		return new ArrayList<GroupGroup>();
 	}
 
+	/**
+	 * Read a list of GroupGroup Avro Objects from an input stream
+	 */
 	public ArrayList<GroupGroup> readGroupGroupFile(BufferedInputStream bis) throws IOException {
-		DatumReader<GroupGroup> datumReader = new SpecificDatumReader<GroupGroup>(GroupGroup.getClassSchema());
+		DatumReader<GroupGroup> datumReader = new SpecificDatumReader<GroupGroup>(GroupGroup.getClassSchema(),GroupGroup.getClassSchema(),new SpecificData());
 		DataFileStream<GroupGroup> dataFileStream = new DataFileStream<GroupGroup>(bis, datumReader);
 
 		ArrayList<GroupGroup> list = new ArrayList<GroupGroup>();
@@ -125,6 +152,9 @@ public class SyncData {
 		return list;
 	}
 
+	/**
+	 * Read a list of Downtime Avro Objects from a url
+	 */
 	public ArrayList<Downtime> readDowntime(String url) throws URISyntaxException, IOException {
 		URI uri;
 
@@ -140,8 +170,11 @@ public class SyncData {
 		return new ArrayList<Downtime>();
 	}
 
+	/**
+	 * Read a list of Downtime Avro Objects from an input stream
+	 */
 	public ArrayList<Downtime> readDowntimeFile(BufferedInputStream bis) throws IOException {
-		DatumReader<Downtime> datumReader = new SpecificDatumReader<Downtime>(Downtime.getClassSchema());
+		DatumReader<Downtime> datumReader = new SpecificDatumReader<Downtime>(Downtime.getClassSchema(),Downtime.getClassSchema(),new SpecificData());
 		DataFileStream<Downtime> dataFileStream = new DataFileStream<Downtime>(bis, datumReader);
 
 		ArrayList<Downtime> list = new ArrayList<Downtime>();
@@ -157,6 +190,9 @@ public class SyncData {
 		return list;
 	}
 
+	/**
+	 * Read a list of MetricProfile Avro Objects from a url
+	 */
 	public ArrayList<MetricProfile> readMetricProfile(String url) throws URISyntaxException, IOException {
 		URI uri;
 
@@ -172,8 +208,11 @@ public class SyncData {
 		return new ArrayList<MetricProfile>();
 	}
 
+	/**
+	 * Read a list of MetricProfile Avro Objects from an input stream
+	 */
 	public ArrayList<MetricProfile> readMetricProfileFile(BufferedInputStream bis) throws IOException {
-		DatumReader<MetricProfile> datumReader = new SpecificDatumReader<MetricProfile>(MetricProfile.getClassSchema());
+		DatumReader<MetricProfile> datumReader = new SpecificDatumReader<MetricProfile>(MetricProfile.getClassSchema(),MetricProfile.getClassSchema(),new SpecificData());
 		DataFileStream<MetricProfile> dataFileStream = new DataFileStream<MetricProfile>(bis, datumReader);
 
 		
@@ -191,6 +230,9 @@ public class SyncData {
 		return list;
 	}
 
+	/**
+	 * Read a list of MetricData Avro Objects from a url
+	 */
 	public ArrayList<MetricData> readMetricData(String url) throws URISyntaxException, IOException {
 		URI uri;
 
@@ -206,8 +248,11 @@ public class SyncData {
 		return new ArrayList<MetricData>();
 	}
 
+	/**
+	 * Read a list of MetricData Avro Objects from an input stream
+	 */
 	public ArrayList<MetricData> readMetricDataFile(BufferedInputStream bis) throws IOException {
-		DatumReader<MetricData> datumReader = new SpecificDatumReader<MetricData>(MetricData.getClassSchema());
+		DatumReader<MetricData> datumReader = new SpecificDatumReader<MetricData>(MetricData.getClassSchema(),MetricData.getClassSchema(),new SpecificData());
 		DataFileStream<MetricData> dataFileStream = new DataFileStream<MetricData>(bis, datumReader);
 
 		ArrayList<MetricData> list = new ArrayList<MetricData>();
@@ -223,6 +268,9 @@ public class SyncData {
 		return list;
 	}
 
+	/**
+	 * Read a list of Weight Avro Objects from a url
+	 */
 	public ArrayList<Weight> readWeight(String url) throws URISyntaxException, IOException {
 		URI uri;
 
@@ -238,8 +286,11 @@ public class SyncData {
 		return new ArrayList<Weight>();
 	}
 
+	/**
+	 * Read a list of Weight Avro Objects from an input stream
+	 */
 	public ArrayList<Weight> readWeightFile(BufferedInputStream bis) throws IOException {
-		DatumReader<Weight> datumReader = new SpecificDatumReader<Weight>(Weight.getClassSchema());
+		DatumReader<Weight> datumReader = new SpecificDatumReader<Weight>(Weight.getClassSchema(),Weight.getClassSchema(),new SpecificData());
 		DataFileStream<Weight> dataFileStream = new DataFileStream<Weight>(bis, datumReader);
 
 		ArrayList<Weight> list = new ArrayList<Weight>();
@@ -255,6 +306,9 @@ public class SyncData {
 		return list;
 	}
 
+	/**
+	 * Read a list of GenericRecord Avro Objects from a url
+	 */
 	public String readGenericAvro(String url) throws URISyntaxException, IOException {
 		URI uri;
 
@@ -270,6 +324,9 @@ public class SyncData {
 		return "";
 	}
 
+	/**
+	 * Read a list of GenericRecord Avro Objects from an input stream
+	 */
 	public String readGenericAvroFile(BufferedInputStream bis) throws IOException {
 
 		DatumReader<GenericRecord> datumReader = new GenericDatumReader<GenericRecord>();
@@ -291,6 +348,9 @@ public class SyncData {
 		return str;
 	}
 
+	/**
+	 *  Create a buffered reader from hdfs uri 
+	 */
 	public BufferedReader bfrHDFS(URI uri) throws IOException {
 		Configuration conf = new Configuration();
 		conf.set("fs.defaultFS", uri.getScheme() + "://" + uri.getHost() + ":" + uri.getPort());
@@ -302,6 +362,9 @@ public class SyncData {
 
 	}
 
+	/**
+	 *  Create a buffered input stream from hdfs uri
+	 */
 	public BufferedInputStream bisHDFS(URI uri) throws IOException {
 		Configuration conf = new Configuration();
 		conf.set("fs.defaultFS", uri.getScheme() + "://" + uri.getHost() + ":" + uri.getPort());

--- a/flink_jobs/stream_status/src/main/java/argo/streaming/SyncParse.java
+++ b/flink_jobs/stream_status/src/main/java/argo/streaming/SyncParse.java
@@ -10,6 +10,7 @@ import java.util.Map.Entry;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
 
 import com.google.gson.JsonElement;
@@ -30,7 +31,7 @@ public class SyncParse {
 		
 		ArrayList<GroupEndpoint> result = new ArrayList<GroupEndpoint>();
 		
-		DatumReader<GroupEndpoint> avroReader = new SpecificDatumReader<GroupEndpoint>(GroupEndpoint.getClassSchema());
+		DatumReader<GroupEndpoint> avroReader = new SpecificDatumReader<GroupEndpoint>(GroupEndpoint.getClassSchema(),GroupEndpoint.getClassSchema(),new SpecificData());
 		BinaryDecoder decoder = DecoderFactory.get().binaryDecoder(avroBytes, null);
 		
 		while (!decoder.isEnd()){
@@ -48,7 +49,7 @@ public class SyncParse {
 		
 		ArrayList<MetricProfile> result = new ArrayList<MetricProfile>();
 		
-		DatumReader<MetricProfile> avroReader = new SpecificDatumReader<MetricProfile>(MetricProfile.getClassSchema());
+		DatumReader<MetricProfile> avroReader = new SpecificDatumReader<MetricProfile>(MetricProfile.getClassSchema(),MetricProfile.getClassSchema(),new SpecificData());
 		BinaryDecoder decoder = DecoderFactory.get().binaryDecoder(avroBytes, null);
 		
 		while (!decoder.isEnd()){

--- a/flink_jobs/stream_status/src/main/java/status/StatusManager.java
+++ b/flink_jobs/stream_status/src/main/java/status/StatusManager.java
@@ -417,6 +417,13 @@ public class StatusManager {
 	 */
 	public void addMetrics(StatusNode endpointNode, String service, String hostname, int defStatus, Date defTs) {
 		ArrayList<String> metrics = this.mps.getProfileServiceMetrics(this.validMetricProfile, service);
+		
+		// Check if metrics = null
+		if (metrics==null) { 
+			String msg = endpointNode + "/" + service + "/" + hostname + " " + this.validMetricProfile; 
+			throw new RuntimeException(msg);
+		}
+		
 		// For all available metrics create leaf metric nodes
 		for (String metric : metrics) {
 			StatusNode metricNode = new StatusNode("metric", defStatus, defTs, endpointNode);


### PR DESCRIPTION
# Issue 
ClassCast Exceptions on Avro Objects when re-submitting job in flink cluster.
- Identical Cached Avro related classes were loaded by different classloaders in flink -- this resulted in ClassCast Exceptions. 

# Fix 
- Use a new instance of SpecificData on each AvroReader Instantiation

# Other supplementary fixes
- Align flink version in pom file with cluster's
- Raise a runtime exception when a piece of irrelevant metric data (which should be filtered) is presented in status computation  