### PR TITLE
ARGO-1931 Use proxy options in scripts for ams and web-api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ python:
 script:
   - pip install -r ./bin/requirements.txt
   - pytest
-  - cd flink_jobs/ams_ingest_metric/ && travis_wait mvn test
-  - cd ../batch_ar && travis_wait mvn test
-  - cd ../batch_status && travis_wait mvn test
-  - cd ../stream_status && travis_wait mvn test
-  - cd ../ams_ingest_sync && travis_wait mvn test
+  - cd flink_jobs/ams_ingest_metric/ && travis_wait mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn test 
+  - cd ../batch_ar && travis_wait mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn test
+  - cd ../batch_status && travis_wait mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn test
+  - cd ../stream_status && travis_wait mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn test
+  - cd ../ams_ingest_sync && travis_wait mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn test
   
+ 

--- a/bin/utils/check_tenant.py
+++ b/bin/utils/check_tenant.py
@@ -204,15 +204,24 @@ def check_tenants(tenants, target_date, days_back, config):
     # ams client init
     ams_token = config.get("AMS", "access_token")
     ams_host = config.get("AMS", "endpoint").hostname
-    ams = ArgoAmsClient(ams_host, ams_token)
+    ams_proxy = config.get("AMS","proxy")
+    if ams_proxy:
+        ams_proxy = ams_proxy.geturl()
+    ams_verify = config.get("AMS","verify")
+
+    ams = ArgoAmsClient(ams_host, ams_token, ams_verify, ams_proxy)
     log.info("connecting to AMS: {}".format(ams_host))
 
     # Upload tenant statuses in argo web api 
     api_endpoint = config.get("API","endpoint").netloc
     api_token = config.get("API","access_token")
+    api_proxy = config.get("API","proxy")
+    if api_proxy:
+        api_proxy = api_proxy.geturl()
+    api_verify = config.get("API","verify")
 
     # Get tenant uuids 
-    tenant_uuids = get_tenant_uuids(api_endpoint, api_token)
+    tenant_uuids = get_tenant_uuids(api_endpoint, api_token, api_verify, api_proxy)
     if not tenant_uuids: 
         log.error("Without tenant uuids service is unable to check and upload tenant status")
         sys.exit(1)
@@ -235,7 +244,7 @@ def check_tenants(tenants, target_date, days_back, config):
         log.info("Status for tenant[{}] = {}".format(tenant,json.dumps(status_tenant)))
         # Upload tenant status to argo-web-api
         complete_status.append(status_tenant)
-        upload_tenant_status(api_endpoint,api_token,tenant,tenant_uuids[tenant],status_tenant)
+        upload_tenant_status(api_endpoint,api_token,tenant,tenant_uuids[tenant],status_tenant,api_verify,api_proxy)
         
     return complete_status
 
@@ -280,12 +289,14 @@ def run_tenant_check(args):
 
    
 
-def get_tenant_uuids(api_endpoint, api_token):
+def get_tenant_uuids(api_endpoint, api_token, verify=False, http_proxy_url=None):
     """Get tenant uuids from remote argo-web-api endpoint
     
     Args:
         api_endpoint (str.): hostname of the remote argo-web-api endpoint
         api_token (str.): access token for the remote argo-web-api endpoint
+        verify (boolean): flag if the remote web api host should be verified
+        http_proxy_url (str.): optional url for local http proxy to be used
     
     Returns:
         dict.: dictionary with mappings of tenant names to tenant uuidss
@@ -294,12 +305,15 @@ def get_tenant_uuids(api_endpoint, api_token):
     log.info("Retrieving tenant uuids from api: {}".format(api_endpoint))
     result = dict()
     url = "https://{}/api/v2/admin/tenants".format(api_endpoint)
+    proxies = None
+    if http_proxy_url:
+        proxies = {'http':http_proxy_url,'https':http_proxy_url}
     headers = dict()
     headers.update({
         'Accept': 'application/json',
         'x-api-key': api_token
     })
-    r = requests.get(url, headers=headers, verify=False)
+    r = requests.get(url, headers=headers, verify=verify, proxies=proxies)
 
     if 200 == r.status_code:
        
@@ -313,7 +327,7 @@ def get_tenant_uuids(api_endpoint, api_token):
         return result
 
     
-def upload_tenant_status(api_endpoint, api_token, tenant, tenant_id, tenant_status):
+def upload_tenant_status(api_endpoint, api_token, tenant, tenant_id, tenant_status, verify=False, http_proxy_url=None):
     """Uploads tenant's status to a remote argo-web-api endpoint
     
     Args:
