### PR TITLE
ARGO-1286 Parse and separate manual and automatic sections of argo-st…

### DIFF
--- a/bin/utils/test_update_config.py
+++ b/bin/utils/test_update_config.py
@@ -1,0 +1,32 @@
+import unittest
+import os
+from urlparse import urlparse
+from update_config import ArgoConfig
+from update_config import Template
+import json
+
+
+CONF_FILE = os.path.join(os.path.dirname(__file__), '../../conf/argo-streaming.conf')
+SCHEMA_FILE = os.path.join(os.path.dirname(__file__), '../../conf/config.schema.json')
+
+class TestClass(unittest.TestCase):
+
+    def test_config(self):
+        argo_conf = ArgoConfig()
+        argo_conf.load_conf(CONF_FILE)
+        argo_conf.load_schema(SCHEMA_FILE)
+        argo_conf.check_conf()
+
+        # get fixed HDFS -> user param (string)
+        self.assertEqual("foo",argo_conf.get("HDFS","user"))
+        # get var TENANTS:TENANT_A -> reports param (list of strings)
+        self.assertEqual(["report1","report2"],argo_conf.get("TENANTS:TENANT_A","reports"))
+        # get var TENANTS:TENANT_B -> mongo_uri (url)
+        self.assertEqual(urlparse("mongodb://localhost:21017/tenant_db"),argo_conf.get("TENANTS:TENANT_B","mongo_uri"))
+       
+        # get var HDFS -> path_metric (template) and fill it with specific arguments
+        exp_result = "hdfs://localhost:2000/user/foobar/argo/tenants/wolf/mdata"
+        self.assertEqual(exp_result,argo_conf.get("HDFS","path_metric").fill(namenode="localhost:2000",user="foobar",tenant="wolf"))
+        # fill template with different user argument
+        self.assertNotEqual(exp_result,argo_conf.get("HDFS","path_metric").fill(namenode="localhost:2000",user="foobar2",tenant="wolf"))
+        

