### PR TITLE
ARGO-1823 Alerts add synopsis list of metrics included in endpoint

### DIFF
--- a/flink_jobs/stream_status/src/main/java/status/StatusEvent.java
+++ b/flink_jobs/stream_status/src/main/java/status/StatusEvent.java
@@ -33,6 +33,11 @@ public class StatusEvent{
 	private @SerializedName("group_endpoints") String groupEndpoints[];
 	private @SerializedName("group_services") String groupServices[];
 	
+	// Record all statuses of endpoint's metrics
+	private @SerializedName("metric_statuses") String metricStatuses[];
+	private @SerializedName("metric_names") String metricNames[];
+	
+	
 	public StatusEvent() {
 		this.report  = "";
 		this.type = "";
@@ -57,6 +62,8 @@ public class StatusEvent{
 		this.groupEndpoints = new String[0];
 		this.groupServices= new String[0];
 		this.groupStatuses = new String[0];
+		this.metricStatuses = new String[0];
+		this.metricNames = new String[0];
 		
 	}
 	
@@ -85,6 +92,8 @@ public class StatusEvent{
 		this.groupEndpoints = null;
 		this.groupServices = null;
 		this.groupStatuses = null;
+		this.metricStatuses = null;
+		this.metricNames = null;
 
 		
 	}
@@ -144,7 +153,22 @@ public class StatusEvent{
 		return this.groupEndpoints;
 	}
 	
+	public String[] getMetricStatuses() {
+		return this.metricStatuses;
+	}
 	
+	public String[] getMetricNames() {
+		return this.metricNames;
+	}
+	
+
+	public void setMetricNames(String[] metricNames) {
+		this.metricNames = metricNames;
+	}
+	
+	public void setMetricStatuses(String[] metricStatuses) {
+		this.metricStatuses = metricStatuses;
+	}
 	
 	
 	public String getReport() { return report; }

--- a/flink_jobs/stream_status/src/test/java/status/StatusManagerTest.java
+++ b/flink_jobs/stream_status/src/test/java/status/StatusManagerTest.java
@@ -283,6 +283,10 @@ public class StatusManagerTest {
 		j03 = getJSON(elist07.get(2));
 		j04 = getJSON(elist07.get(3));
 		
+		// check list of metric statuses and metric names included in the endpoint
+		assertTrue(j02.get("metric_statuses").toString().equals("[\"OK\",\"OK\",\"OK\",\"OK\",\"OK\",\"OK\"]"));
+		assertTrue(j02.get("metric_names").toString().equals("[\"emi.cream.CREAMCE-ServiceInfo\",\"emi.cream.CREAMCE-JobCancel\",\"hr.srce.CREAMCE-CertLifetime\",\"eu.egi.CREAM-IGTF\",\"emi.cream.CREAMCE-JobPurge\",\"emi.cream.CREAMCE-AllowedSubmission\"]"));
+		
 		// check if endpoint groups have been captured
 		assertTrue(j04.get("group_endpoints").toString().equals("[\"cetest01.grid.hep.ph.ic.ac.uk\",\"cetest02.grid.hep.ph.ic.ac.uk\",\"bdii.grid.hep.ph.ic.ac.uk\",\"ceprod08.grid.hep.ph.ic.ac.uk\",\"ceprod06.grid.hep.ph.ic.ac.uk\",\"ceprod07.grid.hep.ph.ic.ac.uk\",\"ceprod05.grid.hep.ph.ic.ac.uk\"]"));
 		assertTrue(j04.get("group_services").toString().equals("[\"ARC-CE\",\"ARC-CE\",\"Site-BDII\",\"CREAM-CE\",\"CREAM-CE\",\"CREAM-CE\",\"CREAM-CE\"]"));


### PR DESCRIPTION
# Task
Provide a synopsis of metric statuses on each endpoint event  / notification

# Implementation
- Add two new array fields on the `status event` object that will hold the aligned lists of `metric names` and `metric statuses`
- Implement - in `StatusManager` - a `getMetricStatuses` function that receives an `Endpoint Node` and collects the list of metric statuses included. 
- Use `getMetricStatuses` function in main `setStatus` method when calculating the state of a known endpoint
- Update unit tests

