### PR TITLE
ARGO-1708 Extend event schema to include group item statuses

### DIFF
--- a/flink_jobs/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
+++ b/flink_jobs/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
@@ -343,7 +343,7 @@ public class AmsStreamStatus {
 			byte[] decoded64 = Base64.decodeBase64(data.getBytes("UTF-8"));
 			// Decode from avro
 			DatumReader<MetricData> avroReader = new SpecificDatumReader<MetricData>(MetricData.getClassSchema(),
-					MetricDataOld.getClassSchema(), new SpecificData());
+					MetricData.getClassSchema(), new SpecificData());
 			Decoder decoder = DecoderFactory.get().binaryDecoder(decoded64, null);
 			MetricData item;
 			

--- a/flink_jobs/stream_status/src/main/java/status/StatusEvent.java
+++ b/flink_jobs/stream_status/src/main/java/status/StatusEvent.java
@@ -28,7 +28,10 @@ public class StatusEvent{
 	private @SerializedName("status_service") String statusService[];
 	private @SerializedName("status_endpoint") String statusEndpoint[];
 	private @SerializedName("status_metric") String statusMetric[];
-	
+	// Record statuses of the other groups
+	private @SerializedName("group_statuses") String groupStatuses[];
+	private @SerializedName("group_endpoints") String groupEndpoints[];
+	private @SerializedName("group_services") String groupServices[];
 	
 	public StatusEvent() {
 		this.report  = "";
@@ -51,6 +54,9 @@ public class StatusEvent{
 		this.statusService = new String[0];
 		this.statusEndpoint = new String[0];
 		this.statusMetric = new String[0];
+		this.groupEndpoints = new String[0];
+		this.groupServices= new String[0];
+		this.groupStatuses = new String[0];
 		
 	}
 	
@@ -76,6 +82,10 @@ public class StatusEvent{
 		this.statusService = null;
 		this.statusEndpoint = null;
 		this.statusMetric = null;
+		this.groupEndpoints = null;
+		this.groupServices = null;
+		this.groupStatuses = null;
+
 		
 	}
 	
@@ -107,6 +117,31 @@ public class StatusEvent{
 	}
 	public void setStatusMetric(String[]  statusMetric ) {
 		this.statusMetric = statusMetric;
+	}
+	
+	public void setGroupStatuses(String[] groupStatuses) {
+		this.groupStatuses = groupStatuses;
+	}
+	
+	public void setGroupEndpoints(String[] groupEndpoints) {
+		this.groupEndpoints = groupEndpoints;
+	}
+	
+	
+	public void setGroupServices(String[] groupServices) {
+		this.groupServices = groupServices;
+	}
+	
+	public String[] getGroupStatuses() {
+		return this.groupStatuses;
+	}
+	
+	public String[] getGroupServices() {
+		return this.groupServices;
+	}
+	
+	public String[] getGroupEndpoints() {
+		return this.groupEndpoints;
 	}
 	
 	

--- a/flink_jobs/stream_status/src/test/java/status/StatusManagerTest.java
+++ b/flink_jobs/stream_status/src/test/java/status/StatusManagerTest.java
@@ -275,7 +275,7 @@ public class StatusManagerTest {
 		ArrayList<String> elist07 = sm.setStatus("UKI-LT2-IC-HEP", "CREAM-CE", "ceprod05.grid.hep.ph.ic.ac.uk", "emi.cream.CREAMCE-JobCancel",
 				"OK", "mon01.argo.eu", "2017-03-03T22:30:00Z","","");
 		
-	
+		
 		
 		assertTrue(elist07.size()==4);
 		j01 = getJSON(elist07.get(0));
@@ -283,7 +283,10 @@ public class StatusManagerTest {
 		j03 = getJSON(elist07.get(2));
 		j04 = getJSON(elist07.get(3));
 		
-		
+		// check if endpoint groups have been captured
+		assertTrue(j04.get("group_endpoints").toString().equals("[\"cetest01.grid.hep.ph.ic.ac.uk\",\"cetest02.grid.hep.ph.ic.ac.uk\",\"bdii.grid.hep.ph.ic.ac.uk\",\"ceprod08.grid.hep.ph.ic.ac.uk\",\"ceprod06.grid.hep.ph.ic.ac.uk\",\"ceprod07.grid.hep.ph.ic.ac.uk\",\"ceprod05.grid.hep.ph.ic.ac.uk\"]"));
+		assertTrue(j04.get("group_services").toString().equals("[\"ARC-CE\",\"ARC-CE\",\"Site-BDII\",\"CREAM-CE\",\"CREAM-CE\",\"CREAM-CE\",\"CREAM-CE\"]"));
+		assertTrue(j04.get("group_statuses").toString().equals("[\"CRITICAL\",\"CRITICAL\",\"OK\",\"CRITICAL\",\"CRITICAL\",\"CRITICAL\",\"OK\"]"));
 		assertTrue(j01.get("type").getAsString().equals("metric"));
 		assertTrue(j02.get("type").getAsString().equals("endpoint"));
 		assertTrue(j03.get("type").getAsString().equals("service"));


### PR DESCRIPTION
ARGO-1709 Extend status streaming job to gather status info for all group items

# Use case
In case of endpoint group events provide a complete summary for the statuses of all service endpoints belonging to the group 

# Implementation 
Extend flat status event schema with three additional aligned string arrays 
group_endpoints: is a string array with endpoint hostnames
group_services: is a string array with endpoint service types
group_statuses: is a string array with endpoint status values 
Info for each endpoint is stored inorder. For example info for 3rd endpoint is retrieved from group_endpoints[2], group_services[2] and group_statuses[2] 

Add a getGroupEndpointStatuses Method in status manager which:
  --> For a specific StatusNode that is of type `endpoint_group`
  ---> Iterates over service node children 
  ----> For each service node, iterates over endpoint node children 
  -------> captures endpoint information to an endpoint list 

### Also 
Removed auto failover to MetricData old schema because of issues with decoding new messages with tag data