### PR TITLE
ARGO-1292 Update AMS project from argo-web-api tenant info

### DIFF
--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -1,4 +1,5 @@
 requests==2.18.4
+responses==0.6.0
 pytest==3.4.0
 snakebite==2.11.0
 pymongo==3.6.1

--- a/bin/utils/argo_config.py
+++ b/bin/utils/argo_config.py
@@ -3,7 +3,11 @@ from ConfigParser import SafeConfigParser
 from urlparse import urlparse
 import json
 import re
+import logging
 from os import path
+
+
+log = logging.getLogger(__name__)
 
 
 class Template:
@@ -102,6 +106,7 @@ class ArgoConfig:
     """
 
     def __init__(self, config=None, schema=None):
+        self.log_changes = True
         self.conf_path = None
         self.schema_path = None
         self.conf = SafeConfigParser()
@@ -119,7 +124,10 @@ class ArgoConfig:
         return self.conf.has_option(group, item)
 
     def set(self, group, item, value):
+        old_val = self.conf.get(group, item)
         self.conf.set(group, item, value)
+        if self.log_changes:
+            log.info("config option changed [{}]{}={} (from:{})".format(group, item, value, old_val))
 
     def get(self, group, item=None):
         """

--- a/bin/utils/test_update_ams.py
+++ b/bin/utils/test_update_ams.py
@@ -1,0 +1,174 @@
+import unittest
+import responses
+from update_ams import ArgoAmsClient
+
+
+class TestClass(unittest.TestCase):
+
+    def test_urls(self):
+        ams = ArgoAmsClient("foo.host", "secret_key")
+
+        test_cases = [
+            {"resource": "projects", "item_uuid": None, "group_uuid": None, "action": None,
+             "expected": "https://foo.host/v1/projects?key=secret_key"},
+            {"resource": "projects", "item_uuid": "TEST_PROJECT", "group_uuid": None, "action": None,
+             "expected": "https://foo.host/v1/projects/TEST_PROJECT?key=secret_key"},
+            {"resource": "projects", "item_uuid": "TEST_PROJECT2", "group_uuid": None, "action": None,
+             "expected": "https://foo.host/v1/projects/TEST_PROJECT2?key=secret_key"},
+            {"resource": "users", "item_uuid": None, "group_uuid": None, "action": None,
+             "expected": "https://foo.host/v1/users?key=secret_key"},
+            {"resource": "users", "item_uuid": "userA", "group_uuid": None, "action": None,
+             "expected": "https://foo.host/v1/users/userA?key=secret_key"},
+            {"resource": "users", "item_uuid": "userB", "group_uuid": None, "action": None,
+             "expected": "https://foo.host/v1/users/userB?key=secret_key"},
+            {"resource": "topics", "item_uuid": None, "group_uuid": "PROJECT_A", "action": None,
+             "expected": "https://foo.host/v1/projects/PROJECT_A/topics?key=secret_key"},
+            {"resource": "topics", "item_uuid": "topic101", "group_uuid": "PROJECT_A", "action": None,
+             "expected": "https://foo.host/v1/projects/PROJECT_A/topics/topic101?key=secret_key"},
+            {"resource": "topics", "item_uuid": "topic102", "group_uuid": "PROJECT_A", "action": "acl",
+             "expected": "https://foo.host/v1/projects/PROJECT_A/topics/topic102:acl?key=secret_key"},
+            {"resource": "subscriptions", "item_uuid": None, "group_uuid": "PROJECT_A", "action": None,
+             "expected": "https://foo.host/v1/projects/PROJECT_A/subscriptions?key=secret_key"},
+            {"resource": "subscriptions", "item_uuid": "sub101", "group_uuid": "PROJECT_A", "action": None,
+             "expected": "https://foo.host/v1/projects/PROJECT_A/subscriptions/sub101?key=secret_key"},
+            {"resource": "subscriptions", "item_uuid": "sub102", "group_uuid": "PROJECT_A", "action": "acl",
+             "expected": "https://foo.host/v1/projects/PROJECT_A/subscriptions/sub102:acl?key=secret_key"},
+
+        ]
+
+        for test_case in test_cases:
+            actual = ams.get_url(test_case["resource"], test_case["item_uuid"], test_case["group_uuid"],
+                                 test_case["action"])
+            expected = test_case["expected"]
+            self.assertEquals(expected, actual)
+
+    @responses.activate
+    def test_basic_request(self):
+        # prepare fake responses for ams
+
+        responses.add(responses.GET, 'https://ams.foo/v1/projects/PROJECTA?key=faketoken',
+                      json={
+                          "name": "PROJECTA",
+                          "created_on": "2018-03-27T15:56:28Z",
+                          "modified_on": "2018-03-27T15:56:28Z",
+                          "created_by": "foo_user_admin"
+                      }, status=200)
+        responses.add(responses.GET, 'https://ams.foo/v1/users?key=faketoken',
+                      json={"users": [{
+                          "uuid": "id01",
+                          "projects": [
+                              {
+                                  "project": "PROJECTA",
+                                  "roles": [
+                                      "publisher"
+                                  ],
+                                  "topics": [
+                                      "sync_data",
+                                      "metric_data"
+                                  ],
+                                  "subscriptions": []
+                              }
+                          ],
+                          "name": "ams_projectA_publisher",
+
+                      }, {
+                          "uuid": "id02",
+                          "projects": [
+                              {
+                                  "project": "PROJECTA",
+                                  "roles": [
+                                      "consumer"
+                                  ],
+                                  "topics": [
+
+                                  ],
+                                  "subscriptions": ["ingest_sync",
+                                                    "ingest_metric",
+                                                    "status_sync",
+                                                    "status_metric"]
+                              }
+                          ],
+                          "name": "ams_projecta_consumer",
+                      }]
+                      }, status=200)
+        responses.add(responses.GET, 'https://ams.foo/v1/users/ams_projecta_consumer?key=faketoken',
+                      json={
+                          "uuid": "id02",
+                          "projects": [
+                              {
+                                  "project": "PROJECTA",
+                                  "roles": [
+                                      "publisher"
+                                  ],
+                                  "topics": [
+
+                                  ],
+                                  "subscriptions": ["ingest_metric",
+                                                    "status_metric"]
+                              }
+                          ],
+                          "name": "ams_projecta_consumer",
+
+                      }, status=200)
+        responses.add(responses.GET, 'https://ams.foo/v1/users/ams_projecta_publisher?key=faketoken',
+                      json={
+                          "uuid": "id02",
+                          "projects": [
+                              {
+                                  "project": "PROJECTA",
+                                  "roles": [
+                                      "consumer"
+                                  ],
+                                  "topics": ["sync_data",
+                                             "metric_data"
+
+                                             ],
+                                  "subscriptions": []
+                              }
+                          ],
+                          "name": "ams_projecta_consumer",
+
+                      }, status=200)
+
+        responses.add(responses.GET, 'https://ams.foo/v1/projects/PROJECTA/topics?key=faketoken',
+                      json={"topics": [{
+                          "name": "projects/PROJECTA/topics/metric_data"
+                      }]
+                      }, status=200)
+
+        responses.add(responses.GET, 'https://ams.foo/v1/projects/PROJECTA/subscriptions?key=faketoken',
+                      json={"subscriptions": [{
+                          "name": "projects/PROJECTA/subscriptions/ingest_metric",
+                          "topic": "projects/PROJECTA/topic/metric_data"
+                      },
+                          {
+                              "name": "projects/PROJECTA/subscriptions/status_metric",
+                              "topic": "projects/PROJECTA/topic/metric_data"
+                          }
+                      ]
+                      }, status=200)
+        responses.add(responses.GET, 'https://ams.foo/v1/users/ams_projecta_admin?key=faketoken',
+                      json={"error": {"message": "user not found"}
+                            }, status=404)
+
+        ams = ArgoAmsClient("ams.foo", "faketoken")
+
+        self.assertEquals("PROJECTA", ams.get_project("PROJECTA")["name"])
+        users = ams.get_users()
+        self.assertEquals("id01", users[0]["uuid"])
+        self.assertEquals("id02", users[1]["uuid"])
+        user = ams.get_user("ams_projecta_consumer")
+        self.assertEquals("ams_projecta_consumer", user["name"])
+
+        self.assertEquals(["sync_data", "metric_data"], ams.user_get_topics(users[0], "PROJECTA"))
+        self.assertEquals([], ams.user_get_subs(users[0], "PROJECTA"))
+        self.assertEquals([], ams.user_get_topics(users[1], "PROJECTA"))
+        self.assertEquals(["ingest_sync", "ingest_metric", "status_sync", "status_metric"],
+                          ams.user_get_subs(users[1], "PROJECTA"))
+
+        self.assertEquals("PROJECTA", ams.check_project_exists("projectA")["name"])
+        expected_missing = {'topics': ['sync_data'], 'topic_acls': [],
+                            'subs': ['ingest_sync', 'ingest_metric', 'status_sync', 'status_metric'],
+                            'sub_acls': ['ingest_sync'], 'users': ['project_admin']}
+
+        self.assertEquals(expected_missing, ams.check_tenant("projectA"))

