### PR TITLE
ARGO-1233 Fetch latest report cfg from argo-web-api

### DIFF
--- a/bin/utils/test_update_profiles.py
+++ b/bin/utils/test_update_profiles.py
@@ -61,7 +61,7 @@ class TestClass(unittest.TestCase):
              "expected": "https://foo.host/api/v2/aggregation_profiles"},
             {"resource": "aggregations", "item_uuid": "12",
              "expected": "https://foo.host/api/v2/aggregation_profiles/12"}
-        ]
+            ]
 
         for test_case in test_cases:
             actual = argo_api.get_url(test_case["resource"], test_case["item_uuid"])

--- a/bin/utils/update_profiles.py
+++ b/bin/utils/update_profiles.py
@@ -278,6 +278,7 @@ class ArgoProfileManager:
         Args:
             tenant: str. Tenant name to check profiles from
             report: str. Report name to check profiles from
+            profile_type: str. Name of the profile type used (operations|aggregations|reports)
         """
 
         prof_api = self.api.get_profile(tenant, report, profile_type)
@@ -440,8 +441,8 @@ def run_profile_update(args):
     # Set a new profile manager to be used
     argo = ArgoProfileManager(args.config)
 
-    # check for the following profile types -- now just operations
-    profile_type_checklist = ["operations", "aggregations"]
+    # check for the following profile types
+    profile_type_checklist = ["operations", "aggregations", "reports"]
     for profile_type in profile_type_checklist:
         argo.profile_update_check(args.tenant, args.report, profile_type)
 

--- a/docs/update_profiles.md
+++ b/docs/update_profiles.md
@@ -5,14 +5,19 @@ These profiles are essential for computing a/r and status results during flink-j
 automatically by connectors. Profiles include:
 - operations_profile: `TENANT_ops.json` which includes truth tables about the fundamental aggregation operations applied
   on monitor status timelines (such as 'AND', 'OR' .etc between statuses of 'OK', 'WARNING', 'CRITICAL', 'MISSING' etc.)
-- aggergations_profile: `TENANT_REPORT_aps.json` which includes information on what operations ('AND','OR') and how are 
+- aggregation_profile: `TENANT_REPORT_aps.json` which includes information on what operations ('AND','OR') and how are
   applied on different service levels
+- report configuration profile: `TENANT_REPORT_cfg.json` which includes information on the report it self, what profiles
+it uses and how filters data
 
 Each report uses an operations profile. The operation profile is defined also in argo-web-api instance at the following url
 `GET https://argo-web-api.host.example/api/v2/operations_profiles/{{profile_uuid}}`
 
 Each report uses an aggregation profile. The aggregation profile is defined also in argo-web-api instance at the following url
 `GET https://argo-web-api.host.example/api/v2/aggregation_profiles/{{profile_uuid}}`
+
+Each report contains a configuration profile. The report is defined also in argo-web-api instance at the following url
+`GET https://argo-web-api.host.example/api/v2/reports/{{report_uuid}}`
 
 
 Providing a specific `tenant` and a specific `report`, script `update_profiles` checks corresponding profiles on hdfs  against


### PR DESCRIPTION
Fetch the latest report configuration from argo-web-api and compare it against the report cfg file at hdfs. If the report file at hdfs is out-of-date replace it with.