--- a/bin/utils/update_config.py
+++ b/bin/utils/update_config.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python
+from ConfigParser import SafeConfigParser
+from urlparse import urlparse
+import json
+import re
+from os import path
+
+
+class Template:
+    """
+    Implements option parameters that are templates
+    """
+
+    def __init__(self, tmpl, sub_type):
+        self.tmpl = tmpl
+        self.sub_type = sub_type
+
+    def __repr__(self):
+        """
+        String representation of template object
+        """
+        return self.tmpl
+
+    def get_args(self):
+
+        """
+        Get arguments used in template
+
+        Returns:
+            list: a list of arguments used in the tamplate
+        """
+        return re.findall(r"{{\s*(.*?)\s*}}", self.tmpl)
+
+    def fill(self, **args_new):
+        """
+         Fill template with argument values and get result
+
+         Args:
+             args_new = list of argument key,value pairs fill the template
+         Returns:
+             obj: Fills template and returns an appropriate object based on template type
+         """
+        txt = self.tmpl  # type: str
+        args = self.get_args()
+        if sorted(args) != sorted(args_new.keys()):
+            raise RuntimeError("Argument mismatch, needed arguments:"+str(args))
+        for arg in args:
+            txt = re.sub(r"{{\s*"+str(arg)+r"\s*}}", str(args_new[arg]), txt)
+
+        return self.get_as(txt)
+
+    def get_as(self, text):
+        """
+        Get template result as a string and convert it to an appropriate return type
+
+        Args:
+            text: str. template result
+        Returns:
+            obj: template result in appropriate type
+        """
+        if self.sub_type == "string":
+            return str(text)
+        elif self.sub_type == "int" or self.sub_type == "long":
+            return int(text)
+        elif self.sub_type == "float":
+            return float(text)
+        elif self.sub_type == "uri":
+            return urlparse(text)
+        elif self.sub_type == "list":
+            return text.split(",")
+        elif self.sub_type == "path":
+            return path.normpath(text)
+
+
+class ArgoConfig:
+    """
+    ArgoConfig implements a class that parser argo fixed and dynamic configuration
+    based on a specific schema
+    """
+
+    def __init__(self):
+        self.conf = SafeConfigParser()
+        self.schema = dict()
+        self.fix = dict()
+        self.var = dict()
+
+    def get(self, group, item):
+        """
+        Given a group and an item return its value
+
+        Args:
+            group: str. group name
+            item: str. item name
+        Returns:
+            obj: an object containing the value
+        """
+
+        if group in self.fix:
+            if item in self.fix[group]:
+                return self.fix[group][item]["value"]
+        if group in self.var:
+            if item in self.var[group]:
+                return self.var[group][item]["value"]
+        return None
+
+    def load_conf(self, conf_path):
+        """
+        Load configuration from file using a SafeConfigParser
+        """
+        self.conf.read(conf_path)
+
+    def load_schema(self, schema_path):
+        """
+        Load configuration schema (JSON format) from file
+        """
+        with open(schema_path, 'r') as schema_file:
+            self.schema = json.load(schema_file)
+
+    def get_as(self, group, item, item_type, og_item):
+        """
+        Return appropriate value dict object
+
+        Args:
+            group: str. group name
+            item: str. item name
+            item_type: str. type of the item
+            og_item: str. optional reference to original item in schema
+
+
+        Returns:
+            dict: result dictionary with value and optional reference to original item in schema
+        """
+        result = None
+        if item_type == "string":
+            result = self.conf.get(group, item)
+        elif item_type == "int" or item_type == "long":
+            result = self.conf.getint(group, item)
+        elif item_type == "float":
+            result = self.conf.getfloat(group, item)
+        elif item_type == "uri":
+            result = urlparse(self.conf.get(group, item))
+        elif item_type == "list":
+            result = self.conf.get(group, item).split(",")
+        elif item_type == "path":
+            result = path.normpath(self.conf.get(group, item))
+        elif item_type.startswith("template"):
+            tok = item_type.split(",")
+            if len(tok) > 1:
+                sub_type = tok[1]
+            else:
+                sub_type = "string"
+            result = Template(self.conf.get(group, item), sub_type)
+
+        pack = dict()
+        pack["value"] = result
+
+        if og_item != item:
+            pack["og_item"] = og_item
+
+        return pack
+
+    def add_config_item(self, group, item, og_item, dest, og_group):
+        """
+        Add new item to the ArgoConfig params
+
+        Args:
+            group: str. group name
+            item: str. item name
+            og_item: str. reference to original item in schema
+            dest: dict. where to add the item (in the fixed or varied item dictionary)
+            og_group: str. reference to original group in schema
+        """
+
+        if group not in dest:
+            dest[group] = dict()
+            if og_group is not None:
+                dest[group]["og_group"] = og_group
+        if og_group is not None:
+            dest[group][item] = self.get_as(group,  item, self.schema[og_group][og_item]["type"], og_item)
+        else:
+            dest[group][item] = self.get_as(group, item, self.schema[group][og_item]["type"], og_item)
+
+    def add_group_items(self, group, items, var, og_group):
+        """
+        Add a list of items to a group. If var=true the items are treated as
+        varied items.
+
+        Args:
+            group: str. group name
+            items: list(str). list of item names
+            var: bool. if the items are considered varied
+            og_group: str. reference to original group in schema
+        """
+        if var:
+            dest = self.var
+        else:
+            dest = self.fix
+
+        for item in items:
+            if type(item) is not dict:
+                self.add_config_item(group, item, item, dest, og_group)
+            else:
+                for sub_item in item["vars"]:
+                    self.add_config_item(group, sub_item, item["item"], dest, og_group)
+
+    @staticmethod
+    def is_var(name):
+        """
+        If a name is considered to represent a varied object"
+
+        Returns:
+            bool. is considered varied or not
+        """
+        if "~" in name:
+            return True
+
+        return False
+
+    def get_item_variations(self, group, item, ogroup):
+        """
+        Search schema for the field that provides the variations
+        and create a list of the expected varied items
+
+        Returns:
+            list(str). a list with all available item name variations
+        """
+        variations = {'group': group, 'item': item, 'vars': list()}
+
+        if ogroup is not None:
+            map_pool = self.schema[ogroup][item]["~"]
+        else:
+            map_pool = self.schema[group][item]["~"]
+        if '.' in map_pool:
+            map_pool = map_pool.split(".")
+        else:
+            tmp_item = map_pool
+            map_pool = list()
+            map_pool.append(group)
+            map_pool.append(tmp_item)
+
+        name_pool = self.conf.get(map_pool[0], map_pool[1]).split(",")
+
+        for name in name_pool:
+            variations["vars"].append(item.replace("~", name))
+        return variations
+
+    def get_group_variations(self, group):
+        """
+        Search schema for the field that provides the variations
+        and create a list of the expected varied groups
+
+        Returns:
+            list(str). a list with all available group name variations
+        """
+        variations = {'group': group, 'vars': list()}
+
+        map_pool = self.schema[group]["~"]
+        if '.' in map_pool:
+            map_pool = map_pool.split(".")
+        else:
+            item = map_pool
+            map_pool = list()
+            map_pool.append(group)
+            map_pool.append(item)
+
+        name_pool = self.conf.get(map_pool[0], map_pool[1]).split(",")
+        for name in name_pool:
+            variations["vars"].append(group.replace("~", name))
+        return variations
+
+    def check_conf(self):
+
+        """
+        Validate schema and configuration file. Iterate and extract
+        all configuration parameters
+        """
+        fix_groups = self.schema.keys()
+        var_groups = list()
+
+        for group in fix_groups:
+            if self.is_var(group):
+                var_groups.append(self.get_group_variations(group))
+                continue
+
+            fix_items = list()
+            var_items = list()
+            for item in self.schema[group].keys():
+                if self.is_var(item):
+                    var_items.append(self.get_item_variations(group, item, None))
+                    continue
+                fix_items.append(item)
+            self.add_group_items(group, fix_items, False, None)
+            self.add_group_items(group, var_items, True, None)
+
+        for group in var_groups:
+            for sub_group in group["vars"]:
+                fix_items = list()
+                var_items = list()
+                for item in self.schema[group["group"]].keys():
+
+                    if item == "~":
+                        continue
+
+                    if self.is_var(item):
+                        var_items.append(self.get_item_variations(sub_group, item, group["group"]))
+                        continue
+                    fix_items.append(item)
+                # Both fix and var items are in a var group so are considered var
+                self.add_group_items(sub_group, fix_items, True, group["group"])
+                self.add_group_items(sub_group, var_items, True, group["group"])
+
+
+def main():
+    # Local files
+    conf_fn = "argo-streaming.conf"
+    schema_fn = "config.schema.json"
+
+    argo_conf = ArgoConfig()
+    argo_conf.load_conf(conf_fn)
+    argo_conf.load_schema(schema_fn)
+    argo_conf.check_conf()
+
+    print "Fixed parameters:"
+    print json.dumps(argo_conf.fix, default=str, indent=2)
+    print "Variable parameters:"
+    print json.dumps(argo_conf.var, default=str, indent=2)
+
+
+if __name__ == '__main__':
+    main()

