### PR TITLE
ARGO-1402 Enable streaming-status job per report

### DIFF
--- a/flink_jobs/stream_status/src/main/java/argo/streaming/StatusConfig.java
+++ b/flink_jobs/stream_status/src/main/java/argo/streaming/StatusConfig.java
@@ -22,6 +22,8 @@ public class StatusConfig implements Serializable {
 	// Avro schema
 	public String avroSchema;
 	
+	public String report;
+	
 	// Sync files
 	public String aps;
 	public String mps;
@@ -50,6 +52,7 @@ public class StatusConfig implements Serializable {
 	   this.ops = pt.getRequired("sync.ops");
 	   this.runDate = pt.getRequired("run.date");
 	   this.downtime = pt.getRequired("sync.downtime");
+	   this.report = pt.getRequired("report");
 	   // Optional timeout parameter
 	   if (pt.has("timeout")){
 		   this.timeout = pt.getLong("timeout");

--- a/flink_jobs/stream_status/src/main/java/status/StatusManager.java
+++ b/flink_jobs/stream_status/src/main/java/status/StatusManager.java
@@ -43,7 +43,7 @@ public class StatusManager {
 	static Logger LOG = LoggerFactory.getLogger(StatusManager.class);
 
 	// Name of the report used
-	String report;
+	private String report;
 
 	// Sync file structures necessary for status computation
 	public EndpointGroupManagerV2 egp = new EndpointGroupManagerV2();
@@ -70,6 +70,13 @@ public class StatusManager {
 	// trigger
 	String tsLatest;
 	
+	public void setReport(String report) {
+		this.report = report;
+	}
+	
+	public String getReport() {
+		return this.report;
+	}
 	
 	public void setTimeout(Long timeout) {
 		this.timeout = timeout;
@@ -760,8 +767,9 @@ public class StatusManager {
 				toZulu(ts), tsProc, prevStatus, toZulu(prevTs), new Boolean(repeat).toString(), summary, message );
 		
 		Gson gson = new Gson();
-		LOG.debug("Event Generated: " + gson.toJson(evnt));
-		return gson.toJson(evnt);
+		String evntJson = gson.toJson(evnt);
+		LOG.debug("Event Generated: " + evntJson);
+		return evntJson;
 	
 	}
 

--- a/flink_jobs/stream_status/src/test/java/status/StatusManagerTest.java
+++ b/flink_jobs/stream_status/src/test/java/status/StatusManagerTest.java
@@ -41,6 +41,9 @@ public class StatusManagerTest {
 
 	@Test
 	public void test() throws URISyntaxException, IOException, ParseException {
+		
+		
+		
 		// Prepare Resource File
 		URL resAPSJsonFile = StatusManagerTest.class.getResource("/ops/ap1.json");
 		File jsonAPSFile = new File(resAPSJsonFile.toURI());
@@ -58,7 +61,7 @@ public class StatusManagerTest {
 		File avroDownFile = new File(resDownAvroFile.toURI());
 
 		StatusManager sm = new StatusManager();
-		sm.report="Critical";
+		sm.setReport("Critical");
 		sm.loadAllFiles("2017-03-03", avroDownFile, avroEGPFile, avroMPSFile, jsonAPSFile, jsonOPSFile);
 
 		Date ts1 = sm.fromZulu("2017-03-03T00:00:00Z");


### PR DESCRIPTION
**Fix for devel branch**

Establish report (name & uuid) information on status-streaming job.
Decline sync files concerning other reports.
Fix: Use report-uuid instead of report name in mongo sink