@@ -322,6 +336,8 @@ def upload_tenant_status(api_endpoint, api_token, tenant, tenant_id, tenant_stat
         tenant (str.): tenant name
         tenant_id (str.): tenant uuid
         tenant_status (obj.): json representation of tenant's status report
+        verify (boolean): flag if the remote web api host should be verified
+        http_proxy_url (str.): optional url for local http proxy to be used
     
     Returns:
         bool: true if upload is successfull
@@ -334,7 +350,10 @@ def upload_tenant_status(api_endpoint, api_token, tenant, tenant_id, tenant_stat
         'Accept': 'application/json',
         'x-api-key': api_token
     })
-    r = requests.put(url, headers=headers, data=json.dumps(tenant_status), verify=False)
+    proxies = None
+    if http_proxy_url:
+        proxies={'http':http_proxy_url, 'https':http_proxy_url}
+    r = requests.put(url, headers=headers, data=json.dumps(tenant_status), verify=verify, proxies=proxies)
     if 200 == r.status_code:
         log.info("Tenant's {} status upload succesfull to {}".format(tenant, api_endpoint))
         return True

--- a/bin/utils/update_profiles.py
+++ b/bin/utils/update_profiles.py
@@ -23,14 +23,22 @@ class ArgoApiClient:
     It connects to an argo-web-api host and retrieves profile information per tenant and report
     """
 
-    def __init__(self, host, tenant_keys):
+    def __init__(self, host, tenant_keys, verify=False, http_proxy_url=None):
         """
         Initialize ArgoApiClient which is used to retrieve profiles from argo-web-api
         Args:
             host: str. argo-web-api host
             tenant_keys: dict. a dictionary of {tenant: api_token} entries
+            verify (boolean): flag if the remote web api host should be verified
+            http_proxy_url (str.): optional url for local http proxy to be used
         """
         self.host = host
+        self.verify = verify
+        if http_proxy_url:
+            self.proxies = {'http': http_proxy_url, 'https': http_proxy_url}
+        else:
+            self.proxies = None
+
         self.paths = dict()
         self.tenant_keys = tenant_keys
         self.paths.update({
@@ -73,7 +81,8 @@ class ArgoApiClient:
             'Accept': 'application/json',
             'x-api-key': self.tenant_keys[tenant]
         })
-        r = requests.get(url, headers=headers, verify=False)
+        r = requests.get(url, headers=headers,
+                         verify=self.verify, proxies=self.proxies)
 
         if 200 == r.status_code:
             return json.loads(r.text)["data"]
@@ -95,11 +104,10 @@ class ArgoApiClient:
         for item in tenants:
             for user in item["users"]:
                 if user["name"].startswith("argo_engine_") and user["api_key"]:
-                    print len(user["api_key"])
+
                     tenant_keys[item["info"]["name"]] = user["api_key"]
         return tenant_keys
 
-    @staticmethod
     def get_admin_resource(token, url):
         """
         Returns an argo-web-api resource by tenant and url
@@ -116,7 +124,8 @@ class ArgoApiClient:
             'Accept': 'application/json',
             'x-api-key': token
         })
-        r = requests.get(url, headers=headers, verify=False)
+        r = requests.get(url, headers=headers,
+                         verify=self.verify, proxies=self.proxies)
 
         if 200 == r.status_code:
             return json.loads(r.text)["data"]
