### PR TITLE
ARGO-1230 Fetch latest ops profile from argo-web-api

### DIFF
--- a/bin/ar_job_submit.py
+++ b/bin/ar_job_submit.py
@@ -11,7 +11,7 @@ from urlparse import urlparse
 from utils.argo_log import ArgoLogger
 from utils.argo_mongo import ArgoMongoClient
 from utils.common import cmd_toString, date_rollback, flink_job_submit, hdfs_check_path
-
+from utils.update_profiles import ArgoProfileManager
 
 def compose_hdfs_commands(year, month, day, args, config, logger):
 
@@ -168,6 +168,11 @@ def main(args=None):
     # check if configuration for the given tenant exists
     if not config.has_section("TENANTS:"+args.Tenant):
         logger.print_and_log(logging.CRITICAL, "Tenant: "+args.Tenant+" doesn't exist.", 1)
+
+    # call update profiles
+    profile_mgr = ArgoProfileManager(args.ConfigPath)
+    profile_mgr.profile_update_check(args.Tenant, args.Report)
+
 
     # dictionary containing the argument's name and the command assosciated with each name
     hdfs_commands = compose_hdfs_commands(year, month, day, args, config, logger)

--- a/bin/status_job_submit.py
+++ b/bin/status_job_submit.py
@@ -10,7 +10,7 @@ from urlparse import urlparse
 from utils.argo_log import ArgoLogger
 from utils.argo_mongo import ArgoMongoClient
 from utils.common import cmd_toString, date_rollback, flink_job_submit, hdfs_check_path
-
+from utils.update_profiles import ArgoProfileManager
 
 def compose_hdfs_commands(year, month, day, args, config, logger):
 
@@ -163,6 +163,10 @@ def main(args=None):
     # check if configuration for the given tenant exists
     if not config.has_section("TENANTS:"+args.Tenant):
         logger.print_and_log(logging.CRITICAL, "Tenant: "+args.Tenant+" doesn't exist.", 1)
+
+    # call update profiles
+    profile_mgr = ArgoProfileManager(args.ConfigPath)
+    profile_mgr.profile_update_check(args.Tenant, args.Report)
 
     # dictionary containing the argument's name and the command assosciated with each name
     hdfs_commands = compose_hdfs_commands(year, month, day, args, config, logger)

