### PR TITLE
Fix event generation for services that belong to multipe groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,21 @@ Job optional cli parameters for filesystem output (local/hdfs):
 
 `--fs.output`         : filesystem path for output (prefix with "hfds://" for hdfs usage)
 
+Job optional cli parameters for mongo output:
+
+`--mongo.uri`         : Mongo uri to store status events to
+
+`--mongo.method`      : Mongo store method used (insert/upsert)
+
 Job Optional cli parameters for ams ingestion related
 
 `--ams.batch`         : num of messages to be retrieved per request to AMS service
 
 `--ams.interval`      : interval (in ms) between AMS service requests
+Other optional cli parameters
+`--daily`             : true/false - controls daily regeneration of events (not used in notifications)
+
+`--timeout`           : long(ms) - controls default timeout for event regeneration (used in notifications)
 
 `--ams.proxy`         : optional http proxy url to be used for AMS requests
 

--- a/flink_jobs/ams_ingest_metric/src/main/java/argo/streaming/AmsIngestMetric.java
+++ b/flink_jobs/ams_ingest_metric/src/main/java/argo/streaming/AmsIngestMetric.java
@@ -151,7 +151,7 @@ public class AmsIngestMetric {
 		if (parameterTool.has("ams.verify")) {
 			ams.setVerify(parameterTool.getBoolean("ams.verify"));
 		}
-		
+
 		if (parameterTool.has("ams.proxy")) {
 			ams.setProxy(parameterTool.get("ams.proxy"));
 		}

--- a/flink_jobs/ams_ingest_sync/src/main/java/argo/streaming/AmsIngestSync.java
+++ b/flink_jobs/ams_ingest_sync/src/main/java/argo/streaming/AmsIngestSync.java
@@ -76,11 +76,11 @@ public class AmsIngestSync {
 		
 		//Ingest sync avro encoded data from AMS endpoint
 		ArgoMessagingSource ams = new ArgoMessagingSource(endpoint, port, token, project, sub, batch, interval);
-		
+
 		if (parameterTool.has("ams.verify")){
 			ams.setVerify(parameterTool.getBoolean("ams.verify"));
 		}
-		
+
 		if (parameterTool.has("ams.proxy")) {
 			ams.setProxy(parameterTool.get("ams.proxy"));
 		}

--- a/flink_jobs/stream_status/pom.xml
+++ b/flink_jobs/stream_status/pom.xml
@@ -134,6 +134,12 @@
 			<artifactId>xercesImpl</artifactId>
 			<version>2.7.1</version>
 		</dependency>
+		<dependency>
+			<groupId>org.mongodb</groupId>
+			<artifactId>mongo-java-driver</artifactId>
+			<version>3.2.2</version>
+			<scope>compile</scope>
+		</dependency>
 
 
 
@@ -184,6 +190,12 @@
 					<groupId>com.google.code.gson</groupId>
 					<artifactId>gson</artifactId>
 					<version>2.7</version>
+				</dependency>
+				<dependency>
+					<groupId>org.mongodb</groupId>
+					<artifactId>mongo-java-driver</artifactId>
+					<version>3.2.2</version>
+					<scope>compile</scope>
 				</dependency>
 			</dependencies>
 

--- a/flink_jobs/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
+++ b/flink_jobs/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
@@ -67,14 +67,17 @@ import sync.MetricProfileManager;
  * --ams.interval      : interval (in ms) between AMS service requests
  * --kafka.servers     : list of kafka servers to connect to
  * --kafka.topic       : kafka topic name to publish events
+ * --mongo.uri         : mongo uri to store latest status results
+ * --mongo.method      : mongo method to use (insert,upsert)
  * --hbase.master      : hbase master hostname
  * --hbase.port        : hbase master.port
  * --hbase.zk.quorum   : hbase zookeeper quorum
  * --hbase.namespace   : hbase namespace
  * --hbase.table       : hbase table name
  * --fs.ouput          : filesystem output path (local or hdfs) mostly for debugging
- * --ams.proxy		   : http proxy url
- * --ams.verify        : optional turn on/off ssl verify
+ * --ams.proxy		   : http proxy url 
+ * --timeout           : time in ms - Optional timeout parameter (used in notifications)
+ * --daily             : true/false - Optional daily event generation parameter (not needed in notifications)
  */
 public class AmsStreamStatus {
 	// setup logger
@@ -118,6 +121,11 @@ public class AmsStreamStatus {
 		String fsOutArgs[] = { "fs.output" };
 		return hasArgs(fsOutArgs, paramTool);
 	}
+	
+	public static boolean hasMongoArgs(ParameterTool paramTool) {
+		String mongoArgs[] = { "mongo.uri", "mongo.method" };
+		return hasArgs(mongoArgs, paramTool);
+	}
 
 	public static boolean hasArgs(String[] reqArgs, ParameterTool paramTool) {
 
@@ -139,10 +147,10 @@ public class AmsStreamStatus {
 		final ParameterTool parameterTool = ParameterTool.fromArgs(args);
 
 		final StatusConfig conf = new StatusConfig(parameterTool);
-
-		StreamExecutionEnvironment see = setupEnvironment(conf);
 		
-
+		StreamExecutionEnvironment see = setupEnvironment(conf);
+		see.setParallelism(1);
+		
 		// Initialize Input Source : ARGO Messaging Source
 		String endpoint = parameterTool.getRequired("ams.endpoint");
 		String port = parameterTool.getRequired("ams.port");
@@ -159,18 +167,20 @@ public class AmsStreamStatus {
 			batch = parameterTool.getInt("ams.batch");
 			interval = parameterTool.getLong("ams.interval");
 		}
+		
+		
 
 		// Establish the metric data AMS stream
 		// Ingest sync avro encoded data from AMS endpoint
 		ArgoMessagingSource amsMetric = new ArgoMessagingSource(endpoint, port, token, project, subMetric, batch, interval);
 		ArgoMessagingSource amsSync = new ArgoMessagingSource(endpoint, port, token, project, subSync, batch, interval);
-		
+
 		if (parameterTool.has("ams.verify")) {
 			boolean verify = parameterTool.getBoolean("ams.verify");
 			amsMetric.setVerify(verify);
-			amsMetric.setVerify(verify);
+			amsSync.setVerify(verify);
 		}
-		
+
 		if (parameterTool.has("ams.proxy")) {
 			String proxyURL = parameterTool.get("ams.proxy");
 			amsMetric.setProxy(proxyURL);
@@ -218,6 +228,14 @@ public class AmsStreamStatus {
 			hbf.setTableName(parameterTool.get("hbase.table"));
 			hbf.setReport(parameterTool.get("report"));
 			events.writeUsingOutputFormat(hbf);
+		}
+		
+		if (hasMongoArgs(parameterTool)) {
+
+			MongoStatusOutput mongoOut = new MongoStatusOutput(parameterTool.get("mongo.uri"), "status_metrics",
+					"status_endpoints", "status_services", "status_endpoint_groups", parameterTool.get("mongo.method"),
+					parameterTool.get("report"));
+			events.writeUsingOutputFormat(mongoOut);
 		}
 
 		if (hasFsOutArgs(parameterTool)) {
@@ -322,21 +340,21 @@ public class AmsStreamStatus {
 			MetricData item;
 			item = avroReader.read(null, decoder);
 
-			System.out.println("metric data item received" + item.toString());
+			//System.out.println("metric data item received" + item.toString());
 
 			// generate events and get them
 			String service = item.getService();
 			String hostname = item.getHostname();
 
 			ArrayList<String> groups = egp.getGroup(hostname, service);
-			System.out.println(egp.getList());
+			//System.out.println(egp.getList());
 
 			for (String groupItem : groups) {
 				Tuple2<String, MetricData> curItem = new Tuple2<String, MetricData>();
 				curItem.f0 = groupItem;
 				curItem.f1 = item;
 				out.collect(curItem);
-				System.out.println("item enriched: " + curItem.toString());
+				//System.out.println("item enriched: " + curItem.toString());
 			}
 
 		}
@@ -400,6 +418,8 @@ public class AmsStreamStatus {
 		public StatusConfig config;
 
 		public int defStatus;
+		
+		
 
 		public StatusMap(StatusConfig config) {
 			LOG.info("Created new Status map");
@@ -417,7 +437,7 @@ public class AmsStreamStatus {
 		public void open(Configuration parameters) throws IOException, ParseException, URISyntaxException {
 
 			pID = Integer.toString(getRuntimeContext().getIndexOfThisSubtask());
-			LOG.info("initializing status manager:" + pID);
+			
 			SyncData sd = new SyncData();
 
 			String opsJSON = sd.readText(config.ops);
@@ -427,11 +447,13 @@ public class AmsStreamStatus {
 
 			// create a new status manager
 			sm = new StatusManager();
+			sm.setTimeout(config.timeout);
 			// load all the connector data
 			sm.loadAll(egpListFull, mpsList, apsJSON, opsJSON);
 
 			// Set the default status as integer
 			defStatus = sm.getOps().getIntStatus(config.defStatus);
+			LOG.info("Initialized status manager:" + pID + " (with timeout:" + sm.getTimeout() + ")");
 
 		}
 
@@ -457,9 +479,11 @@ public class AmsStreamStatus {
 			String status = item.getStatus();
 			String tsMon = item.getTimestamp();
 			String monHost = item.getMonitoringHost();
+			String message = item.getMessage();
+			String summary = item.getSummary();
 
-			// Has Date Changed?
-			if (sm.hasDayChanged(sm.getTsLatest(), tsMon)) {
+			// if daily generation is enable check if has day changed?
+			if (config.daily && sm.hasDayChanged(sm.getTsLatest(), tsMon)) {
 				ArrayList<String> eventsDaily = sm.dumpStatus(tsMon);
 				sm.setTsLatest(tsMon);
 				for (String event : eventsDaily) {
@@ -476,7 +500,7 @@ public class AmsStreamStatus {
 				sm.addGroup(group, service, hostname, defStatus, dateTS);
 			}
 
-			ArrayList<String> events = sm.setStatus(service, hostname, metric, status, monHost, tsMon);
+			ArrayList<String> events = sm.setStatus(service, hostname, metric, status, monHost, tsMon, message, summary);
 
 			for (String event : events) {
 				out.collect(event);

--- a/flink_jobs/stream_status/src/main/java/argo/streaming/ArgoMessagingClient.java
+++ b/flink_jobs/stream_status/src/main/java/argo/streaming/ArgoMessagingClient.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
 import org.apache.http.entity.StringEntity;
@@ -88,13 +89,34 @@ public class ArgoMessagingClient {
 		this.maxMessages = String.valueOf(batch);
 		this.verify = verify;
 		
-		if (this.verify) {
-			this.httpClient = HttpClients.createDefault();
-		} else {
-			this.httpClient = HttpClients.custom().setSSLSocketFactory(selfSignedSSLF()).build();
-		}
+		this.httpClient = buildHttpClient();
 		
 	}
+	
+	/**
+	 * Initializes Http Client (if not initialized during constructor)
+	 * @return 
+	 */
+	private  CloseableHttpClient buildHttpClient() throws NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
+		if (this.verify) {
+			return this.httpClient = HttpClients.createDefault();
+		} else {
+			return this.httpClient = HttpClients.custom().setSSLSocketFactory(selfSignedSSLF()).build();
+		}
+	}
+	
+	/**
+	 * Create an SSL Connection Socket Factory with a strategy to trust self signed certificates
+	 */
+	private SSLConnectionSocketFactory selfSignedSSLF() throws NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
+		SSLContextBuilder sslBuild = new SSLContextBuilder();
+	    sslBuild.loadTrustMaterial(null, new TrustSelfSignedStrategy());
+	    
+	    return new SSLConnectionSocketFactory(sslBuild.build(),NoopHostnameVerifier.INSTANCE);
+	    
+	   
+	}
+	
 	
 	/**
 	 * Set AMS http client to use http proxy
@@ -112,14 +134,6 @@ public class ArgoMessagingClient {
 	}
 
 	
-	/**
-	 * Create an SSL Connection Socket Factory with a strategy to trust self signed certificates
-	 */
-	private SSLConnectionSocketFactory selfSignedSSLF() throws NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
-		SSLContextBuilder sslBuild = new SSLContextBuilder();
-	    sslBuild.loadTrustMaterial(null, new TrustSelfSignedStrategy());
-	    return new SSLConnectionSocketFactory(sslBuild.build());
-	}
 	
 	/**
 	 * Create a configuration for using http proxy on each request
@@ -130,17 +144,7 @@ public class ArgoMessagingClient {
 		return config;
 	}
 
-	/**
-	 * Initializes Http Client (if not initialized during constructor)
-	 */
-	private void buildHttpClient() throws NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
-		if (this.verify) {
-			this.httpClient = HttpClients.custom().setSSLSocketFactory(selfSignedSSLF()).build();
-		} else {
-			this.httpClient = HttpClients.createDefault();
-		}
-		
-	}
+
 
 	/**
 	 * Properly compose url for each AMS request
@@ -166,7 +170,7 @@ public class ArgoMessagingClient {
 		postPull.setEntity(postBody);
 
 		if (this.httpClient == null) {
-			buildHttpClient();
+			this.httpClient = buildHttpClient();
 		}
 
 		// check for proxy 

--- a/flink_jobs/stream_status/src/main/java/argo/streaming/MongoStatusOutput.java
+++ b/flink_jobs/stream_status/src/main/java/argo/streaming/MongoStatusOutput.java
@@ -1,0 +1,286 @@
+package argo.streaming;
+
+import java.io.IOException;
+
+import org.apache.flink.api.common.io.OutputFormat;
+import org.apache.flink.configuration.Configuration;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientURI;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.UpdateOptions;
+
+import status.StatusEvent;
+
+
+/**
+ * MongoOutputFormat for storing status data to mongodb
+ */
+public class MongoStatusOutput implements OutputFormat<String> {
+
+	public enum MongoMethod {
+		INSERT, UPSERT
+	};
+
+	
+	private static final long serialVersionUID = 1L;
+
+	private String mongoHost;
+	private int mongoPort;
+	private String dbName;
+	private String metricName;
+	private String endpointName;
+	private String serviceName;
+	private String egroupName;
+	private MongoMethod method;
+	private String report;
+
+	private MongoClient mClient;
+	private MongoDatabase mDB;
+	private MongoCollection<Document> metricCol;
+	private MongoCollection<Document> endpointCol;
+	private MongoCollection<Document> serviceCol;
+	private MongoCollection<Document> egroupCol;
+
+	// constructor
+	public MongoStatusOutput(String uri, String metricName,String serviceName, String endpointName, String egroupName, String method , String report) {
+
+		if (method.equalsIgnoreCase("upsert")) {
+			this.method = MongoMethod.UPSERT;
+		} else {
+			this.method = MongoMethod.INSERT;
+		}
+
+		
+		this.report = report;
+
+		MongoClientURI mURI = new MongoClientURI(uri);
+		String[] hostParts = mURI.getHosts().get(0).split(":");
+		String hostname = hostParts[0];
+		int port = Integer.parseInt(hostParts[1]);
+
+		this.mongoHost = hostname;
+		this.mongoPort = port;
+		this.dbName = mURI.getDatabase();
+		this.metricName = metricName;
+		this.serviceName = serviceName;
+		this.endpointName = endpointName;
+		this.egroupName = egroupName;
+	}
+
+	// constructor
+	public MongoStatusOutput(String host, int port, String db, String metricName,String serviceName, String endpointName, String egroupName, MongoMethod method, 
+			String report) {
+		this.mongoHost = host;
+		this.mongoPort = port;
+		this.dbName = db;
+		this.metricName = metricName;
+		this.serviceName = serviceName;
+		this.endpointName = endpointName;
+		this.egroupName = egroupName;
+		this.method = method;
+		this.report = report;
+	}
+
+	private void initMongo() {
+		this.mClient = new MongoClient(mongoHost, mongoPort);
+		this.mDB = mClient.getDatabase(dbName);
+		this.metricCol = mDB.getCollection(metricName);
+		this.endpointCol = mDB.getCollection(endpointName);
+		this.serviceCol = mDB.getCollection(serviceName);
+		this.egroupCol = mDB.getCollection(egroupName);
+	}
+
+	/**
+	 * Initialize MongoDB remote connection
+	 */
+	@Override
+	public void open(int taskNumber, int numTasks) throws IOException {
+		// Configure mongo
+		initMongo();
+	}
+
+	/**
+	 * Prepare correct MongoDocument according to record values and selected StatusType.
+	 * A different document is needed for storing Status Metric results than Endpoint,
+	 * Service or Endpoint Group ones.       
+	 */
+	private Document prepDoc(StatusEvent record) {
+		Document doc = new Document("report",this.report)
+				.append("endpoint_group", record.getGroup());
+				
+		
+		if (record.getType().equalsIgnoreCase("service")) {
+			
+			doc.append("service",record.getService());
+		
+		} else if (record.getType().equalsIgnoreCase("endpoint")) {
+			
+			doc.append("service", record.getService())
+			.append("host", record.getHostname());
+				
+		} else if (record.getType().equalsIgnoreCase("metric")) {
+		
+			doc.append("service", record.getService())
+			.append("host", record.getHostname())
+			.append("metric", record.getMetric())
+			.append("message", record.getMessage())
+			.append("summary", record.getSummary())
+			.append("time_integer",record.getTimeInt()) 
+			.append("previous_state",record.getPrevStatus())
+			.append("previous_ts", record.getPrevTs());
+		}
+		
+		
+		doc.append("status",record.getStatus())
+				.append("timestamp",record.getTsMonitored())
+				.append("date_integer",record.getDateInt());
+		
+		return doc;
+	}
+	
+	/**
+	 * Prepare correct Update filter according to record values and selected StatusType.
+	 * A different update filter is needed for updating Status Metric results than Endpoint,
+	 * Service or Endpoint Group ones.       
+	 */
+	private Bson prepFilter(StatusEvent record) {
+	
+		if (record.getType().equalsIgnoreCase("metric")) {
+			
+			return Filters.and(Filters.eq("report", this.report), Filters.eq("date_integer", record.getDateInt()),
+					Filters.eq("endpoint_group", record.getGroup()), Filters.eq("service", record.getService()),
+					Filters.eq("host", record.getHostname()), Filters.eq("metric", record.getMetric()),
+					Filters.eq("timestamp", record.getTsMonitored()));
+		
+		} else if (record.getType().equalsIgnoreCase("endpoint")) {
+			
+			return Filters.and(Filters.eq("report", this.report), Filters.eq("date_integer", record.getDateInt()),
+					Filters.eq("endpoint_group", record.getGroup()), Filters.eq("service", record.getService()),
+					Filters.eq("host", record.getHostname()), Filters.eq("timestamp", record.getTsMonitored()));
+			
+		} else if (record.getType().equalsIgnoreCase("service")) {
+			
+			return Filters.and(Filters.eq("report", this.report), Filters.eq("date_integer", record.getDateInt()),
+					Filters.eq("endpoint_group", record.getGroup()), Filters.eq("service", record.getService()),
+					Filters.eq("timestamp", record.getTsMonitored()));
+		
+		} else if (record.getType().equalsIgnoreCase("endpoint_group")) {
+			
+			return Filters.and(Filters.eq("report", this.report), Filters.eq("date_integer", record.getDateInt()),
+					Filters.eq("endpoint_group", record.getGroup()), Filters.eq("timestamp", record.getTsMonitored()));
+
+		}
+		
+		return null;
+		
+	
+	}
+	
+	/**
+	 * Extract json representation as string to be used as a field value
+	 */
+	private String extractJson(String field, JsonObject root) {
+		JsonElement el = root.get(field);
+		if (el != null && !(el.isJsonNull())) {
+
+			return el.getAsString();
+
+		}
+		return "";
+	}
+	
+	public StatusEvent jsonToStatusEvent(JsonObject jRoot) {
+		
+		String rep = this.report;
+		String tp = extractJson("type", jRoot);
+		String dt = extractJson("date", jRoot);
+		String eGroup = extractJson("endpoint_group", jRoot);
+		String service = extractJson("service", jRoot);
+		String hostname = extractJson("hostname", jRoot);
+		String metric = extractJson("metric", jRoot);
+		String status = extractJson("status", jRoot);
+		String prevStatus = extractJson("prev_status", jRoot);
+		String prevTs = extractJson("prev_ts", jRoot);
+		String tsm = extractJson("ts_monitored", jRoot);
+		String tsp = extractJson("ts_processed", jRoot);
+		String monHost = extractJson("monitor_host",jRoot);
+		String repeat = extractJson("repeat",jRoot);
+		String message = extractJson("message",jRoot);
+		String summary = extractJson("summary",jRoot);
+		return new StatusEvent(rep,tp,dt,eGroup,service,hostname,metric,status,monHost,tsm,tsp,prevTs,prevStatus,repeat,summary,message);
+	}
+
+	/**
+	 * Store a MongoDB document record
+	 */
+	@Override
+	public void writeRecord(String recordJSON) throws IOException {
+
+		JsonParser jsonParser = new JsonParser();
+		// parse the json root object
+		JsonObject jRoot = jsonParser.parse(recordJSON).getAsJsonObject();
+		StatusEvent record = jsonToStatusEvent(jRoot);
+		
+		
+		// Mongo Document to be prepared according to StatusType of input
+		Document doc = prepDoc(record);
+
+		if (this.method == MongoMethod.UPSERT) {
+
+			// Filter for upsert to be prepared according to StatusType of input
+			Bson f = prepFilter(record);
+			UpdateOptions opts = new UpdateOptions().upsert(true);
+			if (record.getType().equalsIgnoreCase("metric")) {
+				metricCol.replaceOne(f, doc, opts);
+			} else if (record.getType().equalsIgnoreCase("endpoint")) {
+				endpointCol.replaceOne(f, doc, opts);
+			} else if (record.getType().equalsIgnoreCase("service")) {
+				serviceCol.replaceOne(f, doc, opts);
+			}  else if (record.getType().equalsIgnoreCase("endpoint_group")) {
+				egroupCol.replaceOne(f, doc, opts);
+			}
+			
+		} else {
+			if (record.getType().equalsIgnoreCase("metric")) {
+				metricCol.insertOne(doc);
+			} else if (record.getType().equalsIgnoreCase("endpoint")) {
+				endpointCol.insertOne(doc);
+			} else if (record.getType().equalsIgnoreCase("service")) {
+				serviceCol.insertOne(doc);
+			}  else if (record.getType().equalsIgnoreCase("endpoint_group")) {
+				egroupCol.insertOne(doc);
+			}
+		}
+	}
+
+	/**
+	 * Close MongoDB Connection
+	 */
+	@Override
+	public void close() throws IOException {
+		if (mClient != null) {
+			mClient.close();
+			mClient = null;
+			mDB = null;
+			metricCol = null;
+			endpointCol = null;
+			serviceCol = null;
+			egroupCol = null; 
+		}
+	}
+
+	@Override
+	public void configure(Configuration arg0) {
+		// configure
+
+	}
+
+}

--- a/flink_jobs/stream_status/src/main/java/argo/streaming/StatusConfig.java
+++ b/flink_jobs/stream_status/src/main/java/argo/streaming/StatusConfig.java
@@ -19,7 +19,6 @@ public class StatusConfig implements Serializable {
 	public String amsProject;
 	public String amsSub;
 	
-	
 	// Avro schema
 	public String avroSchema;
 	
@@ -28,6 +27,10 @@ public class StatusConfig implements Serializable {
 	public String mps;
 	public String egp;
 	public String ops;
+	// Parameter used in alert timeouts for notifications
+	public long timeout;
+	// Parameter used for daily event generation (not used in notifications)
+	public boolean daily;
 	public String defStatus = "MISSING";
 	
 	// Raw parameters
@@ -35,16 +38,25 @@ public class StatusConfig implements Serializable {
 	
 	public StatusConfig(ParameterTool pt){
 	    this.pt = pt;
-	   this.amsHost = pt.get("ams.host","localhost");
-	   this.amsPort = pt.get("ams.port","443");
-	   this.amsToken = pt.get("ams.token","metric");
-	   this.amsProject = pt.get("ams.project","TESTPROJECT");
-	   this.avroSchema = pt.get("avro.schema","metric_data.avsc");
-	   this.aps = pt.get("sync.aps","ap1.json");
-	   this.mps = pt.get("sync.mps","metric_data.avro");
-	   this.egp = pt.get("sync.egp","group_endpoints.avro");
-	   this.ops = pt.get("sync.ops","ops.json");
-	   this.runDate = pt.get("run.date","");
+	   this.amsHost = pt.getRequired("ams.endpoint");
+	   this.amsPort = pt.getRequired("ams.port");
+	   this.amsToken = pt.getRequired("ams.token");
+	   this.amsProject = pt.getRequired("ams.project");
+	   
+	   this.aps = pt.getRequired("sync.apr");
+	   this.mps = pt.getRequired("sync.mps");
+	   this.egp = pt.getRequired("sync.egp");
+	   this.ops = pt.getRequired("sync.ops");
+	   this.runDate = pt.getRequired("run.date");
+	   // Optional timeout parameter
+	   if (pt.has("timeout")){
+		   this.timeout = pt.getLong("timeout");
+	   } else {
+		   this.timeout = 86400000L;
+	   }
+	   
+	   // Optional set daily parameter
+	   this.daily = pt.getBoolean("daily",false);
 	   
 	  }
 	

--- a/flink_jobs/stream_status/src/main/java/status/StatusEvent.java
+++ b/flink_jobs/stream_status/src/main/java/status/StatusEvent.java
@@ -3,21 +3,25 @@ package status;
 import com.google.gson.annotations.SerializedName;
 
 public class StatusEvent{
-	String report;
-	String type;
-	@SerializedName("date") String dt;
-	@SerializedName("endpoint_group") String group;
-	String service;
-	String hostname;
-	String metric;
-	String status;
-	@SerializedName("monitoring_host") String monHost;
-	@SerializedName("ts_monitored") String tsMonitored;
-	@SerializedName("ts_processed") String tsProcessed;
-	@SerializedName("prev_status")String prevStatus;
-	@SerializedName("prev_ts")String prevTs;
+
+	private String report;
+	private String type;
+	private @SerializedName("date") String dt;
+	private @SerializedName("endpoint_group") String group;
+	private String service;
+	private String hostname;
+	private String metric;
+	private String status;
+	private @SerializedName("monitoring_host") String monHost;
+	private @SerializedName("ts_monitored") String tsMonitored;
+	private @SerializedName("ts_processed") String tsProcessed;
+	private @SerializedName("prev_status")String prevStatus;
+	private @SerializedName("prev_ts")String prevTs;
+	private String repeat;
+	private String summary;
+	private String message;
 	
-	public StatusEvent (String report, String type, String dt, String group,String service,String hostname,String metric,String status,String monHost, String tsMonitored, String tsProcessed, String prevStatus, String prevTs){
+	public StatusEvent (String report, String type, String dt, String group,String service,String hostname,String metric,String status,String monHost, String tsMonitored, String tsProcessed, String prevStatus, String prevTs, String repeat, String summary, String message){
 		this.report  = report;
 		this.type =type;
 		this.group = group;
@@ -31,5 +35,54 @@ public class StatusEvent{
 		this.tsProcessed = tsProcessed;
 		this.prevStatus = prevStatus;
 		this.prevTs = prevTs;
+		this.repeat = repeat;
+		this.summary = summary;
+		this.message = message;
+		
 	}
+	
+	public String getReport() { return report; }
+	public String getType() { return type; }
+	public String getDt() {return dt;}
+	public String getGroup() {return group;}
+	public String getService() {return service;}
+	public String getHostname() {return hostname;}
+	public String getStatus() {return status;}
+	public String getMetric() {return metric;}
+	public String getMonHost() {return monHost;}
+	public String getTsMonitored() {return tsMonitored;}
+	public String getTsProcessed() {return tsProcessed;}
+	public String getPrevStatus() {return prevStatus;}
+	public String getPrevTs() {return prevTs;}
+	public String getRepeat() {return repeat;}
+	public String getSummary() {return this.summary;}
+	public String getMessage() {return this.message;}
+
+	public void setReport(String report) {this.report = report;}	
+	public void setType(String type) {this.type = type;}
+	public void setDt(String dt) {this.dt = dt;}
+	public void setGroup(String group) {this.group = group;}
+	public void setService(String service) {this.service = service;}
+	public void setHostname(String hostname) {this.hostname = hostname;}
+	public void setMetric(String metric) {this.metric = metric;}
+	public void setStatus(String status) {this.status = status;}
+	public void setMonHost(String monHost) {this.monHost = monHost;}
+	public void setTsMonitored(String tsMonitored) {this.tsMonitored = tsMonitored;}
+	public void setTsProcessed(String tsProcessed) {this.tsProcessed = tsProcessed;}
+	public void setPrevStatus(String prevStatus) {this.prevStatus = prevStatus;}
+	public void setPrevTs(String prevTs) {this.prevTs = prevTs;}
+	public void setRepeat(String repeat) {this.repeat = repeat;}
+	public void setSummary(String summary) {this.summary = summary;}
+	public void setMessage (String message) {this.message = message;}
+	
+	public int getDateInt() {
+		return Integer.parseInt(this.dt);
+	}
+	
+	public int getTimeInt() {
+		String timePart = this.tsMonitored.replaceAll(":|Z", "").split("T")[1];
+		return Integer.parseInt(timePart);
+	}
+	
+	
 }

--- a/flink_jobs/stream_status/src/test/java/status/StatusManagerTest.java
+++ b/flink_jobs/stream_status/src/test/java/status/StatusManagerTest.java
@@ -57,13 +57,13 @@ public class StatusManagerTest {
 
 		sm.addNewGroup("GR-01-AUTH",sm.ops.getIntStatus("OK"), ts1);
 		ArrayList<String> list = sm.setStatus("CREAM-CE", "cream01.grid.auth.gr", "emi.cream.CREAMCE-JobCancel",
-				"CRITICAL", "mon01.argo.eu", "2017-03-03T00:00:00Z");
+				"CRITICAL", "mon01.argo.eu", "2017-03-03T00:00:00Z","","");
 		ArrayList<String> list2 = sm.setStatus("CREAM-CE", "cream01.grid.auth.gr", "eu.egi.CREAM-IGTF", "WARNING",
-				"mon01.argo.eu", "2017-03-03T05:00:00Z");
+				"mon01.argo.eu", "2017-03-03T05:00:00Z","","");
 		ArrayList<String> list3 = sm.setStatus("CREAM-CE", "cream01.grid.auth.gr", "emi.cream.CREAMCE-JobCancel", "OK",
-				"mon01.argo.eu", "2017-03-03T09:00:00Z");
+				"mon01.argo.eu", "2017-03-03T09:00:00Z","","");
 		ArrayList<String> list4 = sm.setStatus("CREAM-CE", "cream01.grid.auth.gr", "eu.egi.CREAM-IGTF", "OK",
-				"mon01.argo.eu", "2017-03-03T15:00:00Z");
+				"mon01.argo.eu", "2017-03-03T15:00:00Z","","");
 
 		
 		Gson gson = new Gson();
@@ -75,7 +75,7 @@ public class StatusManagerTest {
 
 		String jproc = jRoot.getAsJsonObject().get("ts_processed").getAsString();
 		StatusEvent evnt = new StatusEvent("Critical","metric","20170303","GR-01-AUTH", "CREAM-CE", "cream01.grid.auth.gr",
-				"eu.egi.CREAM-IGTF", "OK", "mon01.argo.eu", "2017-03-03T15:00:00Z", jproc,"WARNING","2017-03-03T05:00:00Z");
+				"eu.egi.CREAM-IGTF", "OK", "mon01.argo.eu", "2017-03-03T15:00:00Z", jproc,"WARNING","2017-03-03T05:00:00Z", "false","","");
 		
 		assertTrue(gson.toJson(evnt).equals(list4.get(0)));
 


### PR DESCRIPTION
# Issues
- Issues in event generation for endpoints that belonged to multiple top level groups
- Better handling needed for controlling event timeouts for notification regeneration

# Fixes
- Refactor StatusManager to properly support event generation for all top-level groups that an endpoint metric check affects
- Refactor StatusManager to accept a timeout parameter with default value of 84000000ms (1day). Events generate if status change or time duration > timeout 

# Addition
If an event is regenerated (due to timeout) 