### PR TITLE
ARGO-2006 Streaming status job: fix issue with decomissioned topology…

### DIFF
--- a/flink_jobs/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
+++ b/flink_jobs/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
@@ -571,8 +571,17 @@ public class AmsStreamStatus {
 							egpTrim.add(egpItem);
 						}
 					}
-					sm.egp = new EndpointGroupManagerV2();
-					sm.egp.loadFromList(egpTrim);
+					// load next topology into a temporary endpoint group manager
+					EndpointGroupManagerV2 egpNext = new EndpointGroupManagerV2();
+					egpNext.loadFromList(egpTrim);
+					
+					// Use existing topology manager inside status manager to make a comparison
+					// with the new topology stored in the temp endpoint group manager
+					// update topology also sets the next topology manager as status manager current 
+					// topology manager only after removal of decomissioned items
+					sm.updateTopology(egpNext);
+					
+					
 				} else if (sType.equals("downtimes") && attr.containsKey("partition_date")) {
 					String pDate = attr.get("partition_date");
 					ArrayList<Downtime> downList = SyncParse.parseDowntimes(decoded64);

--- a/flink_jobs/stream_status/src/main/java/status/StatusManager.java
+++ b/flink_jobs/stream_status/src/main/java/status/StatusManager.java
@@ -201,9 +201,13 @@ public class StatusManager {
 		// find a list of lost items to remove them from status tree
 		ArrayList<String> lostItems = this.egp.compareToBeRemoved(egpNext);
 		
+		// removal performed
 		for (String item : lostItems) {
 			removeEndpoint(item);
 		}
+		
+		// set the next topology as status manager's current topology
+		this.egp = egpNext;
 		
 	}
 


### PR DESCRIPTION
… endpoints

## Issue 
Decomissioned Feature didn't work correctly in streaming job operators

## Fix 
- [x] Refactor Status Manager `updateTopology()` method to replace current topology manager with next topology manager only after decomissioned item removal 
- [x] Refactor coMap operator to create a temporary toplogy manager when a new avro file is received and use. Use temp topology manager as input to `updateTopology()` method. This method checks the existing topology manager against the new topology manager and finds which items are missing (thus are decomissioned). It removes all these items from the StatusManager state tree. Then it replaces StatusManager current topology manager with the new one 