--- a/bin/utils/test_update_profiles.py
+++ b/bin/utils/test_update_profiles.py
@@ -1,0 +1,84 @@
+import unittest
+import os
+from update_profiles import HdfsReader
+from update_profiles import ArgoApiClient
+from update_profiles import get_config
+
+CONF_TEMPLATE = os.path.join(os.path.dirname(__file__), '../../conf/conf.template')
+
+
+class TestClass(unittest.TestCase):
+
+    def test_hdfs_reader(self):
+        hdfs_host = "foo"
+        hdfs_port = "9000"
+        hdfs_sync = "/user/foo/argo/tenants/{{tenant}}/sync"
+        hdfs = HdfsReader(hdfs_host, hdfs_port, hdfs_sync)
+
+        test_cases = [
+            {"tenant": "TA", "report": "Critical", "profile_type": "operations",
+             "expected": "/user/foo/argo/tenants/TA/sync/TA_ops.json"},
+            {"tenant": "TA", "report": "Super-Critical", "profile_type": "operations",
+             "expected": "/user/foo/argo/tenants/TA/sync/TA_ops.json"},
+            {"tenant": "TA", "report": "Critical", "profile_type": "reports",
+             "expected": "/user/foo/argo/tenants/TA/sync/TA_Critical_cfg.json"},
+            {"tenant": "TA", "report": "Critical", "profile_type": "aggregations",
+             "expected": "/user/foo/argo/tenants/TA/sync/TA_Critical_ap.json"},
+            {"tenant": "TA", "report": "Crit", "profile_type": "reports",
+             "expected": "/user/foo/argo/tenants/TA/sync/TA_Crit_cfg.json"},
+            {"tenant": "TA", "report": "Super-Critical", "profile_type": "aggregations",
+             "expected": "/user/foo/argo/tenants/TA/sync/TA_Super-Critical_ap.json"},
+            {"tenant": "TB", "report": "Critical", "profile_type": "aggregations",
+             "expected": "/user/foo/argo/tenants/TB/sync/TB_Critical_ap.json"},
+            {"tenant": "TB", "report": "Critical", "profile_type": "reports",
+             "expected": "/user/foo/argo/tenants/TB/sync/TB_Critical_cfg.json"}
+        ]
+
+        for test_case in test_cases:
+            actual = hdfs.gen_profile_path(test_case["tenant"], test_case["report"], test_case["profile_type"])
+            expected = test_case["expected"]
+            self.assertEquals(expected, actual)
+
+    def test_api(self):
+
+        cfg = {
+            "api_host": "foo.host",
+            "tenant_keys": {"TA": "key1", "TB": "key2"}
+        }
+
+        argo_api = ArgoApiClient(cfg["api_host"], cfg["tenant_keys"])
+
+        test_cases = [
+            {"resource": "reports", "item_uuid": None,
+             "expected": "https://foo.host/api/v2/reports"},
+            {"resource": "reports", "item_uuid": "12",
+             "expected": "https://foo.host/api/v2/reports/12"},
+            {"resource": "operations", "item_uuid": None,
+             "expected": "https://foo.host/api/v2/operations_profiles"},
+            {"resource": "operations", "item_uuid": "12",
+             "expected": "https://foo.host/api/v2/operations_profiles/12"}
+        ]
+
+        for test_case in test_cases:
+            actual = argo_api.get_url(test_case["resource"], test_case["item_uuid"])
+            expected = test_case["expected"]
+            self.assertEquals(expected, actual)
+
+    def test_cfg(self):
+
+        actual_cfg = get_config(CONF_TEMPLATE)
+
+        expected_cfg = {
+            'hdfs_host': 'hdfs_test_host',
+            'hdfs_port': 'hdfs_test_port',
+            'hdfs_user': 'hdfs_test_user',
+            'hdfs_writer': '/path/to/binary',
+            'hdfs_sync': 'hdfs://{{hdfs_host}}:{{hdfs_port}}/user/{{hdfs_user}}/argo/tenants/{{tenant}}/sync',
+            'log_level': 'info',
+            'api_host': 'api.foo',
+            'tenant_keys': {'TA': 'key1',
+                            'TB': 'key2',
+                            'TC': 'key3'}
+        }
+
+        self.assertEquals(expected_cfg, actual_cfg)

