### PR TITLE
ARGO-1287 Update tenant list from argo-web-api

### DIFF
--- a/bin/stream_status_job_submit.py
+++ b/bin/stream_status_job_submit.py
@@ -52,19 +52,15 @@ def compose_command(config, args,  hdfs_commands):
     if args.sudo is True:
         cmd_command.append("sudo")
 
-    tenant = args.tenant
-
     # get needed config params
     section_tenant = "TENANTS:" + args.tenant
     section_tenant_job = "TENANTS:" + args.tenant + ":stream-status"
     job_namespace = config.get("JOB-NAMESPACE", "stream-status-namespace")
     ams_endpoint = config.get("AMS", "endpoint")
 
-
     ams_project = config.get(section_tenant, "ams_project")
     ams_sub_metric = config.get(section_tenant_job, "ams_sub_metric")
     ams_sub_sync = config.get(section_tenant_job, "ams_sub_sync")
-
 
     # flink executable
     cmd_command.append(config.get("FLINK", "path"))
@@ -162,7 +158,7 @@ def compose_command(config, args,  hdfs_commands):
                 # kafka list of servers
                 if config.has(section_tenant_job, "kafka_servers"):
                     cmd_command.append("--kafka.servers")
-                    kafka_servers = ','.join(config.get(section_tenant_job,"kafka_servers"))
+                    kafka_servers = ','.join(config.get(section_tenant_job, "kafka_servers"))
                     cmd_command.append(kafka_servers)
                 # kafka topic to send status events to
                 if config.has(section_tenant_job, "kafka_topic"):

--- a/bin/utils/argo_config.py
+++ b/bin/utils/argo_config.py
@@ -64,6 +64,8 @@ class Template:
         args = self.get_args()
 
         for arg in args:
+            if arg not in args_new.keys():
+                continue
             txt = re.sub(r"{{\s*" + str(arg) + r"\s*}}", str(args_new[arg]), txt)
 
         return txt
@@ -113,6 +115,9 @@ class ArgoConfig:
         if item is None:
             return self.conf.has_section(group)
         return self.conf.has_option(group, item)
+
+    def set(self, group, item, value):
+        self.conf.set(group, item, value)
 
     def get(self, group, item=None):
         """
@@ -172,6 +177,11 @@ class ArgoConfig:
         """
         with open(schema_path, 'r') as schema_file:
             self.schema = json.load(schema_file)
+
+    def save_as(self,file_path):
+        with open(file_path, 'w') as file_conf:
+            self.conf.write(file_conf)
+
 
     def get_as(self, group, item, item_type, og_item):
         """

--- a/bin/utils/test_update_profiles.py
+++ b/bin/utils/test_update_profiles.py
@@ -1,5 +1,4 @@
 import unittest
-import os
 from update_profiles import HdfsReader
 from update_profiles import ArgoApiClient
 
@@ -57,7 +56,11 @@ class TestClass(unittest.TestCase):
             {"resource": "aggregations", "item_uuid": None,
              "expected": "https://foo.host/api/v2/aggregation_profiles"},
             {"resource": "aggregations", "item_uuid": "12",
-             "expected": "https://foo.host/api/v2/aggregation_profiles/12"}
+             "expected": "https://foo.host/api/v2/aggregation_profiles/12"},
+            {"resource": "tenants", "item_uuid": None,
+             "expected": "https://foo.host/api/v2/admin/tenants"},
+            {"resource": "tenants", "item_uuid": "12",
+             "expected": "https://foo.host/api/v2/admin/tenants/12"}
             ]
 
         for test_case in test_cases:

--- a/conf/argo-streaming.conf
+++ b/conf/argo-streaming.conf
@@ -8,6 +8,7 @@ writer_bin= /home/root/hdfs
 
 [API]
 endpoint=https://api_host
+access_token=token01
 tenants=TENANT_A,TENANT_B
 TENANT_A_key=key1
 TENANT_B_key=key2
@@ -37,7 +38,7 @@ batch-status= argo.batch.ArgoStatusBatch
 stream-status= argo.streaming.AmsStreamStatus
 
 [JARS]
-ams-ingest-metric= /path/to/ams-ingest-metric-close.jar 
+ams-ingest-metric= /path/to/ams-ingest-metric-close.jar
 ams-ingest-sync= /path/to/ams-ingest-sync-0.1.jar
 batch-ar= /path/to/ArgoArBatch-1.0.jar
 batch-status= /path/to/ArgoStatusBatch-1.0.jar
@@ -52,7 +53,7 @@ ams_token= key_1
 mongo_uri= mongodb://localhost:27017/tenant_db
 
 reports= report1,report2
-report_report1= uuid1 
+report_report1= uuid1
 report_report2= uuid2
 
 [TENANTS:TENANT_A:ingest-metric]
@@ -85,7 +86,7 @@ ams_token= key_1
 mongo_uri= mongodb://localhost:21017/tenant_db
 
 reports= report1,report2
-report_report1= uuid1 
+report_report1= uuid1
 report_report2= uuid2
 
 [TENANTS:TENANT_B:ingest-metric]

--- a/conf/conf.template
+++ b/conf/conf.template
@@ -16,6 +16,7 @@ writer_bin: /path/to/binary
 [API]
 endpoint = api.foo
 tenants = TENANTA
+access_token = key0
 TENANTA_key = key1
 TENANTB_key = key2
 TENANTC_key = key3

--- a/conf/config.schema.json
+++ b/conf/config.schema.json
@@ -46,6 +46,10 @@
         "desc": "argo-web-api endpoint",
         "type": "uri"
       },
+      "access_token": {
+        "desc": "token for argo-web-api access",
+        "type": "string"
+      },
       "tenants": {
         "desc": "list of tenants",
         "type": "list"


### PR DESCRIPTION
:warning: __Note__: to be merged right after https://github.com/ARGOeu/argo-streaming/pull/81

# Task
Configuration manager in argo engine should be able to contact argo-web-api and retrieve a list of available tenants. The configuration should be updated with the retrieved list of tenants

# Implementation
- [x] Add `get_admin_resource` method to ArgoProfileManager to retrieve admin resources from argo-web-api (such as tenant information)
- [x] Add `get_tenants` method to ArgoProfileManager to retrieve tenant list
- [x] Add `set` method to ArgoConfig to be able to update configuration parameters with new values
- [x] Add `save_as` method to ArgoConfig to be able to write updated configuration back at ini file
- [x] update unit tests
- [x] When update_profile.py runs as cli script has two modes: update profiles for specific tenant/report or update list of tenants.