@@ -142,7 +151,8 @@ class ArgoApiClient:
         item_uuid = self.find_profile_uuid(tenant, report, profile_type)
         if item_uuid is None:
             return None
-        profiles = self.get_resource(tenant, self.get_url(profile_type, item_uuid))
+        profiles = self.get_resource(
+            tenant, self.get_url(profile_type, item_uuid))
         if profiles is not None:
             return profiles[0]
 
@@ -204,13 +214,13 @@ class ArgoApiClient:
         Returns:
 
         """
-	if profile_type is "aggregations":
-	   profile_type = "aggregation"
-        	
+        if profile_type is "aggregations":
+            profile_type = "aggregation"
+
         report = self.get_report(tenant, self.find_report_uuid(tenant, report))
         if profile_type == "reports":
-		return report["id"]
-	for profile in report["profiles"]:
+            return report["id"]
+        for profile in report["profiles"]:
             if profile["type"] == profile_type:
                 return profile["id"]
 
@@ -320,7 +330,8 @@ class ArgoProfileManager:
         namenode = config.get("HDFS", "namenode")
         hdfs_user = config.get("HDFS", "user")
         full_path = config.get("HDFS", "path_sync")
-        full_path = full_path.partial_fill(namenode=namenode.geturl(), hdfs_user=hdfs_user)
+        full_path = full_path.partial_fill(
+            namenode=namenode.geturl(), hdfs_user=hdfs_user)
 
         short_path = urlparse(full_path).path
 
@@ -330,10 +341,13 @@ class ArgoProfileManager:
         for tenant in tenant_list:
             tenant_key = config.get("API", tenant + "_key")
             tenant_keys[tenant] = tenant_key
-        
-	print namenode.hostname, namenode.port, short_path 
+
+        ams_proxy = config.get("API","proxy")
+        if ams_proxy:
+            ams_proxy = ams_proxy.geturl()
         self.hdfs = HdfsReader(namenode.hostname, namenode.port, short_path)
-        self.api = ArgoApiClient(config.get("API", "endpoint").netloc, tenant_keys)
+        self.api = ArgoApiClient(config.get("API", "endpoint").netloc, tenant_keys, config.get(
+            "API", "verify"),ams_proxy)
 
     def profile_update_check(self, tenant, report, profile_type):
         """
@@ -347,16 +361,17 @@ class ArgoProfileManager:
 
         prof_api = self.api.get_profile(tenant, report, profile_type)
         if prof_api is None:
-            log.info("profile type %s doesn't exist in report --skipping", profile_type)
+            log.info(
+                "profile type %s doesn't exist in report --skipping", profile_type)
             return
 
         log.info("retrieved %s profile(api): %s", profile_type, prof_api)
-	
+
         prof_hdfs, exists = self.hdfs.cat(tenant, report, profile_type)
-	
-           
+
         if exists:
-            log.info("retrieved %s profile(hdfs): %s ", profile_type, prof_hdfs)
+            log.info("retrieved %s profile(hdfs): %s ",
+                     profile_type, prof_hdfs)
             prof_update = prof_api != prof_hdfs
 
             if prof_update:
@@ -366,11 +381,13 @@ class ArgoProfileManager:
         else:
             # doesn't exist so it should be uploaded
             prof_update = True
-            log.info("%s profile doesn't exist in hdfs, should be uploaded", profile_type)
+            log.info(
+                "%s profile doesn't exist in hdfs, should be uploaded", profile_type)
 
         # Upload if it's deemed to be uploaded
         if prof_update:
