### PR TITLE
ARGO-1074 Add reference to config template relative to each test file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,14 @@ python:
   - "2.7"
 
 script:
+  - pip install requests==2.18.4
+  - pip install pytest==3.4.0
+  - pip install snakebite==2.11.0
+  - pip install pymongo==3.6.1
+  - pytest
   - cd flink_jobs/ams_ingest_metric/ && mvn test
   - cd ../batch_ar && mvn test
   - cd ../batch_status && mvn test
   - cd ../stream_status && mvn test
   - cd ../ams_ingest_sync && mvn test
-  - pip install requests==2.18.4 
-  - pip install pytest==3.4.0
-  - pip install snakebite==2.11.0
-  - pip install pymongo==3.6.1
-  - cd ../../bin && pytest
+  

--- a/bin/test_ar_job_submit.py
+++ b/bin/test_ar_job_submit.py
@@ -2,8 +2,11 @@ import unittest
 import argparse
 import ConfigParser
 import datetime
+import os
 from ar_job_submit import compose_command
 from utils.common import cmd_toString
+
+CONF_TEMPLATE = os.path.join(os.path.dirname(__file__), '../conf/conf.template') 
 
 class TestClass(unittest.TestCase):
 
@@ -11,7 +14,7 @@ class TestClass(unittest.TestCase):
         
         # set up the config parser
         config = ConfigParser.ConfigParser()
-        config.read("../conf/conf.template")
+        config.read(CONF_TEMPLATE)
 
         parser = argparse.ArgumentParser()
         parser.add_argument('--Tenant')

--- a/bin/test_metric_ingestion_submit.py
+++ b/bin/test_metric_ingestion_submit.py
@@ -3,7 +3,9 @@ from metric_ingestion_submit import compose_command
 from utils.common import cmd_toString
 import ConfigParser
 import argparse
+import os
 
+CONF_TEMPLATE = os.path.join(os.path.dirname(__file__), '../conf/conf.template')
 
 class TestClass(unittest.TestCase):
 
@@ -11,7 +13,7 @@ class TestClass(unittest.TestCase):
 
         # set up the config parser
         config = ConfigParser.ConfigParser()
-        config.read("../conf/conf.template")
+        config.read(CONF_TEMPLATE)
 
         test_cmd = "sudo flink_path run -c test_class test.jar --ams.endpoint test_endpoint --ams.port test_port --ams.token test_token --ams.project test_project --ams.sub job_name --hdfs.path hdfs://hdfs_test_host:hdfs_test_port/user/hdfs_test_user/argo/tenants/TENANTA/mdata --check.path test_path --check.interval 30000 --ams.batch 100 --ams.interval 300"
 

--- a/bin/test_sync_ingestion_submit.py
+++ b/bin/test_sync_ingestion_submit.py
@@ -3,7 +3,9 @@ from sync_ingestion_submit import compose_command
 from utils.common import cmd_toString
 import ConfigParser
 import argparse
+import os
 
+CONF_TEMPLATE = os.path.join(os.path.dirname(__file__), '../conf/conf.template')
 
 class TestClass(unittest.TestCase):
 
@@ -11,7 +13,7 @@ class TestClass(unittest.TestCase):
 
         # set up the config parser
         config = ConfigParser.ConfigParser()
-        config.read("../conf/conf.template")
+        config.read(CONF_TEMPLATE)
 
         test_cmd = "sudo flink_path run -c test_class test.jar --ams.endpoint test_endpoint --ams.port test_port --ams.token test_token --ams.project test_project --ams.sub job_name --hdfs.path hdfs://hdfs_test_host:hdfs_test_port/user/hdfs_test_user/argo/tenants/TENANTA/sync --ams.batch 100 --ams.interval 3000"
 


### PR DESCRIPTION
Issue
-------
pytests currently run only with pytest is invoked from ./bin folder

Fix
----
Add reference to config template relative to path of each test file