### PR TITLE
ARGO-1581 In status streaming job use optimistically OK as init status

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ Job Optional cli parameters for ams ingestion related
 
 `--ams.interval`      : interval (in ms) between AMS service requests
 Other optional cli parameters
+`--init.status`       : "OK", "MISSING" - initialize statuses for new items to a default value. Optimistically defaults to "OK"
+
 `--daily`             : true/false - controls daily regeneration of events (not used in notifications)
 
 `--timeout`           : long(ms) - controls default timeout for event regeneration (used in notifications)

--- a/flink_jobs/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
+++ b/flink_jobs/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
@@ -422,7 +422,7 @@ public class AmsStreamStatus {
 
 		public StatusConfig config;
 
-		public int defStatus;
+		public int initStatus;
 		
 	
 		
@@ -461,7 +461,7 @@ public class AmsStreamStatus {
 			sm.loadAll(config.runDate, downList, egpListFull, mpsList, apsJSON, opsJSON);
 
 			// Set the default status as integer
-			defStatus = sm.getOps().getIntStatus(config.defStatus);
+			initStatus = sm.getOps().getIntStatus(config.initStatus);
 			LOG.info("Initialized status manager:" + pID + " (with timeout:" + sm.getTimeout() + ")");
 
 		}
@@ -506,7 +506,7 @@ public class AmsStreamStatus {
 			if (!sm.hasGroup(group)) {
 				// Get start of the day to create new entries
 				Date dateTS = sm.setDate(tsMon);
-				sm.addNewGroup(group, defStatus, dateTS);
+				sm.addNewGroup(group, initStatus, dateTS);
 			}
 
 			ArrayList<String> events = sm.setStatus(group, service, hostname, metric, status, monHost, tsMon, message, summary);

--- a/flink_jobs/stream_status/src/main/java/argo/streaming/StatusConfig.java
+++ b/flink_jobs/stream_status/src/main/java/argo/streaming/StatusConfig.java
@@ -34,7 +34,8 @@ public class StatusConfig implements Serializable {
 	public long timeout;
 	// Parameter used for daily event generation (not used in notifications)
 	public boolean daily;
-	public String defStatus = "MISSING";
+	// Parameter used to initialize a status to a default value (OK optimistically, MISSING pessimistically)
+	public String initStatus;
 	
 	// Raw parameters
 	public final ParameterTool pt;
@@ -58,6 +59,14 @@ public class StatusConfig implements Serializable {
 		   this.timeout = pt.getLong("timeout");
 	   } else {
 		   this.timeout = 86400000L;
+	   }
+	   
+	   // optional cli parameter to configure default status
+	   if (pt.has("init.status")) {
+		   this.initStatus = pt.get("init.status");
+	   } else {
+		   // by default, default initial status should be optimistically OK
+		   this.initStatus = "OK";
 	   }
 	   
 	   // Optional set daily parameter


### PR DESCRIPTION
Status streaming job initializes new items with MISSING status. It  is preferable the system to be optimistic and initialize to OK instead of MISSING. 

- Change defStatus parameter to initStatus (more appropriate)
- Default initStatus to "OK" instead of "MISSING"
- Expose initStatus optionally through configuration (cli parameter --init.status)
- Update readme