-            self.upload_profile_to_hdfs(tenant, report, profile_type, prof_api, exists)
+            self.upload_profile_to_hdfs(
+                tenant, report, profile_type, prof_api, exists)
 
     def upload_profile_to_hdfs(self, tenant, report, profile_type, profile, exists):
         """
@@ -391,7 +408,8 @@ class ArgoProfileManager:
         if exists:
             is_removed = self.hdfs.rem(tenant, report, profile_type)
             if not is_removed:
-                log.error("Could not remove old %s profile from hdfs", profile_type)
+                log.error(
+                    "Could not remove old %s profile from hdfs", profile_type)
                 return
 
         # If all ok continue with uploading the new file to hdfs
@@ -403,29 +421,33 @@ class ArgoProfileManager:
         local_path = "/tmp/" + temp_fn
         with open(local_path, 'w') as outfile:
             json.dump(profile, outfile)
-        hdfs_host = self.cfg.get("HDFS","namenode").hostname
+        hdfs_host = self.cfg.get("HDFS", "namenode").hostname
         hdfs_path = self.hdfs.gen_profile_path(tenant, report, profile_type)
-        status = subprocess.check_call([hdfs_write_bin, hdfs_write_cmd, local_path, hdfs_path])
+        status = subprocess.check_call(
+            [hdfs_write_bin, hdfs_write_cmd, local_path, hdfs_path])
 
         if status == 0:
-            log.info("File uploaded successfully to hdfs host: %s path: %s", hdfs_host, hdfs_path)
+            log.info(
+                "File uploaded successfully to hdfs host: %s path: %s", hdfs_host, hdfs_path)
             return True
         else:
-            log.error("File uploaded unsuccessful to hdfs host: %s path: %s", hdfs_host, hdfs_path)
+            log.error(
+                "File uploaded unsuccessful to hdfs host: %s path: %s", hdfs_host, hdfs_path)
             return False
 
     def upload_tenant_reports_cfg(self, tenant):
         reports = self.api.get_reports(tenant)
         report_name_list = []
         for report in reports:
-           
+
             # double check if indeed report belongs to tenant
             if report["tenant"] == tenant:
                 report_name = report["info"]["name"]
                 report_name_list.append(report_name)
                 report_uuid = report["id"]
                 # Set report in configuration
-                self.cfg.set("TENANTS:"+tenant, "report_" + report_name, report_uuid)
+                self.cfg.set("TENANTS:"+tenant, "report_" +
+                             report_name, report_uuid)
 
         # update tenant's report name list
         self.cfg.set("TENANTS:"+tenant, "reports", ",".join(report_name_list))
@@ -437,9 +459,9 @@ class ArgoProfileManager:
         """
         token = self.cfg.get("API", "access_token")
         tenant_keys = self.api.get_tenants(token)
-        self.api.tenant_keys=tenant_keys
+        self.api.tenant_keys = tenant_keys
         tenant_names = ",".join(tenant_keys.keys())
-       
+
         self.cfg.set("API", "tenants", tenant_names)
 
         # For each tenant update also it's report list
@@ -451,36 +473,34 @@ class ArgoProfileManager:
 
     def upload_tenant_defaults(self, tenant):
         # check