--- a/bin/utils/update_profiles.py
+++ b/bin/utils/update_profiles.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python
+import requests
+import json
+from snakebite.client import Client
+from snakebite.errors import FileNotFoundException
+from ConfigParser import SafeConfigParser
+import logging
+import logging.handlers
+import os
+import uuid
+from urlparse import urlparse
+from argparse import ArgumentParser
+import sys
+import subprocess
+
+CONF_ETC = '/etc/argo-streaming/argo-streaming.cfg'
+CONF_LOCAL = './argo-streaming.cfg'
+
+
+class ArgoApiClient:
+    """
+    ArgoApiClient class
+
+    It connects to an argo-web-api host and retrieves profile information per tenant and report
+    """
+
+    def __init__(self, host, tenant_keys):
+        """
+        Initialize ArgoApiClient which is used to retrieve profiles from argo-web-api
+        Args:
+            host: str. argo-web-api host
+            tenant_keys: dict. a dictionary of {tenant: api_token} entries
+        """
+        self.host = host
+        self.paths = dict()
+        self.tenant_keys = tenant_keys
+        self.paths.update({
+            'reports': '/api/v2/reports',
+            'operations': '/api/v2/operations_profiles'
+        })
+
+    def get_url(self, resource, item_uuid):
+        """
+        Constructs an argo-web-api url based on the resource and item_uuid
+        Args:
+            resource:   str. resource to be retrieved (reports|ops)
+            item_uuid: str. retrieve a specific item from the resource
+
+        Returns:
+            str: url path
+
+        """
+        if item_uuid is None:
+            return "".join(["https://", self.host, self.paths[resource]])
+        else:
+            return "".join(["https://", self.host, self.paths[resource], "/", item_uuid])
+
+    def get_resource(self, tenant, url):
+        """
+        Returns an argo-web-api resource by tenant and url
+        Args:
+            tenant: str. tenant to be used (for auth)
+            url: str. url of resource
+
+        Returns:
+            dict: resource contents
+
+        """
+        headers = dict()
+        headers.update({
+            'Accept': 'application/json',
+            'x-api-key': self.tenant_keys[tenant]
+        })
+        r = requests.get(url, headers=headers, verify=False)
+
+        if 200 == r.status_code:
+            return json.loads(r.text)["data"]
+        else:
+            return None
+
+    def get_profile(self, tenant, report, profile_type):
+        """
+        Gets an argo-web-api profile by tenant, report and profile type
+        Args:
+            tenant: str. tenant name
+            report: str. report name
+            profile_type: str. profile type (ops)
+
+        Returns:
+            dict: profile contents
+
+        """
+        item_uuid = self.find_profile_uuid(tenant, report, profile_type)
+        profiles = self.get_resource(tenant, self.get_url(profile_type, item_uuid))
+        if profiles is not None:
+            return profiles[0]
+
+    def get_reports(self, tenant):
+        """
+        Get all reports for a tenant
+
+        Args:
+            tenant: str. tenant name
+
+        Returns:
+            list(dict): a list of reports (dict objects)
+
+        """
+        return self.get_resource(tenant, self.get_url("reports", None))
+
+    def find_report_uuid(self, tenant, name):
+        """
+
+        Args:
+            tenant: str. tenant name to be used
+            name: str. report name to be used
+
+        Returns:
+            str: report's uuid
+
+        """
+        r = self.get_reports(tenant)
+        if r is None:
+            return ''
+
+        for report in r:
+            if report["info"]["name"] == name:
+                return report["id"]
+
+    def get_report(self, tenant, item_uuid):
+        """
+        Gets a report based on a report uuid or a report list if uuid is None
+        Args:
+            tenant: str. Tenant to retrieve report from
+            item_uuid: str. report uuid to be used - or None to get all reports
+
+        Returns:
+            obj: Returns an array of reports or one report
+
+        """
+        reports = self.get_resource(tenant, self.get_url("reports", item_uuid))
+        if reports is not None:
+            return reports[0]
+
+    def find_profile_uuid(self, tenant, report, profile_type):
+        """
+        Finds a profile uuid by tenant, report and it's type (ops)
+        Args:
+            tenant: str. Tenant name to retrieve profile uuid from
+            report: str. Report name that the profile is used
+            profile_type: str. Type of the profile (ops)
+
+        Returns:
+
+        """
+        report = self.get_report(tenant, self.find_report_uuid(tenant, report))
+        for profile in report["profiles"]:
+            if profile["type"] == profile_type:
+                return profile["id"]
+
+
+class HdfsReader:
+    """
+    HdfsReader class
+
+    Connects to an hdfs endpoint (namenode) and checks argo profile files stored there
+    Uses a specific base path for determining argo file destinations
+    """
+
+    def __init__(self, namenode, port, base_path):
+        """
+        Initialized HdfsReader which is used to check/read profile files from hdfs
+        Args:
+            namenode: str. hdfs namenode host
+            port: int. hdfs namenode port
+            base_path: str. base path to  destination used for argo
+        """
+        self.client = Client(namenode, port)
+        self.base_path = base_path
+
+    def gen_profile_path(self, tenant, report, profile_type):
+        """
+        Generates a valid hdfs path to a specific profile
+        Args:
+            tenant: str. tenant to be used
+            report: str. report to be used
+            profile_type: str. profile_type (operations|reports|aggregations)
+
+        Returns:
+            str: hdfs path
+
+        """
+        templates = dict()
+        templates.update({
+            'operations': '{0}_ops.json',
+            'aggregations': '{0}_{1}_ap.json',
+            'reports': '{0}_{1}_cfg.json'
+        })
+
+        sync_path = self.base_path.replace("{{tenant}}", tenant)
+        filename = templates[profile_type].format(tenant, report)
+        return os.path.join(sync_path, filename)
+
+    def cat(self, tenant, report, profile_type):
+        """
+        Returns the contents of a profile stored in hdfs
+        Args:
+            tenant: str. tenant name
+            report: str. report name
+            profile_type: str. profile type (operations|reports|aggregations)
+
+        Returns:
+
+        """
+        path = self.gen_profile_path(tenant, report, profile_type)
+        try:
+            txt = self.client.cat([path])
+            j = json.loads(txt.next().next())
+            return j, True
+        except FileNotFoundException:
+            return None, False
+
+    def rem(self, tenant, report, profile_type):
+        """
+        Removes a profile file that already exists in hdfs (in order to be replaced)
+        Args:
+            tenant: str. tenant name
+            report: str. report name
+            profile_type: str. profile type (operations|reports|aggregations)
+
+        Returns:
+
+        """
+        path = self.gen_profile_path(tenant, report, profile_type)
+        try:
+            self.client.delete([path]).next()
+            return True
+        except FileNotFoundException:
+            return False
+
+
+class ArgoProfileManager:
+    """
+    ArgoProfileManager
+
+    Checks argo profile definitions per tenant between an argo-web-api instance and
+    an hdfs destination. If argo profiles are out of date in hdfs they are updated
+    from their latest profile definitions given from argo-web-api.
+    """
+
+    def __init__(self, cfg_path):
+        """
+        Initialized ArgoProfileManager which manages updating argo profile files in hdfs
+        Args:
+            cfg_path: str. path to the configuration file used
+        """
+        self.cfg = get_config(cfg_path)
+
+        self.log = get_logger("argo-profile-mgr", self.cfg["log_level"])
+
+        # process hdfs base path
+        full_path = str(self.cfg["hdfs_sync"])
+        full_path = full_path.replace("{{hdfs_host}}", str(self.cfg["hdfs_host"]))
+        full_path = full_path.replace("{{hdfs_port}}", str(self.cfg["hdfs_port"]))
+        full_path = full_path.replace("{{hdfs_user}}", str(self.cfg["hdfs_user"]))
+
+        short_path = urlparse(full_path).path
+
+        self.hdfs = HdfsReader(self.cfg["hdfs_host"], int(self.cfg["hdfs_port"]), short_path)
+        self.api = ArgoApiClient(self.cfg["api_host"], self.cfg["tenant_keys"])
+
+    def profile_update_check(self, tenant, report, profile_type):
+        """
+        Checks if latest api profiles are aligned with profile files stored in hdfs.
+        If not the updated api profile are uploaded to hdfs
+        Args:
+            tenant: str. Tenant name to check profiles from
+            report: str. Report name to check profiles from
+        """
+
+        prof_api = self.api.get_profile(tenant, report, profile_type)
+        self.log.info("retrieved %s profile(api): %s", profile_type, prof_api)
+
+        prof_hdfs, exists = self.hdfs.cat(tenant, report, profile_type)
+
+        if exists:
+            self.log.info("retrieved %s profile(hdfs): %s ", profile_type, prof_hdfs)
+            prof_update = prof_api != prof_hdfs
+
+            if prof_update:
+                self.log.info("%s profile mismatch", profile_type)
+            else:
+                self.log.info("%s profiles match -- no need for update", profile_type)
+        else:
+            # doesn't exist so it should be uploaded
+            prof_update = True
+            self.log.info("%s profile doesn't exist in hdfs, should be uploaded", profile_type)
+
+        # Upload if it's deemed to be uploaded
+        if prof_update:
+            self.upload_profile_to_hdfs(tenant, report, profile_type, prof_api, exists)
+
+    def upload_profile_to_hdfs(self, tenant, report, profile_type, profile, exists):
+        """
+        Uploads an updated profile (from api) to the specified hdfs destination
+        Args:
+            tenant: str. The tenant name used in hdfs path
+            report: str. The report name used in hdfs path/filenames
+            profile_type: str. The profile type to be used in hdfs filename
+            profile: dict. Content data of the profile
+            exists: bool. if an old profile exists already in hdfs
+
+        Returns:
+            bool: if the operation was successful or not
+
+        """
+        # If file exists on hdfs should be removed first
+        if exists:
+            is_removed = self.hdfs.rem(tenant, report, profile_type)
+            if not is_removed:
+                self.log.error("Could not remove old %s profile from hdfs", profile_type)
+                return
+
+        # If all ok continue with uploading the new file to hdfs
+
+        hdfs_write_bin = self.cfg["hdfs_writer"]
+        hdfs_write_cmd = "put"
+
+        temp_fn = "prof_" + str(uuid.uuid4())
+        local_path = "/tmp/" + temp_fn
+        with open(local_path, 'w') as outfile:
+            json.dump(profile, outfile)
+
+        hdfs_host = str(self.cfg["hdfs_host"])
+        hdfs_path = self.hdfs.gen_profile_path(tenant, report, profile_type)
+
+        status = subprocess.check_call([hdfs_write_bin, hdfs_write_cmd, local_path, hdfs_path])
+
+        if status == 0:
+            self.log.info("File uploaded successfully to hdfs host: %s path: %s", hdfs_host, hdfs_path)
+            return True
+        else:
+            self.log.error("File uploaded unsuccessful to hdfs host: %s path: %s", hdfs_host, hdfs_path)
+            return False
+
+
+def get_config(path):
+    """
+    Creates a specific dictionary with only needed configuration options retrieved from an argo config file
+    Args:
+        path: str. path to the generic argo config file to be used
+
+    Returns:
+        dict: a specific configuration option dictionary with only necessary parameters
+
+    """
+    # set up the config parser
+    config = SafeConfigParser()
+
+    if path is None:
+
+        if os.path.isfile(CONF_ETC):
+            # Read default etc_conf
+            config.read(CONF_ETC)
+        else:
+            # Read local
+            config.read(CONF_LOCAL)
+    else:
+        config.read(path)
+
+    cfg = dict()
+    cfg.update(dict(log_level=config.get("LOGS", "log_level"), hdfs_host=config.get("HDFS", "hdfs_host"),
+                    hdfs_port=config.get("HDFS", "hdfs_port"), hdfs_user=config.get("HDFS", "hdfs_user"),
+                    hdfs_sync=config.get("HDFS", "hdfs_sync"), api_host=config.get("API", "host"),
+                    hdfs_writer=config.get("HDFS", "writer_bin")))
+
+    tenant_list = config.get("API", "tenants").split(",")
+    tenant_keys = dict()
+    # Create a list of tenants -> api_keys
+    for tenant in tenant_list:
+        tenant_key = config.get("API", tenant + "_key")
+        tenant_keys[tenant] = tenant_key
+    cfg["tenant_keys"] = tenant_keys
+
+    return cfg
+
+
+def get_logger(log_name, log_level):
+    """
+    Instantiates a logger
+    Args:
+        log_name: str. log name to be used in logger
+        log_level: str. log level
+
+    Returns:
+        obj: logger
+
+    """
+    # Instantiate logger with proper name
+    log = logging.getLogger(log_name)
+    log.setLevel(logging.DEBUG)
+
+    log_level = log_level.upper()
+
+    # Instantiate default levels
+    levels = {
+        'DEBUG': logging.DEBUG,
+        'INFO': logging.INFO,
+        'WARNING': logging.WARNING,
+        'ERROR': logging.ERROR,
+        'CRITICAL': logging.CRITICAL
+    }
+
+    # Log to console
+    stream_log = logging.StreamHandler()
+    stream_log.setLevel(logging.INFO)
+    log.addHandler(stream_log)
+
+    # Log to syslog
+    sys_log = logging.handlers.SysLogHandler("/dev/log")
+    sys_format = logging.Formatter('%(name)s[%(process)d]: %(levelname)s %(message)s')
+    sys_log.setFormatter(sys_format)
+    sys_log.setLevel(levels[log_level])
+    log.addHandler(sys_log)
+
+    return log
+
+
+def run_profile_update(args):
+    """
+    Method to be executed when this is invoked as a command line script.
+    Reads tenant,report and config arguments from cli and instantiates an
+    ArgoProfileManager which does a profile update check
+    Args:
+        args: obj. command line arguments from arg parser
+    """
+    # Set a new profile manager to be used
+    argo = ArgoProfileManager(args.config)
+
+    # check for the following profile types -- now just operations
+    profile_type_checklist = ["operations"]
+    for profile_type in profile_type_checklist:
+        argo.profile_update_check(args.tenant, args.report, profile_type)
+
+
+if __name__ == '__main__':
+    # Feed Argument parser with the description of the 3 arguments we need
+    arg_parser = ArgumentParser(
+        description="update profiles for specific tenant/report")
+    arg_parser.add_argument(
+        "-t", "--tenant", help="tenant owner ", dest="tenant", metavar="STRING", required=True)
+    arg_parser.add_argument(
+        "-r", "--report", help="report", dest="report", metavar="STRING", required=True)
+    arg_parser.add_argument(
+        "-c", "--config", help="config", dest="config", metavar="STRING")
+
+    # Parse the command line arguments accordingly and introduce them to the run method
+    sys.exit(run_profile_update(arg_parser.parse_args()))