--- a/bin/utils/update_ams.py
+++ b/bin/utils/update_ams.py
@@ -1,0 +1,782 @@
+#!/usr/bin/env python
+import requests
+import json
+import logging
+from common import get_config_paths, get_log_conf
+from argo_config import ArgoConfig
+from argparse import ArgumentParser
+import sys
+
+
+log = logging.getLogger(__name__)
+
+
+class ArgoAmsClient:
+    """
+    ArgoAmsClient class
+
+    It connects to an argo-messaging host and retrieves project/user/topic/subscription information
+    """
+
+    def __init__(self, host, admin_key, verify=True):
+        """
+        Initialize ArgoAAmsClient
+        Args:
+            host: str. argo ams host
+            admin_key: str. admin token
+        """
+
+        # flag to verify https connections or not
+        self.verify = verify
+        # ams host
+        self.host = host
+        # admin key to access ams service
+        self.admin_key = admin_key
+
+        # ams api resource paths
+        self.paths = dict()
+        self.paths.update({
+            'projects': '/v1/projects',
+            'users': '/v1/users',
+            'topics': '/v1/projects/{}/topics',
+            'subscriptions': '/v1/projects/{}/subscriptions',
+        })
+
+    def get_url(self, resource, item_id=None, group_id=None, action=None):
+        """
+        Constructs an ams url based on resource, item and group(project)
+        Args:
+            resource:   str. resource to be retrieved (projects/users/topics/susbscriptions)
+            item_id: str. retrieve a specific item from the resource
+            group_id: str. retrieve item from a specific group (grouped resource)
+            action: str. additional actions for some urls (such as acl, modifyAcl etc)
+
+        Returns:
+            str: url path
+
+        """
+        # get resource path
+        resource_path = self.paths[resource]
+        # if grouped resource (like topics or subs that belong under a project)
+        if '{}' in resource_path:
+            # add groups name into the resource path
+            resource_path = resource_path.format(group_id)
+        # if a resource item is not specified get all items
+        if item_id is None:
+            return "".join(["https://", self.host, resource_path, "?key=", self.admin_key])
+        else:
+            # if a specific item is given check if an additional api action is specified on item (like :acl on topics)
+            if action is not None:
+                return "".join(
+                    ["https://", self.host, resource_path, "/", item_id, ":", action, "?key=", self.admin_key])
+            return "".join(["https://", self.host, resource_path, "/", item_id, "?key=", self.admin_key])
+
+    def post_resource(self, url, data):
+        """
+        Posts (inserts) an ams resource by token
+        Args:
+            url: str. url of resource
+            data: dict. data to post
+
+        Returns:
+            dict: resource contents
+
+        """
+        # Set up headers
+        headers = dict()
+        headers.update({
+            'Accept': 'application/json'
+        })
+        # do the post requests
+        r = requests.post(url, headers=headers, verify=self.verify, data=json.dumps(data))
+        # if successful return data (or empty json)
+        if 200 == r.status_code:
+            if r.text == "":
+                return {}
+            return json.loads(r.text)
+        # If not successful return None
+        else:
+            log.critical(r.text)
+            return None
+
+    def put_resource(self, url, data):
+        """
+        Puts (inserts/updates) an ams resource by token
+        Args:
+            url: str. url of resource
+            data: dict. data to post
+
+        Returns:
+            dict: resource contents
+
+        """
+        # Set up headers
+        headers = dict()
+        headers.update({
+            'Accept': 'application/json'
+        })
+        # do the put request
+        r = requests.put(url, headers=headers, verify=self.verify, data=json.dumps(data))
+        # if successful return json data (or empty json)
+        if 200 == r.status_code:
+            if r.text == "":
+                return {}
+            return json.loads(r.text)
+        # if not successful return None
+        else:
+            log.critical(r.text)
+            return None
+
+    def get_resource(self, url):
+        """
+        Returns an ams resource by token
+        Args:
+            url: str. url of resource
+
+        Returns:
+            dict: resource contents
+
+        """
+        # Set up headers
+        headers = dict()
+        headers.update({
+            'Accept': 'application/json'
+        })
+        # do the get resource
+        r = requests.get(url, headers=headers, verify=self.verify)
+        # if successful return the json data or empty json
+        if 200 == r.status_code:
+            if r.text == "":
+                return {}
+            return json.loads(r.text)
+        else:
+            return None
+
+    def get_project(self, project):
+        """
+        Get a specific project from AMS
+        Args:
+            project: str. name of the project
+
+        Returns:
+            dict. json representation of the project
+
+        """
+        url = self.get_url("projects", project)
+        return self.get_resource(url)
+
+    def get_users(self):
+        """
+        Get the list of users from AMS
+
+        Returns:
+            dict. json representation of the list of users
+
+        """
+        url = self.get_url("users")
+        return self.get_resource(url)["users"]
+
+    def get_user(self, name):
+        """
+        Get a specific AMS user
+        Args:
+            name: str. username
+
+        Returns:
+            dict. json representation of the AMS user
+
+        """
+        url = self.get_url("users", name)
+        return self.get_resource(url)
+
+    def get_topics(self, project):
+        """
+        Get list of topics for an AMS project
+        Args:
+            project: str. name of the project
+
+        Returns:
+            dict. json representation of the list of topics
+
+        """
+        url = self.get_url("topics", None, project)
+        return self.get_resource(url)
+
+    def get_subs(self, project):
+        """
+        Get list of subs for an AMS project
+        Args:
+            project: str. name of the project
+
+        Returns:
+            dict. json represenatation of the list of subscriptions
+
+        """
+        url = self.get_url("subscriptions", None, project)
+        return self.get_resource(url)
+
+    def get_topic_acl(self, project, topic):
+        """
+        Get ACL list for a specific project's topic
+        Args:
+            project: str. project name
+            topic: str. topic name
+
+        Returns:
+            list. a list of authorized users
+
+        """
+        url = self.get_url("topics", topic, project, "acl")
+        return self.get_resource(url)["authorized_users"]
+
+    def get_sub_acl(self, project, sub):
+        """
+        Get ACL list for a specific project's subscription
+        Args:
+            project: str. project name
+            sub: str. topic name
+
+        Returns:
+            list. a list of authorized users
+
+        """
+        url = self.get_url("subscriptions", sub, project, "acl")
+        return self.get_resource(url)["authorized_users"]
+
+    def get_tenant_project(self, tenant):
+        """
+        For a given tenant name get the corresponding project in AMS
+        Args:
+            tenant: str. tenant name
+
+        Returns:
+            dict. json representation of AMS project
+
+        """
+        project = tenant.upper()
+        return self.get_project(project)
+
+    def get_tenant_user(self, tenant, role):
+        """
+        For a given tenant and role get the corresponding AMS user
+        Args:
+            tenant: str. tenant name
+            role: str. user role (project_admin|consumer|publisher)
+
+        Returns:
+            dict. json representation of AMS user
+
+        """
+        if role == "project_admin":
+            username = "ams_{}_admin".format(tenant.lower())
+        else:
+            username = "ams_{}_{}".format(tenant.lower(), role)
+        return self.get_user(username)
+
+    def get_tenant_users(self, tenant):
+        """
+        For a given tenant get a list of all AMS users associated with this tenant
+
+        Args:
+            tenant: str. tenant name
+
+        Returns:
+            dict. json representation of list of AMS users
+
+        """
+        # tenant must have 3 users: project_admin, publisher, consumer
+        lookup = [("project_admin", "ams_{}_admin"), ("publisher", "ams_{}_publisher"), ("consumer", "ams_{}_consumer")]
+        lookup = [(x, y.format(tenant.lower())) for (x, y) in lookup]
+        users = dict()
+        for (role, name) in lookup:
+            data = self.get_user(name)
+            if data is not None:
+                users[role] = data
+
+        return users
+
+    def get_tenant_topics(self, tenant):
+        """
+        For a specific tenant get all relevant AMS topics
+        Args:
+            tenant: str. tenant name
+
+        Returns:
+            dict. A set of relevant AMS topics
+
+        """
+        project = tenant.upper()
+        found = dict()
+        topics = self.get_topics(project)
+
+        if topics is not None and "topics" in topics:
+            topics = topics['topics']
+        for topic in topics:
+            name = topic["name"]
+            if name.endswith('sync_data'):
+                found["sync_data"] = name
+            if name.endswith('metric_data'):
+                found["metric_data"] = name
+        return found
+
+    def get_tenant_subs(self, tenant, topics):
+        """
+        For a given tenant and specific topics get relevant subscriptions
+        tied to those topics
+        Args:
+            tenant: str. tenant name
+            topics: list. list of ams topics
+
+        Returns:
+            dict. a set of relevant subscriptions
+
+        """
+        project = tenant.upper()
+        found = dict()
+        subs = self.get_subs(project)
+        if subs is not None and "subscriptions" in subs:
+            subs = subs['subscriptions']
+        for sub in subs:
+            name = sub["name"]
+            if name.endswith('ingest_sync'):
+                if topics["sync_data"] == sub["topic"]:
+                    found["ingest_sync"] = name
+            if name.endswith('ingest_metric'):
+                if topics["metric_data"] == sub["topic"]:
+                    found["ingest_metric"] = name
+            if name.endswith('status_sync'):
+                if topics["sync_data"] == sub["topic"]:
+                    found["status_sync"] = name
+            if name.endswith('status_metric'):
+                if topics["metric_data"] == sub["topic"]:
+                    found["status_metric"] = name
+        return found
+
+    @staticmethod
+    def user_get_topics(user, project):
+        """
+        Given an AMS user definition and a specific project
+        get project's topics that this user has access to
+        Args:
+            user: dict. AMS user representation
+            project: str. project name
+
+        Returns:
+            list(str) list of topics
+
+        """
+        for item in user['projects']:
+            if item['project'] == project:
+                return item['topics']
+        return []
+
+    @staticmethod
+    def user_get_subs(user, project):
+        """
+        Given an AMS user definition and a specific project
+        get project's subscriptions that this user has access to
+        Args:
+            user: dict. AMS user representation
+            project: str. project name
+
+        Returns:
+            list(str) list of subscriptions
+
+        """
+        for item in user['projects']:
+            if item['project'] == project:
+                return item['subscriptions']
+        return []
+
+    def update_tenant_configuration(self, tenant, config):
+        """
+        Given a tenant and an instance of argo configuration
+        update argo configuration with latest tenant's AMS details
+        Args:
+            tenant: str. tenant name
+            config: obj. ArgoConfig object
+        """
+
+        # Get tenant's section in argo configuration
+        section_tenant = "TENANTS:" + tenant
+
+        # update tenant ams project
+        ams_project = self.get_tenant_project(tenant)
+
+        if ams_project is not None:
+            if ams_project["name"] != config.get(section_tenant, "ams_project"):
+                config.set(section_tenant, "ams_project", ams_project["name"])
+
+        # update tenant ams_token
+        ams_consumer = self.get_tenant_user(tenant, "consumer")
+
+        if ams_consumer["token"] != config.get(section_tenant, "ams_token"):
+            config.set(section_tenant, "ams_token", ams_consumer["token"])
+
+        # get tenant's job sections in argo configuration
+        section_ingest_metric = "TENANTS:{}:ingest-metric".format(tenant)
+        section_ingest_sync = "TENANTS:{}:ingest-sync".format(tenant)
+        section_status_stream = "TENANTS:{}:stream-status".format(tenant)
+
+        # update tenant ingest-metric
+        if config.get(section_ingest_metric, "ams_sub") != "metric_data":
+            config.set(section_ingest_metric, "ams_sub", "metric_data")
+
+        # update tenant ingest-sync
+        if config.get(section_ingest_sync, "ams_sub") != "sync_data":
+            config.set(section_ingest_sync, "ams_sub", "sync_data")
+
+        # update tenant status_stream
+        if config.get(section_status_stream, "ams_sub_metric") != "status_metric":
+            config.set(section_status_stream, "ams_sub_metric", "status_metric")
+
+        if config.get(section_status_stream, "ams_sub_sync") != "status_sync":
+            config.set(section_status_stream, "ams_sub_sync", "status_sync")
+
+    def create_tenant_project(self, tenant):
+        """
+        For a given tenant create an AMS project
+        Args:
+            tenant: str. tenant name
+
+        Returns:
+            dict. json representation of the newly created AMS project
+
+        """
+        project_name = tenant.upper()
+        url = self.get_url("projects", project_name)
+        data = {"description": "generated by argo engine"}
+        return self.post_resource(url, data)
+
+    def create_tenant_topic(self, tenant, topic):
+        """
+        For a given tenant and topic name create a new AMS topic
+        Args:
+            tenant: str. tenant name
+            topic: str. topic name
+
+        Returns:
+            dict. json representation of the newly created AMS topic
+
+        """
+        project_name = tenant.upper()
+        url = self.get_url("topics", topic, project_name)
+        return self.put_resource(url, "")
+
+    def create_tenant_sub(self, tenant, topic, sub):
+        """
+        For a given tenant, topic and subscription name create a new AMS subscription
+        tied to that topic
+
+        Args:
+            tenant: str. tenant name
+            topic: str. topic name
+            sub: str. subscription name
+
+        Returns:
+            dict. json representation of the newly created AMS subscription
+
+        """
+        project_name = tenant.upper()
+        url = self.get_url("subscriptions", sub, project_name)
+        data = {"topic": "projects/{}/topics/{}".format(project_name, topic)}
+        return self.put_resource(url, data)
+
+    def create_tenant_user(self, tenant, role):
+        """
+        For a given tenant and user role create a new user tied to that tenant
+        Args:
+            tenant: str. tenant name
+            role: str. user role (project_admin|consumer|publisher)
+
+        Returns:
+            dict: json representation of the newly created AMS user
+
+        """
+        project_name = tenant.upper()
+        if role == "project_admin":
+            username = "ams_{}_admin".format(tenant.lower())
+        else:
+            username = "ams_{}_{}".format(tenant.lower(), role)
+
+        print username, role
+        url = self.get_url("users", username)
+        data = {"projects": [{"project": project_name, "roles": [role]}]}
+        return self.post_resource(url, data)
+
+    def set_topic_acl(self, tenant, topic, acl):
+        """
+        For a given tenant, topic and acl list, update topic's acl
+
+        Args:
+            tenant: str. tenant name
+            topic: str. topic name
+            acl: list(str). list of authorized usernames
+
+        Returns:
+            dict. json representation of the updated AMS acl
+        """
+        project_name = tenant.upper()
+        url = self.get_url("topics", topic, project_name, "modifyAcl")
+        data = {"authorized_users": acl}
+        return self.post_resource(url, data)
+
+    def set_sub_acl(self, tenant, sub, acl):
+        """
+        For a given tenant, subscription and acl list, update subscription's acl
+
+        Args:
+            tenant: str. tenant name
+            sub: str. subscription name
+            acl: list(str). list of authorized usernames
+
+        Returns:
+            dict. json representation of the updated AMS acl
+        """
+        project_name = tenant.upper()
+        url = self.get_url("subscriptions", sub, project_name, "modifyAcl")
+        data = {"authorized_users": acl}
+        return self.post_resource(url, data)
+
+    def check_tenant(self, tenant):
+        """
+        For a given tenant check AMS for missing tenant definitions (topics,subs,users,acls)
+        Args:
+            tenant: str. tenant name
+
+        Returns:
+            dict: a dictionary containing missing topics,subs,users and acls
+
+        """
+
+        project = tenant.upper()
+
+        # Things that sould be present in AMS definitions
+        topics_lookup = ["sync_data", "metric_data"]
+        subs_lookup = ["ingest_sync", "ingest_metric", "status_sync", "status_metric"]
+        users_lookup = ["project_admin", "publisher", "consumer"]
+        topic_acl_lookup = ["sync_data", "metric_data"]
+        sub_acl_lookup = ["ingest_sync", "ingest_metric"]
+
+        # Initialize a dictionary with missing definitions
+        missing = dict()
+        missing["topics"] = list()
+        missing["subs"] = list()
+        missing["users"] = list()
+        missing["topic_acls"] = list()
+        missing["sub_acls"] = list()
+
+        # Get tenant's AMS topics, subs and users
+        topics = self.get_tenant_topics(tenant)
+        subs = self.get_tenant_subs(tenant, topics)
+        users = self.get_tenant_users(tenant)
+
+        # If AMS definitions are None create empty lists
+        if topics is None:
+            topics = {}
+        if subs is None:
+            subs = {}
+        if users is None:
+            users = {}
+
+        # For each expected topic check if it was indeed found in AMS or if it's missing
+        for item in topics_lookup:
+            if item not in topics.keys():
+                missing["topics"].append(item)
+
+        # For each expected sub check if it was indeed found in AMS or if it's missing
+        for item in subs_lookup:
+            if item not in subs.keys():
+                missing["subs"].append(item)
+
+        # For each expected user check if it was indeed found in AMS or if it's missing
+        for item in users_lookup:
+            if item not in users.keys():
+                missing["users"].append(item)
+
+        user_topics = []
+        user_subs = []
+
+        # Get publisher topics
+        if "publisher" in users:
+            user_topics = self.user_get_topics(users["publisher"], project)
+
+        # Check expected topic acls if are missing
+        for item in topic_acl_lookup:
+            if item not in user_topics:
+                missing["topic_acls"].append(item)
+        # Get consumers subscriptions
+        if "consumer" in users:
+            user_subs = self.user_get_subs(users["consumer"], project)
+
+        # check expected sub acls if are missing
+        for item in sub_acl_lookup:
+            if item not in user_subs:
+                missing["sub_acls"].append(item)
+
+        return missing
+
+    def fill_missing(self, tenant, missing):
+        """
+        Giving a dictionary with missing tenant definitions (returned from check_tenant method) attempt to create
+        the missing defnitions in AMS
+
+        Args:
+            tenant: str. tenant name
+            missing: dict. tenant's missing definitions (topics,subs,users,acls)
+
+        """
+
+        # For each missing topic attempt to create it in AMS
+        for topic in missing["topics"]:
+            # create topic
+            topic_new = self.create_tenant_topic(tenant, topic)
+            log.info("Tenant:{} - created missing topic: {}".format(tenant, topic_new["name"]))
+
+        # For each missing sub attempt to create it in AMS
+        for sub in missing["subs"]:
+            # create sub
+            if sub.endswith("metric"):
+                topic = "metric_data"
+            elif sub.endswith("sync"):
+                topic = "sync_data"
+            else:
+                continue
+            sub_new = self.create_tenant_sub(tenant, topic, sub)
+            log.info("Tenant:{} - created missing subscription: {} on topic: {}".format(tenant, sub_new["name"],
+                                                                                        sub_new["topic"]))
+
+        # For each missing user attempt to create it in AMS
+        for user in missing["users"]:
+            # create user
+            user_new = self.create_tenant_user(tenant, user)
+            log.info("Tenant:{} - created missing user: {}".format(tenant, user_new["name"]))
+
+        # For each missing topic acl attempt to set it in AMS
+        for topic_acl in missing["topic_acls"]:
+            acl = self.get_topic_acl(tenant, topic_acl)
+            user_pub = "ams_{}_publisher".format(tenant.lower())
+            if user_pub not in acl:
+                acl.append(user_pub)
+
+            r = self.set_topic_acl(tenant, topic_acl, acl)
+            if r is not None:
+                log.info("Tenant:{} - set missing acl on topic: {} for user: {}".format(tenant, topic_acl, user_pub))
+
+        # For each missing subscription attempt to set it in AMS
+        for sub_acl in missing["sub_acls"]:
+            acl = self.get_sub_acl(tenant, sub_acl)
+            user_con = "ams_{}_consumer".format(tenant.lower())
+            if user_con not in acl:
+                acl.append(user_con)
+
+            r = self.set_sub_acl(tenant, sub_acl, acl)
+            if r is not None:
+                log.info(
+                    "Tenant:{} - set missing acl on subscription: {} for user: {}".format(tenant, sub_acl, user_con))
+
+    def check_project_exists(self, tenant):
+        """
+        Given a tenant name check if corresponding AMS project exists
+        If doesnt exist calls create_tenant_project() method to create it
+        Args:
+            tenant: str. tenant name
+
+        Returns:
+           dict. json representation of the project
+        """
+        # check if project exists
+        project = self.get_tenant_project(tenant)
+        if project is None:
+            # if project doesn't exist attempt to create it
+            log.info("{} project not found on ams".format(tenant))
+            project = self.create_tenant_project(tenant)
+            log.info("{} project created for tenant: {}".format(project["name"], tenant))
+            return project
+        log.info("{} project found for tenant: {}".format(project["name"], tenant))
+        return project
+
+
+def is_tenant_complete(missing):
+    """
+    Given a dict of missing tenant definitions, check if the missing
+    definitions are empty thus the tenant is complete
+    Args:
+        missing: dict. tenant's missing definitions (topics,subs,users,acls)
+
+    Returns:
+        bool: True if tenant's missing definitions are empty
+
+    """
+    check_list = ["topics", "subs", "users", "topic_acls", "sub_acls"]
+    for item in check_list:
+        if len(missing[item]) > 0:
+            return False
+    return True
+
+
+def run_ams_update(args):
+    """
+    Runs when this script is called from CLI.
+    Runs for a specific tenant or all tenants in argo config
+    Reads argo configuration tenant list. For each tenant, creates missing tenant's definitions
+    and updates argo configuration with tenant's ams parameters
+
+    Args:
+        args: cli arguments
+
+    """
+    # Get configuration paths
+    conf_paths = get_config_paths(args.config)
+
+    # Get logger config file
+    get_log_conf(conf_paths['log'])
+
+    # Get main configuration and schema
+    config = ArgoConfig(conf_paths["main"], conf_paths["schema"])
+
+    ams_token = config.get("AMS", "access_token")
+    ams_host = config.get("AMS", "endpoint").hostname
+    log.info("ams api used {}".format(ams_host))
+
+    tenant_list = config.get("API", "tenants")
+    ams = ArgoAmsClient(ams_host, ams_token)
+
+    if args.tenant is not None:
+        # Check if tenant exists in argo configuarion
+        if args.tenant not in tenant_list:
+            log.fatal("Tenant:{} is not in argo configuration - exiting...".format(args.tenant))
+            sys.exit(1)
+        # Check only the tenant that user specified
+        check_tenants = [args.tenant]
+    else:
+        # Check all tenants that are specified in argo configuration
+        check_tenants = tenant_list
+
+    for tenant in check_tenants:
+        ams.check_project_exists(tenant)
+        missing = ams.check_tenant(tenant)
+        if is_tenant_complete(missing):
+            log.info("Tenant {} definition on AMS is complete!".format(tenant))
+        else:
+            ams.fill_missing(tenant, missing)
+        # Update tenant configuration
+        ams.update_tenant_configuration(tenant, config)
+
+    # Save changes to designated configuration file
+    config.save_as(config.conf_path)
+
+
+if __name__ == '__main__':
+    # Feed Argument parser with the description of the arguments we need
+    arg_parser = ArgumentParser(
+        description="update ams with relevant tenant configuration")
+    arg_parser.add_argument(
+        "-c", "--config", help="config", dest="config", metavar="STRING")
+    arg_parser.add_argument(
+        "-t", "--tenant", help="tenant", dest="tenant", metavar="STRING", required=False, default=None)
+    arg_parser.add_argument(
+        "-v", "--verify", help="verify", dest="verify", action="store_true")
+
+    # Parse the command line arguments accordingly and introduce them to the run method
+    sys.exit(run_ams_update(arg_parser.parse_args()))