--- a/conf/argo-streaming.conf
+++ b/conf/argo-streaming.conf
@@ -1,0 +1,106 @@
+[HDFS]
+namenode= localhost:8020
+user= foo
+rollback_days= 3
+path_metric= hdfs://{{namenode}}/user/{{user}}/argo/tenants/{{tenant}}/mdata
+path_sync= hdfs://{{namenode}}:{{user}}/user/{{hdfs_user}}/argo/tenants/{{tenant}}/sync
+writer_bin= /home/root/hdfs
+
+[API]
+host=api_host
+tenants=TENANT_A,TENANT_B
+TENANT_A_key=key1
+TENANT_B_key=key2
+
+[FLINK]
+
+path= /path/to/flink
+job_manager= http://localhost:8081
+
+[JOB-NAMESPACE]
+ingest-metric-namespace= Ingesting  metric data from {{ams_endpoint}}:{{ams_port}}/v1/projects/{{project}}/subscriptions/{{ams_sub}}
+ingest-sync-namespace= Ingesting sync data from {{ams_endpoint}}:{{ams_port}}/v1/projects/{{project}}/subscriptions/{{ams_sub}}
+stream-status-namespace= Streaming status using data {{ams_endpoint}}:{{ams_port}}/v1/projects/{{project}}/subscriptions/[{{ams_sub_metric}}, {{ams_sub_sync}}]
+
+[CLASSES]
+ams-ingest-metric= argo.streaming.AmsIngestMetric
+ams-ingest-sync= argo.streaming.AmsIngestSync
+batch-ar= argo.batch.ArgoArBatch
+batch-status= argo.batch.ArgoStatusBatch
+stream-status= argo.streaming.AmsStreamStatus
+
+[JARS]
+ams-ingest-metric= /path/to/ams-ingest-metric-close.jar 
+ams-ingest-sync= /path/to/ams-ingest-sync-0.1.jar
+batch-ar= /path/to/ArgoArBatch-1.0.jar
+batch-status= /path/to/ArgoStatusBatch-1.0.jar
+stream-status= /path/to/streaming-status-multi2.jar
+
+[AMS]
+ams_endpoint= localhost:8080
+
+[TENANTS:TENANT_A]
+ams_project= TENANT_A
+ams_token= key_1
+mongo_uri= mongodb://localhost:27017/tenant_db
+
+reports= report1,report2
+report_report1= uuid1 
+report_report2= uuid2
+
+[TENANTS:TENANT_A:ingest-metric]
+ams_sub= ingest_metrict
+ams_interval= 300
+ams_batch= 100
+checkpoint_path= hdfs://localhost:8020/user/foo/check
+checkpoint_interval= 30000
+
+[TENANTS:TENANT_A:ingest-sync]
+ams_sub= ingest_sync
+ams_interval= 300
+ams_batch= 100
+checkpoint_path= hdfs://localhost:8020/user/foo/checkt
+checkpoint_interval= 30000
+
+[TENANTS:TENANT_A:stream-status]
+ams_batch= 100
+ams_interval= 100
+ams_sub_metric= status_metric
+ams_sub_sync= status_sync
+kafka_servers= localhost:9092
+kafka_topic= topic.tenant_a
+flink_parallelism= 1
+outputs= kafka
+
+[TENANTS:TENANT_B]
+ams_project= TENANT_B
+ams_token= key_1
+mongo_uri= mongodb://localhost:21017/tenant_db
+
+reports= report1,report2
+report_report1= uuid1 
+report_report2= uuid2
+
+[TENANTS:TENANT_B:ingest-metric]
+ams_sub= ingest_metrict
+ams_interval= 300
+ams_batch= 100
+checkpoint_path= hdfs://localhost:8020/user/foo/check
+checkpoint_interval= 30000
+
+[TENANTS:TENANT_B:ingest-sync]
+ams_sub= ingest_sync
+ams_interval= 300
+ams_batch= 100
+checkpoint_path= hdfs://localhost:8020/user/foo/checkt
+checkpoint_interval= 30000
+
+[TENANTS:TENANT_B:stream-status]
+ams_batch= 100
+ams_interval= 100
+ams_sub_metric= status_metric
+ams_sub_sync= status_sync
+kafka_servers= localhost:9092
+kafka_topic= topic.tenant_a
+flink_parallelism= 1
+outputs= kafka

