### PR TITLE
ARGO-1786 Fix: mongo clean old endpoint_ar data

### DIFF
--- a/bin/ar_job_submit.py
+++ b/bin/ar_job_submit.py
@@ -125,7 +125,7 @@ def compose_command(config, args,  hdfs_commands):
     cmd_command.append(mongo_uri.geturl())
 
     if args.method == "insert":
-        argo_mongo_client = ArgoMongoClient(args, config, ["service_ar", "endpoint_group_ar"])
+        argo_mongo_client = ArgoMongoClient(args, config, ["endpoint_ar", "service_ar", "endpoint_group_ar"])
         argo_mongo_client.mongo_clean_ar(mongo_uri)
 
     # MongoDB method to be used when storing the results, either insert or upsert

--- a/bin/utils/argo_mongo.py
+++ b/bin/utils/argo_mongo.py
@@ -212,7 +212,7 @@ def main_clean(args=None):
 
 
     if args.job == "clean_ar":
-        argo_mongo_client = ArgoMongoClient(args, config, ["service_ar", "endpoint_group_ar"])
+        argo_mongo_client = ArgoMongoClient(args, config, ["endpoint_ar", "service_ar", "endpoint_group_ar"])
         argo_mongo_client.mongo_clean_ar(mongo_uri)
 
     elif args.job == "clean_status":


### PR DESCRIPTION
# Issue 
Recently added endpoint_ar data results were not handled in mongo clean scripts

# Fix
- Add endpoint_ar collection reference in mongo clean script
- Add endpoint_ar  collection reference when using mongo clean logic in ar job submission script