### PR TITLE
ARGO-1441 Fix hdfs_user param in config scripts

### DIFF
--- a/bin/ar_job_submit.py
+++ b/bin/ar_job_submit.py
@@ -28,11 +28,11 @@ def compose_hdfs_commands(year, month, day, args, config):
     hdfs_user = config.get("HDFS", "user")
     tenant = args.tenant
     hdfs_sync = config.get("HDFS", "path_sync")
-    hdfs_sync = hdfs_sync.fill(namenode=namenode.geturl(), user=hdfs_user, tenant=tenant).geturl()
+    hdfs_sync = hdfs_sync.fill(namenode=namenode.geturl(), hdfs_user=hdfs_user, tenant=tenant).geturl()
 
     hdfs_metric = config.get("HDFS", "path_metric")
 
-    hdfs_metric = hdfs_metric.fill(namenode=namenode.geturl(), user=hdfs_user, tenant=tenant).geturl()
+    hdfs_metric = hdfs_metric.fill(namenode=namenode.geturl(), hdfs_user=hdfs_user, tenant=tenant).geturl()
 
     # dictionary holding all the commands with their respective arguments' name
     hdfs_commands = dict()

--- a/bin/status_job_submit.py
+++ b/bin/status_job_submit.py
@@ -26,11 +26,11 @@ def compose_hdfs_commands(year, month, day, args, config):
     hdfs_user = config.get("HDFS", "user")
     tenant = args.tenant
     hdfs_sync = config.get("HDFS", "path_sync")
-    hdfs_sync = hdfs_sync.fill(namenode=namenode.geturl(), user=hdfs_user, tenant=tenant).geturl()
+    hdfs_sync = hdfs_sync.fill(namenode=namenode.geturl(), hdfs_user=hdfs_user, tenant=tenant).geturl()
 
     hdfs_metric = config.get("HDFS", "path_metric")
 
-    hdfs_metric = hdfs_metric.fill(namenode=namenode.geturl(), user=hdfs_user, tenant=tenant).geturl()
+    hdfs_metric = hdfs_metric.fill(namenode=namenode.geturl(), hdfs_user=hdfs_user, tenant=tenant).geturl()
 
     # dictionary holding all the commands with their respective arguments' name
     hdfs_commands = dict()

--- a/bin/stream_status_job_submit.py
+++ b/bin/stream_status_job_submit.py
@@ -20,7 +20,7 @@ def compose_hdfs_commands(year, month, day, args, config):
     hdfs_user = config.get("HDFS", "user")
     tenant = args.tenant
     hdfs_sync = config.get("HDFS", "path_sync")
-    hdfs_sync = hdfs_sync.fill(namenode=namenode.geturl(), user=hdfs_user, tenant=tenant).geturl()
+    hdfs_sync = hdfs_sync.fill(namenode=namenode.geturl(), hdfs_user=hdfs_user, tenant=tenant).geturl()
 
     # dictionary holding all the commands with their respective arguments' name
     hdfs_commands = dict()

--- a/bin/utils/test_argo_config.py
+++ b/bin/utils/test_argo_config.py
@@ -26,9 +26,9 @@ class TestClass(unittest.TestCase):
 
         # get var HDFS -> path_metric (template) and fill it with specific arguments
         exp_result = urlparse("hdfs://localhost:2000/user/foobar/argo/tenants/wolf/mdata")
-        self.assertEqual(exp_result, argo_conf.get("HDFS", "path_metric").fill(namenode="localhost:2000", user="foobar",
+        self.assertEqual(exp_result, argo_conf.get("HDFS", "path_metric").fill(namenode="localhost:2000", hdfs_user="foobar",
                                                                                tenant="wolf"))
         # fill template with different user argument
         self.assertNotEqual(exp_result,
-                            argo_conf.get("HDFS", "path_metric").fill(namenode="localhost:2000", user="foobar2",
+                            argo_conf.get("HDFS", "path_metric").fill(namenode="localhost:2000", hdfs_user="foobar2",
                                                                       tenant="wolf"))

--- a/bin/utils/update_profiles.py
+++ b/bin/utils/update_profiles.py
@@ -137,7 +137,7 @@ class ArgoApiClient:
         """
         # default recomputation is always an empty json array
         if profile_type == "recomputations":
-            return "[]"
+            return []
 
         item_uuid = self.find_profile_uuid(tenant, report, profile_type)
         if item_uuid is None:

--- a/conf/argo-streaming.conf
+++ b/conf/argo-streaming.conf
@@ -2,8 +2,8 @@
 namenode=hdfs://localhost:8020
 user= foo
 rollback_days= 3
-path_metric= hdfs://{{namenode}}/user/{{user}}/argo/tenants/{{tenant}}/mdata
-path_sync= hdfs://{{namenode}}/user/{{user}}/argo/tenants/{{tenant}}/sync
+path_metric= hdfs://{{namenode}}/user/{{hdfs_user}}/argo/tenants/{{tenant}}/mdata
+path_sync= hdfs://{{namenode}}/user/{{hdfs_user}}/argo/tenants/{{tenant}}/sync
 writer_bin= /home/root/hdfs
 
 [API]


### PR DESCRIPTION
- Expect {{hdfs_user}} parameter in templates instead of {{user}}
- Fix empty json array in default recomp.json generation 