--- a/conf/conf.template
+++ b/conf/conf.template
@@ -1,9 +1,9 @@
 [HDFS]
 # hdfs namenode host
 hdfs_host: hdfs_test_host
-# hdfs namenode port 
+# hdfs namenode port
 hdfs_port: hdfs_test_port
-# hdfs user 
+# hdfs user
 hdfs_user: hdfs_test_user
 # hdfs rollback days:
 rollback_days: 3
@@ -12,8 +12,19 @@ hdfs_metric: hdfs://{{hdfs_host}}:{{hdfs_port}}/user/{{hdfs_user}}/argo/tenants/
 # hdfs path for sync data
 hdfs_sync: hdfs://{{hdfs_host}}:{{hdfs_port}}/user/{{hdfs_user}}/argo/tenants/{{tenant}}/sync
 
+# hdfs writer executable
+writer_bin: /path/to/binary
+
+[API]
+host = api.foo
+tenants = TA,TB,TC
+TA_key = key1
+TB_key = key2
+TC_key = key3
+
+
 [LOGS]
-# log handlers to support 
+# log handlers to support
 log_modes: console,syslog,file
 # global log level
 log_level: info
@@ -23,7 +34,7 @@ syslog_level: critical
 file_level: warning
 # specific level for console handler
 console_level: info
