### PR TITLE
ARGO-1221 Report name capitalization fix

### DIFF
--- a/bin/ar_job_submit.py
+++ b/bin/ar_job_submit.py
@@ -143,7 +143,6 @@ def compose_command(config, args,  hdfs_commands, logger=None):
 def main(args=None):
 
     # make sure the argument are in the correct form
-    args.Report = args.Report.capitalize()
     args.Tenant = args.Tenant.upper()
     args.Method = args.Method.lower()
 

--- a/bin/status_job_submit.py
+++ b/bin/status_job_submit.py
@@ -138,7 +138,6 @@ def compose_command(config, args,  hdfs_commands, logger=None):
 def main(args=None):
 
     # make sure the argument are in the correct form
-    args.Report = args.Report.capitalize()
     args.Tenant = args.Tenant.upper()
     args.Method = args.Method.lower()
 

--- a/bin/stream_status_job_submit.py
+++ b/bin/stream_status_job_submit.py
@@ -205,7 +205,7 @@ def main(args=None):
 
     # make sure the argument are in the correct form
     args.Tenant = args.Tenant.upper()
-    args.Report = args.Report.capitalize()
+    
 
     # set up the config parser
     config = ConfigParser.ConfigParser()


### PR DESCRIPTION
Report names won't always be in a strict format having Capital first-letter. 