### PR TITLE
ARGO-1073 Add more verbose names to flink jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,3 +295,19 @@ Job required cli parameters:
 `--mongo.uri`         : MongoDB uri for outputting the results to (e.g. mongodb://localhost:21017/example_db)
 
 `--mongo.method`      : MongoDB method to be used when storing the results ~ either: `insert` or `upsert`
+
+
+## Flink job names
+Running flink jobs can be listed either in flink dashboard by visiting `http://{{flink.webui.host}}:{{flink.webui.port}}`
+or by quering jobmanager api at `http://{{flink.webui.host}:{{flink.webui.port}}/joboverview/running
+
+Each job submitted has a discerning job name based on a specific template. Job names are used also by submission wrapper scripts (`/bin` folder) to check if a identical job runs (to avoid duplicate submission)
+
+Job Name schemes:
+Job Type| Job Name scheme
+--------|----------------
+Ingest Metric | Ingesting metric data from `{{ams-endpoint}}`/v1/projects/`{{project}}`/subscriptions/`{{subscription}}`
+Ingest Sync | Ingesting sync data from `{{ams-endpoint}}`/v1/projects/`{{project}}`/subscriptions/`{{subscription}}`
+Batch AR | Ar Batch job for tenant:`{{tenant}}` on day:`{{day}}` using report:`{{report}}`
+Batch Status | Status Batch job for tenant:`{{tenant}}` on day:`{{day}}` using report:`{{report}}`
+Streaming Status | Streaming status using data from `{{ams-endpoint}}`/v1/projects/`{{project}}`/subscriptions/`[`{{metric_subscription}}`,`{{sync_subscription}}`]

--- a/flink_jobs/ams_ingest_metric/src/main/java/argo/streaming/AmsIngestMetric.java
+++ b/flink_jobs/ams_ingest_metric/src/main/java/argo/streaming/AmsIngestMetric.java
@@ -215,7 +215,7 @@ public class AmsIngestMetric {
 		
 		// Create a job title message to discern job in flink dashboard/cli
 		StringBuilder jobTitleSB = new StringBuilder();
-		jobTitleSB.append("Ingesting  metric data from ");
+		jobTitleSB.append("Ingesting metric data from ");
 		jobTitleSB.append(endpoint);
 		jobTitleSB.append(":");
 		jobTitleSB.append(port);

--- a/flink_jobs/batch_ar/src/main/java/ops/ConfigManager.java
+++ b/flink_jobs/batch_ar/src/main/java/ops/ConfigManager.java
@@ -61,6 +61,22 @@ public class ConfigManager {
 		this.mdataTags.clear();
 
 	}
+	
+	public String getReportID() {
+		return id;
+	}
+	
+	public String getReport() {
+		return report;
+	}
+	
+	public String getTenant() {
+		return tenant;
+	}
+	
+	public String getEgroup() {
+		return egroup;
+	}
 
 	public void loadJson(File jsonFile) throws IOException {
 		// Clear data

--- a/flink_jobs/batch_status/src/main/java/argo/batch/PickEndpoints.java
+++ b/flink_jobs/batch_status/src/main/java/argo/batch/PickEndpoints.java
@@ -18,6 +18,7 @@ import argo.avro.GroupEndpoint;
 import argo.avro.GroupGroup;
 import argo.avro.MetricData;
 import argo.avro.MetricProfile;
+import ops.ConfigManager;
 import ops.OpsManager;
 import sync.AggregationProfileManager;
 import sync.EndpointGroupManager;
@@ -46,10 +47,12 @@ public class PickEndpoints extends RichFlatMapFunction<MetricData,StatusMetric> 
 	private List<GroupEndpoint> egp;
 	private List<GroupGroup> ggp;
 	private List<String> rec;
+	private List<String> cfg;
 	private MetricProfileManager mpsMgr;
 	private EndpointGroupManager egpMgr;
 	private GroupGroupManager ggpMgr;
 	private RecomputationsManager recMgr;
+	private ConfigManager cfgMgr;
 	
 	private String egroupType;
 
@@ -61,6 +64,7 @@ public class PickEndpoints extends RichFlatMapFunction<MetricData,StatusMetric> 
 		this.ggp = getRuntimeContext().getBroadcastVariable("ggp");
 		this.ggp = getRuntimeContext().getBroadcastVariable("ggp");
 		this.rec = getRuntimeContext().getBroadcastVariable("rec");
+		this.cfg = getRuntimeContext().getBroadcastVariable("conf");
 		
 		// Initialize Recomputation manager
 		this.recMgr = new RecomputationsManager();
@@ -75,8 +79,12 @@ public class PickEndpoints extends RichFlatMapFunction<MetricData,StatusMetric> 
 		
 		this.ggpMgr = new GroupGroupManager();
 		this.ggpMgr.loadFromList(ggp);
-		// Initialize endpoint group type
-		this.egroupType = params.getRequired("egroup.type");
+		
+		// Initialize report configuration manager
+		this.cfgMgr = new ConfigManager();
+		this.cfgMgr.loadJsonString(cfg);
+		
+		this.egroupType = cfgMgr.egroup;
 	}
 
 	

--- a/flink_jobs/batch_status/src/main/java/ops/ConfigManager.java
+++ b/flink_jobs/batch_status/src/main/java/ops/ConfigManager.java
@@ -61,8 +61,20 @@ public class ConfigManager {
 		
 	}
 
+	public String getReportID() {
+		return id;
+	}
+	
 	public String getReport() {
 		return report;
+	}
+	
+	public String getTenant() {
+		return tenant;
+	}
+	
+	public String getEgroup() {
+		return egroup;
 	}
 	
 

--- a/flink_jobs/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
+++ b/flink_jobs/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
@@ -50,21 +50,29 @@ import sync.MetricProfileManager;
 
 
 /**
- * Flink Job : Stream metric data from ARGO messaging to Hbase
+ * Flink Job : Streaming status computation with multiple destinations (hbase, kafka, fs)
  * job required cli parameters
- * --ams.endpoint      : ARGO messaging api endoint to connect to msg.example.com
+ * --ams.endpoint      : ARGO messaging api endpoint to connect to msg.example.com
  * --ams.port          : ARGO messaging api port 
  * --ams.token         : ARGO messaging api token
  * --ams.project       : ARGO messaging api project to connect to
  * --ams.sub.metric    : ARGO messaging subscription to pull metric data from
  * --ams.sub.sync      : ARGO messaging subscription to pull sync data from
- * --avro.schema       : avro-schema used for decoding payloads
  * --sync.mps          : metric-profile file used 
  * --sync.egp          : endpoint-group file used for topology
  * --sync.aps          : availability profile used 
  * --sync.ops          : operations profile used
+ * Job optional cli parameters:
  * --ams.batch         : num of messages to be retrieved per request to AMS service
- * --ams.interval      : interval (in ms) between AMS service requestss
+ * --ams.interval      : interval (in ms) between AMS service requests
+ * --kafka.servers     : list of kafka servers to connect to
+ * --kafka.topic       : kafka topic name to publish events
+ * --hbase.master      : hbase master hostname
+ * --hbase.port        : hbase master.port
+ * --hbase.zk.quorum   : hbase zookeeper quorum
+ * --hbase.namespace   : hbase namespace
+ * --hbase.table       : hbase table name
+ * --fs.ouput          : filesystem output path (local or hdfs) mostly for debugging
  */
 public class AmsStreamStatus {
 	// setup logger
@@ -200,6 +208,21 @@ public class AmsStreamStatus {
 			events.writeAsText(parameterTool.get("fs.output"));
 		}
 
+		
+		// Create a job title message to discern job in flink dashboard/cli
+		StringBuilder jobTitleSB = new StringBuilder();
+		jobTitleSB.append("Streaming status using data from ");
+		jobTitleSB.append(endpoint);
+		jobTitleSB.append(":");
+		jobTitleSB.append(port);
+		jobTitleSB.append("/v1/projects/");
+		jobTitleSB.append(project);
+		jobTitleSB.append("/subscriptions/[");
+		jobTitleSB.append(subMetric);
+		jobTitleSB.append(",");
+		jobTitleSB.append(subSync);
+		jobTitleSB.append("]");
+		
 		// Execute flink dataflow
 		see.execute();
 	}

--- a/flink_jobs/stream_status/src/main/java/ops/ConfigManager.java
+++ b/flink_jobs/stream_status/src/main/java/ops/ConfigManager.java
@@ -60,6 +60,22 @@ public class ConfigManager {
 		this.mdataTags.clear();
 		
 	}
+	
+	public String getReportID() {
+		return id;
+	}
+	
+	public String getReport() {
+		return report;
+	}
+	
+	public String getTenant() {
+		return tenant;
+	}
+	
+	public String getEgroup() {
+		return egroup;
+	}
 
 	
 


### PR DESCRIPTION
# Issue
Add consistent and verbose names to batch and streaming status flink jobs

# Implementation
- Refactor ArgoBatchAr main method to add job description 
- Refactor ArgoBatchStatus main method to add job description 
- Refactor AmsStreamStatus main method to add job description 
- Update readme
- Minor fix on Ingest metric job name
- Fix read report-id parameter in Batch Status job 
- Fix read endpoint group type parameter in Batch Status job
- Minor comment fixes 