### PR TITLE
ARGO-1277 Check and update thresholds profiles from argo-web-api

### DIFF
--- a/bin/ar_job_submit.py
+++ b/bin/ar_job_submit.py
@@ -176,7 +176,7 @@ def main(args=None):
     # optional call to update profiles
     if args.profile_check:
         profile_mgr = ArgoProfileManager(args.ConfigPath)
-        profile_type_checklist = ["operations", "aggregations", "reports"]
+        profile_type_checklist = ["operations", "aggregations", "reports", "thresholds"]
         for profile_type in profile_type_checklist:
             profile_mgr.profile_update_check(args.Tenant, args.Report, profile_type)
 

--- a/bin/status_job_submit.py
+++ b/bin/status_job_submit.py
@@ -171,7 +171,7 @@ def main(args=None):
     # optional call to update profiles
     if args.profile_check:
         profile_mgr = ArgoProfileManager(args.ConfigPath)
-        profile_type_checklist = ["operations", "aggregations", "reports"]
+        profile_type_checklist = ["operations", "aggregations", "reports", "thresholds"]
         for profile_type in profile_type_checklist:
             profile_mgr.profile_update_check(args.Tenant, args.Report, profile_type)
 

--- a/docs/update_profiles.md
+++ b/docs/update_profiles.md
@@ -9,6 +9,8 @@ automatically by connectors. Profiles include:
   applied on different service levels
 - report configuration profile: `TENANT_REPORT_cfg.json` which includes information on the report it self, what profiles
 it uses and how filters data
+- threhsolds_profile (optional): `TENANT_REPORT_thresholds.json` which includes thresholds rules to be applied during computation
+
 
 Each report uses an operations profile. The operation profile is defined also in argo-web-api instance at the following url
 `GET https://argo-web-api.host.example/api/v2/operations_profiles/{{profile_uuid}}`
@@ -16,8 +18,12 @@ Each report uses an operations profile. The operation profile is defined also in
 Each report uses an aggregation profile. The aggregation profile is defined also in argo-web-api instance at the following url
 `GET https://argo-web-api.host.example/api/v2/aggregation_profiles/{{profile_uuid}}`
 
+Each report optionally contains a thresholds profile. The thresholds profile is defined also in argo-web-api instance at the following url
+`GET https://argo-web-api.host.example/api/v2/thresholds_profiles/{{profile_uuid}}`
+
 Each report contains a configuration profile. The report is defined also in argo-web-api instance at the following url
 `GET https://argo-web-api.host.example/api/v2/reports/{{report_uuid}}`
+
 
 
 Providing a specific `tenant` and a specific `report`, script `update_profiles` checks corresponding profiles on hdfs  against


### PR DESCRIPTION
# Task
Check and update local threhsolds profiles from argo-web-api definitions

# Implementation
- [x] Add new profile type for checking: thresholds
- [x] Skip profile update if profile type is not used in report (for optional profile types such as thresholds)
- [x] Refactor batch jobs to check also for thresholds profile updates
- [x] Update docs