-        section_tenant = "TENANTS:"+ tenant
-        section_metric = "TENANTS:"+ tenant + ":ingest-metric"
-        mongo_endpoint = self.cfg.get("MONGO","endpoint").geturl()
-        mongo_uri = self.cfg.get_default(section_tenant,"mongo_uri").fill(mongo_endpoint=mongo_endpoint,tenant=tenant).geturl()
-        hdfs_user = self.cfg.get("HDFS","user")
-        namenode = self.cfg.get("HDFS","namenode").netloc
-        hdfs_check = self.cfg.get_default(section_metric,"checkpoint_path").fill(namenode=namenode,hdfs_user=hdfs_user,tenant=tenant)
-       
-        
-        self.cfg.get("MONGO","endpoint")
-       
-        self.cfg.set(section_tenant,"mongo_uri",mongo_uri)
-        self.cfg.set_default(section_tenant,"mongo_method")
-        
-        
-        self.cfg.set_default(section_metric,"ams_interval")
-        self.cfg.set_default(section_metric,"ams_batch")
-        self.cfg.set(section_metric,"checkpoint_path",hdfs_check.geturl())
-        self.cfg.set_default(section_metric,"checkpoint_interval")
-        section_sync = "TENANTS:"+ tenant + ":ingest-sync"
-        
-        self.cfg.set_default(section_sync,"ams_interval")
-        self.cfg.set_default(section_sync,"ams_batch")
-        section_stream = "TENANTS:"+ tenant + ":stream-status"
-        
-        self.cfg.set_default(section_stream,"ams_sub_sync")
-        self.cfg.set_default(section_stream,"ams_interval")
-        self.cfg.set_default(section_stream,"ams_batch")
-        
-        
+        section_tenant = "TENANTS:" + tenant
+        section_metric = "TENANTS:" + tenant + ":ingest-metric"
+        mongo_endpoint = self.cfg.get("MONGO", "endpoint").geturl()
+        mongo_uri = self.cfg.get_default(section_tenant, "mongo_uri").fill(
+            mongo_endpoint=mongo_endpoint, tenant=tenant).geturl()
+        hdfs_user = self.cfg.get("HDFS", "user")
+        namenode = self.cfg.get("HDFS", "namenode").netloc
+        hdfs_check = self.cfg.get_default(section_metric, "checkpoint_path").fill(
+            namenode=namenode, hdfs_user=hdfs_user, tenant=tenant)
+
+        self.cfg.get("MONGO", "endpoint")
+
+        self.cfg.set(section_tenant, "mongo_uri", mongo_uri)
+        self.cfg.set_default(section_tenant, "mongo_method")
+
+        self.cfg.set_default(section_metric, "ams_interval")
+        self.cfg.set_default(section_metric, "ams_batch")
+        self.cfg.set(section_metric, "checkpoint_path", hdfs_check.geturl())
+        self.cfg.set_default(section_metric, "checkpoint_interval")
+        section_sync = "TENANTS:" + tenant + ":ingest-sync"
+
+        self.cfg.set_default(section_sync, "ams_interval")
+        self.cfg.set_default(section_sync, "ams_batch")
+        section_stream = "TENANTS:" + tenant + ":stream-status"
+
+        self.cfg.set_default(section_stream, "ams_sub_sync")
+        self.cfg.set_default(section_stream, "ams_interval")
+        self.cfg.set_default(section_stream, "ams_batch")
 
     def save_config(self, file_path):
         """
@@ -514,17 +534,17 @@ def run_profile_update(args):
 
     if args.tenant is not None:
         # check for the following profile types
-        profile_type_checklist = ["operations", "aggregations", "reports", "thresholds", "recomputations"]
-	reports = []
-	if args.report is not None:
-	    reports.append(args.report)
-	else:
-	    reports = config.get("TENANTS:"+args.tenant,"reports")
+        profile_type_checklist = [
+            "operations", "aggregations", "reports", "thresholds", "recomputations"]
+        reports = []
+        if args.report is not None:
+            reports.append(args.report)
+        else:
+            reports = config.get("TENANTS:"+args.tenant, "reports")
 
-	for report in reports:
-	    for profile_type in profile_type_checklist:
-	        argo.profile_update_check(args.tenant, report, profile_type)
-            
+        for report in reports:
+            for profile_type in profile_type_checklist:
+                argo.profile_update_check(args.tenant, report, profile_type)
 
     else:
         argo.upload_tenants_cfg()

--- a/conf/config.schema.json
+++ b/conf/config.schema.json
@@ -73,6 +73,18 @@
       "desc": "list of tenants",
       "type": "list"
     },
+    "proxy": {
+        "desc": "ams proxy to be used",
+        "type": "uri",
+        "optional": true,
+        "default": "http://localhost:3128"
+      },
+      "verify":{
+          "desc":"ssl verify ams endpoint",
+          "type":"bool",
+          "optional": true,
+          "default": "true"
+    },
     "~_key": {
       "~": "tenants",
       "desc": "tenants key",


### PR DESCRIPTION
# Goal 
Use proxy options for ams and argo-web-api when node is in private network

# Implementation 
- Add proxy and verify options in AMS and API configuration sections 
- Use proxy and verify cfg options in all utility scripts that make http calls to argo-web-api and argo messaging