--- a/conf/config.schema.json
+++ b/conf/config.schema.json
@@ -1,0 +1,211 @@
+{
+    "HDFS": {
+      "namenode": {
+        "desc": "endpoint host of namenode",
+        "type": "uri"
+      },
+      "path_metric": {
+        "desc": "template for constructing the hdfs path to tenants metric data location",
+        "type": "template"
+      },
+      "path_sync": {
+        "desc": "template for constructing the hdfs path to tenants sync data location",
+        "type": "template"
+      },
+      "user": {
+        "desc": "name of the hdfs user",
+        "type": "string"
+      },
+      "rollback_days": {
+        "desc": "how many days to roll back if a sync file is missing",
+        "type": "int"
+      },
+      "writer_bin": {
+        "desc": "path to hdfs binary used for uploading files in hdfs",
+        "type": "path"
+      }
+    },
+    "API": {
+      "host": {
+        "desc": "argo-web-api endpoint",
+        "type": "uri"
+      },
+      "tenants": {
+        "desc": "list of tenants",
+        "type": "list"
+      },
+      "~_key": {
+        "~": "tenants",
+        "desc": "tenants key",
+        "type": "string"
+      }
+    },
+    "FLINK": {
+      "path": {
+        "desc": "path to flink executable",
+        "type": "path"
+      },
+      "job_manager": {
+        "desc": "url of flink's job manager",
+        "type": "uri"
+      }
+    },
+    "JOB-NAMESPACE": {
+      "ingest-metric-namespace": {
+        "desc": "template for naming ingest metric jobs in flink",
+        "type": "template"
+      },
+      "ingest-sync-namespace": {
+        "desc": "template for naming ingest sync jobs in flink",
+        "type": "template"
+      },
+      "stream-status-namespace": {
+        "desc": "template for naming stream status jobs in flink",
+        "type": "template"
+      }
+    },
+    "CLASSES": {
+      "ams-ingest-metric": {
+        "desc": "class name for entry point in ingest metric flink job jar",
+        "type": "string"
+      },
+      "ams-ingest-sync": {
+        "desc": "class name for entry point in ingest sync flink job jar",
+        "type": "string"
+      },
+      "batch-ar": {
+        "desc": "class name for entry point in batch ar flink job jar",
+        "type": "string"
+      },
+      "batch-status": {
+        "desc": "class name for entry point in batch status flink job jar",
+        "type": "string"
+      },
+      "stream-status": {
+        "desc": "class name for entry point in stream status flink job jar",
+        "type": "string"
+      }
+    },
+    "JARS": {
+      "ams-ingest-metric": {
+        "desc": "class name for entry point in ingest metric flink job jar",
+        "type": "path"
+      },
+      "ams-ingest-sync": {
+        "desc": "class name for entry point in ingest sync flink job jar",
+        "type": "path"
+      },
+      "batch-ar": {
+        "desc": "class name for entry point in batch ar flink job jar",
+        "type": "path"
+      },
+      "batch-status": {
+        "desc": "class name for entry point in batch status flink job jar",
+        "type": "path"
+      },
+      "stream-status": {
+        "desc": "class name for entry point in stream status flink job jar",
+        "type": "path"
+      }
+    },
+
+    "TENANTS:~":{
+      "~":"API.tenants",
+      "reports":{
+        "desc": "available reports for tenant",
+        "type": "list"
+      },
+      "report_~": {
+        "desc": "reports uuid",
+        "type": "string",
+        "~": "reports" 
+      },
+      "ams_project": {
+        "desc": "ams project used for this tenant",
+        "type": "string" 
+      },
+      "ams_token": {
+        "desc": "ams token used for this tenant",
+        "type": "string" 
+      },
+      "mongo_uri": {
+        "desc": "mongo uri including host port and database",
+        "type": "uri" 
+      }
+    },
+    "TENANTS:~:ingest-metric":{
+      "~":"API.tenants",
+      "ams_sub":{
+        "desc": "subscription for ingesting metric data",
+        "type": "string"
+      },
+      "ams_interval":{
+        "desc": "interval for polling ams for metric data",
+        "type": "long"
+      },
+      "ams_batch":{
+        "desc": "number of messages to retrieve at once from ams",
+        "type": "long"
+      },
+      "checkpoint_path": {
+        "desc": "hdfs checkpoint path",
+        "type": "template" 
+      },
+      "checkpoint_interval": {
+        "desc": "interval between hdfs checkpoints",
+        "type": "long" 
+      }
+    },
+    "TENANTS:~:ingest-sync":{
+      "~":"API.tenants",
+      "ams_sub":{
+        "desc": "subscription for ingesting sync data",
+        "type": "string"
+      },
+      "ams_interval":{
+        "desc": "interval for polling ams for sync data",
+        "type": "long"
+      },
+      "ams_batch":{
+        "desc": "number of messages to retrieve at once from ams",
+        "type": "long"
+      }
+    },
+    "TENANTS:~:stream-status":{
+      "~":"API.tenants",
+      "ams_sub_metric":{
+        "desc": "subscription for ingesting metric data",
+        "type": "string"
+      },
+      "ams_sub_sync":{
+        "desc": "subscription for ingesting sync data",
+        "type": "string"
+      },
+      "ams_interval":{
+        "desc": "interval for polling ams for sync data",
+        "type": "long"
+      },
+      "ams_batch":{
+        "desc": "number of messages to retrieve at once from ams",
+        "type": "long"
+      },
+      "kafka_servers":{
+        "desc": "list of kafka servers to send messages to",
+        "type": "list"
+      },
+      "kafka_topic":{
+        "desc": "kafka topic to directly write to",
+        "type": "string"
+      },
+      "flink_parallelism":{
+        "desc": "number of parallelism to be used in flink",
+        "type": "int"
+      },
+      "outputs":{
+        "desc": "where to output",
+        "type": "list"
+      }
+      
+    }
+    
+}


