### PR TITLE
ARGO-1626 Status batch service aggregation OR/AND fix

### DIFF
--- a/flink_jobs/batch_status/src/main/java/argo/batch/CalcStatusService.java
+++ b/flink_jobs/batch_status/src/main/java/argo/batch/CalcStatusService.java
@@ -121,7 +121,7 @@ public class CalcStatusService extends RichGroupReduceFunction<StatusMetric, Sta
 		avGroup = this.apsMgr.getGroupByService(aProfile, service);
 		String avOp = this.apsMgr.getProfileGroupServiceOp(aProfile, avGroup, service);
 		
-		this.serviceAggr.aggregate(this.opsMgr, "OR");
+		this.serviceAggr.aggregate(this.opsMgr, avOp);
 
 		// Append the timeline	
 		for (Entry<DateTime, Integer> item : this.serviceAggr.getSamples()) {


### PR DESCRIPTION
# Issue:
Bug: Engine retrieved the correct service aggregation operation from agg. profile and stored it in avOp var.  In the next step the "OR" hardcoded value was used in op selection instead of avOp. Since till now pragmatically all service aggregations resolved to "OR" this worked ok. In a scenario that some service aggregations needed "AND" this bug was quickly exposed

# Fix:
Use avOp result instead of "OR" when calling aggregate() method