### PR TITLE
ARGO-1065 Establish a fixed restart strategy for streaming jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Job optional cli parameters:
 
 `--ams.verify`        : optional turn on/off ssl verify
 
+### Restart strategy
+Job has a fixed delay restart strategy. If it fails it will try to restart for a maximum of 10 attempt with a retry interval of 2 minutes
+between each attempt
+
 ### Metric data hbase schema
 
 Metric data are stored in hbase tables using different namespaces for different tenants (e.g. hbase table name = '{TENANT_name}:metric_data')
@@ -127,6 +131,9 @@ Job required cli parameters:
 
 `--ams.verify`        : optional turn on/off ssl verify
 
+### Restart strategy
+Job has a fixed delay restart strategy. If it fails it will try to restart for a maximum of 10 attempt with a retry interval of 2 minutes
+between each attempt
 
 ### Stream Status
 
@@ -210,6 +217,9 @@ Other optional cli parameters
 
 `--ams.verify`        : optional turn on/off ssl verify
 
+### Restart strategy
+Job has a fixed delay restart strategy. If it fails it will try to restart for a maximum of 10 attempt with a retry interval of 2 minutes
+between each attempt
 
 
 ### Status events schema
@@ -233,13 +243,13 @@ Status events are generated as JSON messages that are defined by the following c
 A metric data message can produce zero, one or more status metric events. The system analyzes the new status introduced by the metric and then aggregates on top levels to see if any other status changes are produced.
 If a status of an item actually changes an appropriate status event is produced based on the item type (endpoint_group,service,endpoint,metric).
 
-## Threshold rule files 
+## Threshold rule files
 Each report can be accompanied by a threshold rules file which includes rules on low level metric data which may accompany a monitoring message with the field 'actual_data'.
 The rule file is in JSON format and has the following schema:
 ```
 {
   "rules": [
-    { 
+    {
       "group" : "site-101",
       "host" : "host.foo",
       "metric": "org.namespace.metric",
@@ -292,7 +302,7 @@ Job required cli parameters:
 
 `--mongo.method`      : MongoDB method to be used when storing the results ~ either: `insert` or `upsert`
 
-`--thr`               : (optional) file location of threshold rules 
+`--thr`               : (optional) file location of threshold rules
 
 
 ## Batch AR
@@ -339,7 +349,7 @@ Job required cli parameters:
 
 `--mongo.method`      : MongoDB method to be used when storing the results ~ either: `insert` or `upsert`
 
-`--thr`               : (optional) file location of threshold rules 
+`--thr`               : (optional) file location of threshold rules
 
 
 ## Flink job names

--- a/flink_jobs/ams_ingest_metric/src/main/java/argo/streaming/AmsIngestMetric.java
+++ b/flink_jobs/ams_ingest_metric/src/main/java/argo/streaming/AmsIngestMetric.java
@@ -2,6 +2,7 @@ package argo.streaming;
 
 
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.io.DatumReader;
@@ -12,6 +13,8 @@ import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.io.OutputFormat;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.utils.ParameterTool;
 
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
@@ -115,6 +118,8 @@ public class AmsIngestMetric {
 		// Create flink execution environment
 		StreamExecutionEnvironment see = StreamExecutionEnvironment.getExecutionEnvironment();
 		see.setParallelism(1);
+		// On failure attempt max 10 times to restart with a retry interval of 2 minutes
+		see.setRestartStrategy(RestartStrategies.fixedDelayRestart(10, Time.of(2, TimeUnit.MINUTES)));
 
 		// Initialize cli parameter tool
 		final ParameterTool parameterTool = ParameterTool.fromArgs(args);

--- a/flink_jobs/ams_ingest_sync/src/main/java/argo/streaming/AmsIngestSync.java
+++ b/flink_jobs/ams_ingest_sync/src/main/java/argo/streaming/AmsIngestSync.java
@@ -1,5 +1,9 @@
 package argo.streaming;
 
+import java.util.concurrent.TimeUnit;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -53,6 +57,8 @@ public class AmsIngestSync {
 		// Create flink execution enviroment
 		StreamExecutionEnvironment see = StreamExecutionEnvironment.getExecutionEnvironment();
 		see.setParallelism(1);
+		// Fixed restart strategy: on failure attempt max 10 times to restart with a retry interval of 2 minutes
+		see.setRestartStrategy(RestartStrategies.fixedDelayRestart(10, Time.of(2, TimeUnit.MINUTES)));
 		// Initialize cli parameter tool
 		final ParameterTool parameterTool = ParameterTool.fromArgs(args);
 

--- a/flink_jobs/batch_status/src/main/java/argo/batch/ArgoStatusBatch.java
+++ b/flink_jobs/batch_status/src/main/java/argo/batch/ArgoStatusBatch.java
@@ -11,8 +11,11 @@ import ops.ConfigManager;
 import org.slf4j.Logger;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.flink.api.common.operators.Order;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.AvroInputFormat;
@@ -54,6 +57,8 @@ public class ArgoStatusBatch {
 		// make parameters available in the web interface
 		env.getConfig().setGlobalJobParameters(params);
 		env.setParallelism(1);
+		// Fixed restart strategy: on failure attempt max 10 times to restart with a retry interval of 2 minutes
+		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(10, Time.of(2, TimeUnit.MINUTES)));
 		// sync data for input
 		Path mps = new Path(params.getRequired("mps"));
 		Path egp = new Path(params.getRequired("egp"));


### PR DESCRIPTION
Streaming jobs will have a restart strategy of 10 Max retries with a delay interval of 2 minutes.