### PR DESCRIPTION
# Task
Handle central argo-streaming.conf with the ability to update specific sections (var) 

# Explanation
argo-streaming conf is an extensible ini config file (new tenants are added as new sections) and consists of:
 - a fixed section part that is configurable during initial deployment 
 - an extensible part that contains new tenants, reports etc.

# Implementation
Implement an ArgoConfig class that uses a SafeConfigParser to parse the ini file along with a JSON config schema that defines what parameters to expect and which parts of the configuration file are extensible (var)

Example of config.schema.json 
```json
 { "API": 
    {
      "reports" : { "type" : "list,string" , "desc": "list of reports" },
       "~_uuid" :  { "type" : "string", "desc": "report uuid", "~": "reports" }
     }
  }
```
The above describes an ini file that has an `[API]` section that includes a fixed "reports" item with a list of strings and an extensible part with items in the repeated form `~_uuid`. The `~` specifies an iteratable item and also plays the role of wildcard in this item's name. The `~` part will be replaced by the "reports" list values and thus new additional item will be defined.
   For eg:
  >   if `reports`: `rep01,rep02,rep03` 
  > the ArgoConfig will expect to find 3 additional items with names:
  > `rep01_uuid`, `rep02_uuid`, `rep03_uuid` etc.

- ArgoConfig returns the value in the type that is specified by onfiguration schema (string, int, float, list, template, uri, path)
- If the type is specified as  template, ArgoConfig will return a special Template object that can be filled with arguments.
For eg.
> If `metric_path` is defined as `{"type": "template,string"}` in configuration schema and has the value of 
`{{name}} is a person from {{country}}` the ArgoConfig will return a template object `tmpl` which can be filled using the arguments `tmpl.fill(name="Joe", country="Neverland")`. After the template is filled, the result is returned in the subtype speficied (template,`string`).
### Quick how ArgoConfig is used
```python
argo_conf = ArgoConfig()
argo_conf.load_conf("path/to/config")
argo_conf.load_schema("path/to/schema")
argo_conf.check_conf() # parses configuration and validates all params against schema. Separates fixed params from extensible params
argo_conf.get("HDFS","user") # <-- get fixed param user from section HDFS as a string (type expected from schema)
```
### Note: Changes in config parameters
Some changes / simplifications have been made in argo-streaming conf parameter names. Those will be reflected in the other scripts in following PRs

### Implementation steps
 - [x] Implement Template class
 - [x] Implement ArgoConfig class 
 - [x] Add config schema 
 - [x] Add test files