-# socket for syslog handler 
+# socket for syslog handler
 syslog_socket: /dev/log
 # path for file handler
 file_path:
@@ -31,7 +42,7 @@ file_path:
 [FLINK]
 # path for flink executable
 path: flink_path
-# url for flink job manager 
+# url for flink job manager
 job_manager:
 
 [JOB-NAMESPACE]
@@ -43,7 +54,7 @@ ingest-sync-namespace: Ingesting sync data from {{ams_endpoint}}:{{ams_port}}/v1
 stream-status-namespace: Streaming status using data {{ams_endpoint}}:{{ams_port}}/v1/projects/{{project}}/subscriptions/[{{ams_sub_metric}}, {{ams_sub_sync}}]
 
 [CLASSES]
-# Specify class to run during job submit 
+# Specify class to run during job submit
 ams-ingest-metric: test_class
 ams-ingest-sync: test_class
 batch-ar: test_class
@@ -51,7 +62,7 @@ batch-status: test_class
 stream-status: test_class
 
 [JARS]
-# Specify jar to run during job submit 
+# Specify jar to run during job submit
 ams-ingest-metric: test.jar
 ams-ingest-sync: test.jar
 batch-ar: test.jar
@@ -60,7 +71,7 @@ stream-status: test.jar
 
 
 [AMS]