--- a/conf/argo-streaming.conf
+++ b/conf/argo-streaming.conf
@@ -15,6 +15,7 @@ TENANT_B_key=key2
 
 [AMS]
 endpoint: test_endpoint:8080
+access_token: foo_token
 # Ams proxy
 proxy:test_proxy
 # Verify ssl
@@ -46,6 +47,7 @@ stream-status= /path/to/streaming-status-multi2.jar
 
 [AMS]
 ams_endpoint= localhost:8080
+access_token= secret
 
 [TENANTS:TENANT_A]
 ams_project= TENANT_A

--- a/conf/conf.template
+++ b/conf/conf.template
@@ -55,6 +55,7 @@ stream-status: test.jar
 
 [AMS]
 endpoint: https://test_endpoint:8080
+access_token: foo_token
 # Ams proxy
 proxy:test_proxy
 # Verify ssl

--- a/conf/config.schema.json
+++ b/conf/config.schema.json
@@ -30,6 +30,10 @@
         "desc": "argo messaging endpoint",
         "type": "uri"
       },
+      "access_token": {
+        "desc": "argo messaging access token",
+        "type": "string"
+      },
       "proxy": {
         "desc": "ams proxy to be used",
         "type": "uri",

--- a/docs/update_ams.md
+++ b/docs/update_ams.md
@@ -1,0 +1,41 @@
+# Python script for updating ams (argo-web-api --> argo streaming engine --> ams)
+
+Having an updated configuration from argo-web-api, argo engine can access Argo
+Messaging service to check if expected projects/topics/subscriptions/users have been
+setup for each tenant. If items are missing update_ams script can create them (by
+  setting up new tenant project, topics, subscriptions and users)
+
+To manually trigger an argo ams check for all tenants, issue:
+`./bin/utils/update_ams.py -c /path/to/argo-streaming.conf`
+
+To manually trigger an argo ams check for a specific tenant issue:
+`./bin/utils/update_ams.py -c /path/to/argo-streaming.conf -t tenant_a`
+
+Script will read the designated `argo-streaming.conf` and extract information
+for all supported Tenants. For each tenant will examine if the corresponding
+project exists in AMS endpoint and if the needed topics for publishing and
+ingestion have been set-up.
+
+# Expected AMS items for each tenant
+
+Given a tenant with name 'foo' the engine expects the following to be set-up
+in AMS:
+- tenant-project: `FOO` (project always has same name as tenant but in all caps)
+- tenant-topics:
+ - `metric_data` (feed for metric data)
+ - `sync_data` (feed for connector data)
+- tenant-subscriptions:
+ - `ingest_metric` (connected to `metric_data` used for ingestion)
+ - `ingest_sync` (connected to `sync_data` used for ingestion)
+ - `status_metric` (connected to `metric_data` used for streaming computations)
+ - `status_sync` (connected to `metric_data` used for streaming computations)
+ - users:
+  - `ams_foo_admin` with role: `project_admin` (project admin)
+  - `ams_foo_publisher` with role `publisher` (used for publishing clients)
+  - `ams_foo_consumer`with role `consumer` (used for ingestion jobs)
+
+Also the topics must include `ams_foo_publisher` in their acls and in the same way
+subscriptions must include `ams_foo_consumer` in their acls
+
+Update_ams for a given tenant, checks AMS endpoint for the above expected items.
+If an item is found missing it's automatically created.


### PR DESCRIPTION
:warning: __Note__: branched from https://github.com/ARGOeu/argo-streaming/pull/84 

# Goal
Given tenant list from argo configuration, argo engine should be able to check in AMS endpoint if all the necessary projects/topics/subscriptions and users have been created. If item are missing argo-engine should attempt to automatically create them using a specific naming scheme (as described in docs)

# Implementation
- [x] ArgoAmsClient class provides methods for managing projects/users/topics/subscriptions in a remote AMS endpoint
- [x] Update_ams script uses ArgoAmsClient and ArgoConfig and checks for all tenants if expected items are missing in AMS
- [x] For missing items found, update_ams attemps to create them and update argo configuration 
- [x] Add unit tests
- [x] Add documentation