### PR TITLE
ARGO-988 BucketSink: Inacticity threshold increase to 30 minutes

### DIFF
--- a/flink_jobs/ams_ingest_metric/src/main/java/argo/streaming/AmsIngestMetric.java
+++ b/flink_jobs/ams_ingest_metric/src/main/java/argo/streaming/AmsIngestMetric.java
@@ -116,6 +116,7 @@ public class AmsIngestMetric {
 		// set ams client batch and interval to default values
 		int batch = 1;
 		long interval = 100L;
+		long inactivityThresh = 1800000L; // default inactivity threshold value ~ 30mins
 		
 		if (hasAmsRateArgs(parameterTool)) {
 			batch = parameterTool.getInt("ams.batch");
@@ -182,6 +183,7 @@ public class AmsIngestMetric {
 			// timestamp parts (YYYY-MM-DD)
 			// in different daily files
 			BucketingSink<MetricData> bs = new BucketingSink<MetricData>(basePath);
+			bs.setInactiveBucketThreshold(inactivityThresh);
 			Bucketer<MetricData> tsBuck = new TSBucketer();
 			bs.setBucketer(tsBuck);
 			bs.setPartPrefix("mdata");


### PR DESCRIPTION
# Issue 
Bucket Sink uses a default inactivity interval of 1 min and creates a new bucket(file).
Ams publisher sends metric data in intervals of ~5min thus having the hdfs sink creating small files due to inactivity threshold

# Fix 
Raise inactivity threshold to a greater value (30mins)  