-# AMS service port 
+# AMS service port
 ams_port: test_port
 # Ams service endpoint
 ams_endpoint: test_endpoint

--- a/docs/update_profiles.md
+++ b/docs/update_profiles.md
@@ -1,0 +1,78 @@
+# Python script for updating profiles (argo-web-api --> hdfs)
+
+Argo-streaming engine maintains profile files stored in flink shared storage per tenant and report.
+These profiles are essential for computing a/r and status results during flink-jobs and are not provided
+automatically by connectors. Profiles include:
+- operations_profile: `TENANT_ops.json` which includes truth tables about the fundamental aggregation operations applied
+  on monitor status timelines (such as 'AND', 'OR' .etc between statuses of 'OK', 'WARNING', 'CRITICAL', 'MISSING' etc.)
+
+Each report uses an operation profile. The operation profile is defined also in argo-web-api instance at the following url
+`GET https://argo-web-api.host.example/api/v2/operations_profiles/{{profile_uuid}}`
+
+Providing a specific `tenant` and a specific `report`, script `update_profiles` checks corresponding hdfs ops profile against
+latest ops profile provided by argo-web-api. If they don't match it uploads the latest argo-web-api ops definition in hdfs
+
+# Submission scripts automatic invoke
+Script logic is programmatically called in a/r and status job submission scripts
+
+# Invoke manually from command line
+Script logic can be invoked from command line by issuing
+`$ ./update_profiles -t TENANT -r REPORT`
+
+help on command line arguments given by issuing
+`$ ./update_profiles -h`
+
+```
+usage: update_profiles.py [-h] -t STRING -r STRING [-c STRING]
+
+update profiles for specific tenant/report
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -t STRING, --tenant STRING
+                        tenant owner
+  -r STRING, --report STRING
+                        report
+  -c STRING, --config STRING
+                        config
+```
+
+# Config file parameters used
+Update_profiles script will search for the main argo-streaming.conf file but uses only the following
+configuration parameters:
+
+```
+[HDFS]
+# hdfs namenode hostname
+hdfs_host : hostname
+# hdfs namenode port
+hdfs_port : portnumber
+# hdfs username used
+hdfs_user : user
+# path template to default argo hdfs base sync folder
+hdfs_sync : hdfs/path/to/argo/{{tenant}}/sync/folder
+# path to local binary that allows hdfs upload (hdfs client)
+writer_bin: local/path/to/binary
+
+[API]
+# endpoint of argo-web-api used
+host : argo-web-api.host.example.foo
+
+# Tenant list supported on argo-web-api (might retrieved automatically later)
+tenants : TENANT_A, TENANT_B
+
+# for each of the above tenants specify it's api_token by using the pattern {{TENANT}}_key : {{value}}
+TENANT_A_key = secret1
+TENANT_B_key = secret2
+
+[LOGS]
+# get log level
+log_level: info
+```
+
+# Dependencies
+Update_profiles script is deployed alongside the other scripts included in the `./bin/` folder of argo-streaming engine
+and relies on the same dependencies. Specifically it uses `requests` lib for contacting argo-web-api and python `snakebite` lib
+for checking hdfs files. Because `snakebite` lib lacks upload mechanism the script relies on a binary client wrapper to upload
+files (maybe a shell script over java-based hdfs-client or other implementations). The wrapper script must be invoked with the following
+argument pattern `./hdfs_writer.sh put {local_path} {hdfs_path}`


### PR DESCRIPTION
Implement script to check argo profile files stored in hdfs destination against argo profiles defined in argo-web-api. If hdfs ones are out-of-date upload latest argo-web-api profile definitions to hdfs
- Implement update_profiles.py script
 - Implement ArgoApiClient class which contacts argo-web-api
 - Implement HdfsReader class which checks files on hdfs 
 - Implement ArgoProfileManager class which uses the above classes and compares the profiles between api <--> hdfs 
- Add unit tests
- Add doc