### PR TITLE
ARGO-1679 Add batch endpoint a/r computation

### DIFF
--- a/flink_jobs/batch_ar/src/main/java/argo/batch/ArgoArBatch.java
+++ b/flink_jobs/batch_ar/src/main/java/argo/batch/ArgoArBatch.java
@@ -165,6 +165,12 @@ public class ArgoArBatch {
 				.withBroadcastSet(mpsDS, "mps").withBroadcastSet(egpDS, "egp").withBroadcastSet(ggpDS, "ggp")
 				.withBroadcastSet(opsDS, "ops").withBroadcastSet(aprDS, "aps").withBroadcastSet(recDS, "rec");
 
+		// Calculate endpoint ar from endpoint timelines
+		DataSet<EndpointAR> endpointResultDS = endpointTimelinesDS.flatMap(new CalcEndpointAR(params))
+				.withBroadcastSet(mpsDS, "mps").withBroadcastSet(egpDS, "egp").withBroadcastSet(ggpDS, "ggp")
+				.withBroadcastSet(aprDS, "apr").withBroadcastSet(recDS, "rec").withBroadcastSet(opsDS, "ops")
+						.withBroadcastSet(confDS, "conf");
+		
 		// Calculate service ar from service timelines
 		DataSet<ServiceAR> serviceResultDS = serviceTimelinesDS.flatMap(new CalcServiceAR(params))
 				.withBroadcastSet(mpsDS, "mps").withBroadcastSet(egpDS, "egp").withBroadcastSet(ggpDS, "ggp")
@@ -181,11 +187,15 @@ public class ArgoArBatch {
 		String dbURI = params.getRequired("mongo.uri");
 		String dbMethod = params.getRequired("mongo.method");
 
-	    // Initialize two mongodb outputs
+		// Initialize endpoint ar mongo output 
+		MongoEndpointArOutput endpointMongoOut = new MongoEndpointArOutput(dbURI,"endpoint_ar",dbMethod);
+	    // Initialize service ar mongo output
 		MongoServiceArOutput serviceMongoOut = new MongoServiceArOutput(dbURI,"service_ar",dbMethod);
-		 // Initialize two mongodb outputs
+		 // Initialize endpoint group ar mongo output
 		MongoEndGroupArOutput egroupMongoOut = new MongoEndGroupArOutput(dbURI,"endpoint_group_ar",dbMethod);
 		
+		
+		endpointResultDS.output(endpointMongoOut);
 		serviceResultDS.output(serviceMongoOut);
 		groupResultDS.output(egroupMongoOut);
 		

--- a/flink_jobs/batch_ar/src/main/java/argo/batch/CalcEndpointAR.java
+++ b/flink_jobs/batch_ar/src/main/java/argo/batch/CalcEndpointAR.java
@@ -1,0 +1,145 @@
+package argo.batch;
+
+import java.io.IOException;
+import java.text.ParseException;
+
+import java.util.List;
+
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import argo.avro.GroupEndpoint;
+import argo.avro.GroupGroup;
+import ops.ConfigManager;
+import ops.DIntegrator;
+import ops.OpsManager;
+import sync.AggregationProfileManager;
+import sync.EndpointGroupManager;
+import sync.GroupGroupManager;
+
+import sync.RecomputationManager;
+
+/**
+ * Accepts a service monitor timeline entry and produces a ServiceAR object by
+ * calculating a/r over timeline data
+ */
+public class CalcEndpointAR extends RichFlatMapFunction<MonTimeline, EndpointAR> {
+
+	private static final long serialVersionUID = 1L;
+
+	final ParameterTool params;
+
+	public CalcEndpointAR(ParameterTool params) {
+		this.params = params;
+	}
+
+	static Logger LOG = LoggerFactory.getLogger(ArgoArBatch.class);
+
+	
+	private List<GroupEndpoint> egp;
+	private List<GroupGroup> ggp;
+	private List<String> apr;
+	private List<String> rec;
+	private List<String> ops;
+	private List<String> conf;
+
+	private EndpointGroupManager egpMgr;
+	private GroupGroupManager ggpMgr;
+	private AggregationProfileManager aprMgr;
+	private RecomputationManager recMgr;
+	private OpsManager opsMgr;
+	private ConfigManager confMgr;
+
+
+	private String runDate;
+	private String report;
+
+	/**
+	 * Initialization method of the RichFlatMapFunction operator
+	 * <p>
+	 * This runs at the initialization of the operator and receives a
+	 * configuration parameter object. It initializes all required structures
+	 * used by this operator such as profile managers, operations managers,
+	 * topology managers etc.
+	 *
+	 * @param parameters
+	 *            A flink Configuration object
+	 */
+	@Override
+	public void open(Configuration parameters) throws IOException, ParseException {
+		// Get data from broadcast variable
+		
+		this.egp = getRuntimeContext().getBroadcastVariable("egp");
+		this.ggp = getRuntimeContext().getBroadcastVariable("ggp");
+		this.apr = getRuntimeContext().getBroadcastVariable("apr");
+		this.rec = getRuntimeContext().getBroadcastVariable("rec");
+		this.ops = getRuntimeContext().getBroadcastVariable("ops");
+		this.conf = getRuntimeContext().getBroadcastVariable("conf");
+
+		
+		// Initialize endpoint group manager
+		this.egpMgr = new EndpointGroupManager();
+		this.egpMgr.loadFromList(egp);
+
+		this.ggpMgr = new GroupGroupManager();
+		this.ggpMgr.loadFromList(ggp);
+
+		// Initialize Aggregation Profile Manager ;
+		this.aprMgr = new AggregationProfileManager();
+		this.aprMgr.loadJsonString(apr);
+
+		// Initialize Recomputations Manager;
+		this.recMgr = new RecomputationManager();
+		this.recMgr.loadJsonString(rec);
+		
+		// Initialize Operations Manager;
+		this.opsMgr = new OpsManager();
+		this.opsMgr.loadJsonString(ops);
+		
+		// Initialize Config Manager
+		this.confMgr = new ConfigManager();
+		this.confMgr.loadJsonString(conf);
+
+	
+
+		// Initialize rundate
+		this.runDate = params.getRequired("run.date");
+
+		// Initialize report id
+		this.report = this.confMgr.id;
+	}
+
+	/**
+	 * The main operator business logic of calculating a/r results from timeline
+	 * data
+	 * <p>
+	 * Uses a DIntegrator to scan the timeline and calculate availability and
+	 * reliability scores
+	 *
+	 * @param in
+	 *            A MonTimeline Object representing a service timeline
+	 * @param out
+	 *            An EndpointAR Object containing a/r results
+	 */
+	@Override
+	public void flatMap(MonTimeline mtl, Collector<EndpointAR> out) throws Exception {
+		
+		
+		
+		DIntegrator dAR = new DIntegrator();
+		dAR.calculateAR(mtl.getTimeline(),this.opsMgr); 
+		
+		int runDateInt = Integer.parseInt(this.runDate.replace("-", ""));
+		
+		EndpointAR result = new EndpointAR(runDateInt,this.report,mtl.getHostname(),mtl.getService(),mtl.getGroup(),dAR.availability,dAR.reliability,dAR.up_f,dAR.unknown_f,dAR.down_f);
+		
+		out.collect(result);
+	
+	}
+
+}

--- a/flink_jobs/batch_ar/src/main/java/argo/batch/EndpointAR.java
+++ b/flink_jobs/batch_ar/src/main/java/argo/batch/EndpointAR.java
@@ -1,10 +1,11 @@
 package argo.batch;
 
-public class ServiceAR {
+public class EndpointAR {
 	
 	private int dateInt;
 	private String report;
 	private String name;
+	private String service;
 	private String group;
 	private double a;
 	private double r;
@@ -12,16 +13,26 @@ public class ServiceAR {
 	private double unknown;
 	private double down;
 	
-	public ServiceAR(int _dateInt, String _report, String _name, String _group, double _a, double _r, double _up, double _unknown, double _down){
+	public EndpointAR(int _dateInt, String _report, String _name, String _service, String _group, double _a, double _r, double _up, double _unknown, double _down){
 		this.dateInt = _dateInt;
 		this.report=_report;
 		this.name = _name;
+		this.service = _service;
 		this.group = _group;
 		this.a = _a;
 		this.r = _r;
 		this.up = _up;
 		this.unknown = _unknown;
 		this.down = _down;
+	}
+	
+	
+	public String getService() {
+		return this.service;
+	}
+	
+	public void setService(String service) {
+		this.service = service;
 	}
 	
 	public int getDateInt(){
@@ -82,7 +93,7 @@ public class ServiceAR {
 	}
 	
 	public String toString() {
-		return "(" + this.dateInt+ "," + this.report + "," + this.name + "," + this.group + "," + this.a + "," + this.r + ","  + this.up + ","  + this.unknown + ","  + this.down  + ")";
+		return "(" + this.dateInt+ "," + this.report + "," + this.name + "," + this.service + "," + this.group + "," + this.a + "," + this.r + ","  + this.up + ","  + this.unknown + ","  + this.down  + ")";
 	}
 
 }

--- a/flink_jobs/batch_ar/src/main/java/argo/batch/MongoEndpointArOutput.java
+++ b/flink_jobs/batch_ar/src/main/java/argo/batch/MongoEndpointArOutput.java
@@ -1,0 +1,127 @@
+package argo.batch;
+
+import java.io.IOException;
+
+import org.apache.flink.api.common.io.OutputFormat;
+import org.apache.flink.configuration.Configuration;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientURI;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.UpdateOptions;
+
+import argo.batch.MongoEndGroupArOutput.MongoMethod;
+
+/**
+ * MongoOutputFormat for storing Service AR data to mongodb
+ */
+public class MongoEndpointArOutput implements OutputFormat<EndpointAR> {
+
+	public enum MongoMethod {
+		INSERT, UPSERT
+	};
+
+	private static final long serialVersionUID = 1L;
+
+	private String mongoHost;
+	private int mongoPort;
+	private String dbName;
+	private String colName;
+	private MongoMethod method;
+
+	private MongoClient mClient;
+	private MongoDatabase mDB;
+	private MongoCollection<Document> mCol;
+
+	// constructor
+	public MongoEndpointArOutput(String uri, String col, String method) {
+
+		if (method.equalsIgnoreCase("upsert")) {
+			this.method = MongoMethod.UPSERT;
+		} else {
+			this.method = MongoMethod.INSERT;
+		}
+
+		MongoClientURI mURI = new MongoClientURI(uri);
+		String[] hostParts = mURI.getHosts().get(0).split(":");
+		String hostname = hostParts[0];
+		int port = Integer.parseInt(hostParts[1]);
+
+		this.mongoHost = hostname;
+		this.mongoPort = port;
+		this.dbName = mURI.getDatabase();
+		this.colName = col;
+	}
+
+	// constructor
+	public MongoEndpointArOutput(String host, int port, String db, String col, MongoMethod method) {
+		this.mongoHost = host;
+		this.mongoPort = port;
+		this.dbName = db;
+		this.colName = col;
+		this.method = method;
+	}
+
+	private void initMongo() {
+		this.mClient = new MongoClient(mongoHost, mongoPort);
+		this.mDB = mClient.getDatabase(dbName);
+		this.mCol = mDB.getCollection(colName);
+	}
+
+	/**
+	 * Initialize MongoDB remote connection
+	 */
+	@Override
+	public void open(int taskNumber, int numTasks) throws IOException {
+		// Configure mongo
+		initMongo();
+	}
+
+	/**
+	 * Store a MongoDB document record
+	 */
+	@Override
+	public void writeRecord(EndpointAR record) throws IOException {
+
+		// create document from record
+		Document doc = new Document("report", record.getReport()).append("date", record.getDateInt())
+				.append("name", record.getName()).append("service", record.getService()).append("supergroup", record.getGroup())
+				.append("availability", record.getA()).append("reliability", record.getR()).append("up", record.getUp())
+				.append("unknown", record.getUnknown()).append("down", record.getDown());
+
+		if (this.method == MongoMethod.UPSERT) {
+			Bson f = Filters.and(Filters.eq("report", record.getReport()), Filters.eq("date", record.getDateInt()),
+					Filters.eq("name", record.getName()), Filters.eq("service", record.getService()), Filters.eq("supergroup", record.getGroup()));
+
+			UpdateOptions opts = new UpdateOptions().upsert(true);
+
+			mCol.replaceOne(f, doc, opts);
+		} else {
+			mCol.insertOne(doc);
+		}
+	}
+
+	/**
+	 * Close MongoDB Connection
+	 */
+	@Override
+	public void close() throws IOException {
+		if (mClient != null) {
+			mClient.close();
+			mClient = null;
+			mDB = null;
+			mCol = null;
+		}
+	}
+
+	@Override
+	public void configure(Configuration arg0) {
+		// configure
+
+	}
+
+}

--- a/flink_jobs/batch_ar/src/main/java/argo/batch/PickEndpoints.java
+++ b/flink_jobs/batch_ar/src/main/java/argo/batch/PickEndpoints.java
@@ -14,7 +14,6 @@ import org.apache.flink.util.Collector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.esotericsoftware.minlog.Log;
 
 import argo.avro.GroupEndpoint;
 import argo.avro.GroupGroup;

--- a/flink_jobs/batch_ar/src/test/java/argo/batch/EndpointArTest.java
+++ b/flink_jobs/batch_ar/src/test/java/argo/batch/EndpointArTest.java
@@ -1,0 +1,104 @@
+package argo.batch;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.text.ParseException;
+import java.util.ArrayList;
+
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+
+import ops.DIntegrator;
+import ops.OpsManager;
+
+public class EndpointArTest {
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		// Assert that files are present
+		assertNotNull("Test file missing", ServiceArTest.class.getResource("/ops/EGI-algorithm.json"));
+	}
+
+	@Test
+	public void test() throws URISyntaxException, IOException, ParseException {
+		// Load operations manager
+		// Prepare Resource File
+		URL resJsonFile = ServiceArTest.class.getResource("/ops/EGI-algorithm.json");
+		File JsonFile = new File(resJsonFile.toURI());
+		// Instatiate class
+		OpsManager opsMgr = new OpsManager();
+		// Test loading file
+		opsMgr.loadJson(JsonFile);
+
+		// Assert the state strings to integer mappings ("OK"=>0, "MISSING"=>3
+		// etc)
+		assertEquals(0, opsMgr.getIntStatus("OK"));
+		assertEquals(1, opsMgr.getIntStatus("WARNING"));
+		assertEquals(3, opsMgr.getIntStatus("MISSING"));
+		assertEquals(4, opsMgr.getIntStatus("CRITICAL"));
+
+		// Add endpoint Timelines
+		int[] endpoint01s = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1,
+				1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+				1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+				1, 1, 1, 1, 1, 1, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+
+		int[] endpoint02s = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+
+		MonTimeline endp01 = new MonTimeline("SITEA", "CREAM-CE", "cream01.endpointA.foo", "");
+		endp01.setTimeline(endpoint01s);
+
+		MonTimeline endp02 = new MonTimeline("SITEA", "SRM", "srm01.endpointB.foo", "");
+		endp02.setTimeline(endpoint02s);
+
+		ArrayList<MonTimeline> endpDS = new ArrayList<MonTimeline>();
+		endpDS.add(endp01);
+	    endpDS.add(endp02);
+		
+	    ArrayList<EndpointAR> resultDS = new ArrayList<EndpointAR>();
+	    
+		String runDate = "2017-07-01";
+		String report = "reportFOO";
+		
+
+		
+		for (MonTimeline item : endpDS) {
+
+			DIntegrator dAR = new DIntegrator();
+			dAR.calculateAR(item.getTimeline(),opsMgr); 
+			
+			int runDateInt = Integer.parseInt(runDate.replace("-", ""));
+			
+			EndpointAR result = new EndpointAR(runDateInt,report,item.getHostname(),item.getService(),item.getGroup(),dAR.availability,dAR.reliability,dAR.up_f,dAR.unknown_f,dAR.down_f);
+			resultDS.add(result);
+		}
+		
+		String expEndpoint01 = "(20170701,reportFOO,cream01.endpointA.foo,CREAM-CE,SITEA,87.5,87.5,0.875,0.0,0.0)";
+		String expEndpoint02 = "(20170701,reportFOO,srm01.endpointB.foo,SRM,SITEA,100.0,100.0,1.0,0.0,0.0)";
+		
+		assertEquals("check cream-ce service results",expEndpoint01,resultDS.get(0).toString());
+		assertEquals("check srm service results",expEndpoint02,resultDS.get(1).toString());
+		
+
+	}
+
+}


### PR DESCRIPTION
### Task 
Add an extra layer of computations for generating a/r scores for endpoint timelines

### Implementation
- Add EndpointAR POJO object 
- Add CalcEndpointAR operator that accepts an endpoint timeline, calculates a/r and stores the result in an EndpointAR POJO
- Add MongoEndpointAR output operation for storing EndpointAR POJOs into a/r documents in 'endpoint_ar' mongodb collection.
- Refactor ArgoArBatch job class to include an extra step of computing and endpoint a/r data set from the already present group of endpoint timelines. Add a third mongodb destination for endpoint a/r results
- Update unit tests 