### PR TITLE
ARGO-2069 Use historic version of argo-web-api profiles in a/r job su…

### DIFF
--- a/bin/ar_job_submit.py
+++ b/bin/ar_job_submit.py
@@ -19,14 +19,14 @@ log = logging.getLogger(__name__)
 
 def compose_hdfs_commands(year, month, day, args, config):
     """Checks hdfs for available files back in time and prepares the correct hdfs arguments
-    
+
     Args:
         year (int): year part of the date to check for hdfs files
         month (int): month part of the date to check for hdfs files
         day (int): day part of the date to check for hdfs files
         config (obj.): argo configuration object
-       
-    
+
+
     Returns:
         list: A list of all hdfs arguments to be used in flink job submission
     """
@@ -40,11 +40,13 @@ def compose_hdfs_commands(year, month, day, args, config):
     hdfs_user = config.get("HDFS", "user")
     tenant = args.tenant
     hdfs_sync = config.get("HDFS", "path_sync")
-    hdfs_sync = hdfs_sync.fill(namenode=namenode.geturl(), hdfs_user=hdfs_user, tenant=tenant).geturl()
+    hdfs_sync = hdfs_sync.fill(namenode=namenode.geturl(
+    ), hdfs_user=hdfs_user, tenant=tenant).geturl()
 
     hdfs_metric = config.get("HDFS", "path_metric")
 
-    hdfs_metric = hdfs_metric.fill(namenode=namenode.geturl(), hdfs_user=hdfs_user, tenant=tenant).geturl()
+    hdfs_metric = hdfs_metric.fill(
+        namenode=namenode.geturl(), hdfs_user=hdfs_user, tenant=tenant).geturl()
 
     # dictionary holding all the commands with their respective arguments' name
     hdfs_commands = dict()
@@ -54,30 +56,65 @@ def compose_hdfs_commands(year, month, day, args, config):
         hdfs_metric + "/" + str(datetime.date(year, month, day) - datetime.timedelta(1)), client)
 
     # file location of target day's metric data (local or hdfs)
-    hdfs_commands["--mdata"] = hdfs_check_path(hdfs_metric + "/" + args.date, client)
+    hdfs_commands["--mdata"] = hdfs_check_path(
+        hdfs_metric + "/" + args.date, client)
 
     # file location of report configuration json file (local or hdfs)
-    hdfs_commands["--conf"] = hdfs_check_path(hdfs_sync + "/" + args.tenant+"_"+args.report+"_cfg.json", client)
+    hdfs_commands["--conf"] = hdfs_check_path(
+        hdfs_sync + "/" + args.tenant+"_"+args.report+"_cfg.json", client)
 
-    # file location of metric profile (local or hdfs)
-    hdfs_commands["--mps"] = date_rollback(
-        hdfs_sync + "/" + args.report + "/" + "metric_profile_" + "{{date}}" + ".avro", year, month, day, config,
-        client)
+    # if profile historic mode is used reference profiles by date
+    if args.historic:
+        # file location of historic operations profile (local or hdfs)
+        hdfs_commands["--ops"] = hdfs_check_path(
+            hdfs_sync+"/"+args.tenant+"_ops_" + args.date + ".json",  client)
 
-    # file location of operations profile (local or hdfs)
-    hdfs_commands["--ops"] = hdfs_check_path(hdfs_sync+"/"+args.tenant+"_ops.json",  client)
+        # file location of historic aggregations profile (local or hdfs)
+        hdfs_commands["--apr"] = hdfs_check_path(
+            hdfs_sync+"/"+args.tenant+"_"+args.report+"_ap_" + args.date + ".json", client)
 
-    # file location of aggregations profile (local or hdfs)
-    hdfs_commands["--apr"] = hdfs_check_path(hdfs_sync+"/"+args.tenant+"_"+args.report+"_ap.json", client)
+        if args.thresholds:
+            # file location of thresholds rules file (local or hdfs)
+            hdfs_commands["--thr"] = hdfs_check_path(os.path.join(hdfs_sync, "".join(
+                [args.tenant, "_", args.report, "_thresholds_", args.date, ".json"])), client)
 
-    if args.thresholds:
-        # file location of thresholds rules file (local or hdfs)
-        hdfs_commands["--thr"] = hdfs_check_path(
-            os.path.join(hdfs_sync, "".join([args.tenant, "_", args.report, "_thresholds.json"])), client)
+        # TODO: Don't Use YET metric profiles from api in json form until ar computation jobs are updated
+        # accordingly - After that uncomment the following
+        # #file location of historic metric profile (local or hdfs) which is in json format
+        # hdfs_commands["--mps"] = hdfs_check_path(
+        #     hdfs_sync+"/"+args.tenant+"_"+args.report+"_metric_" + args.date + ".json", client)
+
+        # TODO: when compute jobs are updated to use metric profiles in json format comment the following:
+        # file location of metric profile (local or hdfs)
+        hdfs_commands["--mps"] = date_rollback(
+            hdfs_sync + "/" + args.report + "/" + "metric_profile_" +
+            "{{date}}" + ".avro", year, month, day, config,
+            client)
+    else:
+
+        # file location of operations profile (local or hdfs)
+        hdfs_commands["--ops"] = hdfs_check_path(
+            hdfs_sync+"/"+args.tenant+"_ops.json",  client)
+
+        # file location of aggregations profile (local or hdfs)
+        hdfs_commands["--apr"] = hdfs_check_path(
+            hdfs_sync+"/"+args.tenant+"_"+args.report+"_ap.json", client)
+
+        if args.thresholds:
+            # file location of thresholds rules file (local or hdfs)
+            hdfs_commands["--thr"] = hdfs_check_path(os.path.join(hdfs_sync, "".join(
+                [args.tenant, "_", args.report, "_thresholds.json"])), client)
+
+        # file location of metric profile (local or hdfs)
+        hdfs_commands["--mps"] = date_rollback(
+            hdfs_sync + "/" + args.report + "/" + "metric_profile_" +
+            "{{date}}" + ".avro", year, month, day, config,
+            client)
 
     #  file location of endpoint group topology file (local or hdfs)
     hdfs_commands["-egp"] = date_rollback(
-        hdfs_sync + "/" + args.report + "/" + "group_endpoints_" + "{{date}}" + ".avro", year, month, day, config,
+        hdfs_sync + "/" + args.report + "/" + "group_endpoints_" +
+        "{{date}}" + ".avro", year, month, day, config,
         client)
 
     # file location of group of groups topology file (local or hdfs)
@@ -97,9 +134,11 @@ def compose_hdfs_commands(year, month, day, args, config):
     # recomputation lies in the hdfs in the form of
     # /sync/recomp_TENANTNAME_ReportName_2018-08-02.json
     if client.test(urlparse(hdfs_sync+"/recomp_"+args.tenant+"_"+args.report+"_"+args.date+".json").path, exists=True):
-        hdfs_commands["--rec"] = hdfs_sync+"/recomp_"+args.tenant+"_"+args.report+"_"+args.date+".json"
+        hdfs_commands["--rec"] = hdfs_sync+"/recomp_" + \
+            args.tenant+"_"+args.report+"_"+args.date+".json"
     else:
-        hdfs_commands["--rec"] = hdfs_check_path(hdfs_sync+"/recomp.json", client)
+        hdfs_commands["--rec"] = hdfs_check_path(
+            hdfs_sync+"/recomp.json", client)
 
     return hdfs_commands
 
@@ -107,14 +146,14 @@ def compose_hdfs_commands(year, month, day, args, config):
 def compose_command(config, args,  hdfs_commands, dry_run=False):
     """Composes a command line execution string for submitting a flink job. Also calls mongodb
        clean up procedure before composing the command
-    
+
     Args:
         config (obj.): argo configuration object
         args (dict): command line arguments of this script
         hdfs_commands (list): a list of hdfs related arguments to be passed in flink job    
         dry_run (bool, optional): signifies a dry-run execution context, if yes no mongodb clean-up is perfomed. 
                                   Defaults to False.
-    
+
     Returns:
         list: A list of all command line arguments for performing the flink job submission
     """
@@ -145,12 +184,14 @@ def compose_command(config, args,  hdfs_commands, dry_run=False):
     #  MongoDB uri for outputting the results to (e.g. mongodb://localhost:21017/example_db)
     cmd_command.append("--mongo.uri")
     group_tenant = "TENANTS:"+args.tenant
-    mongo_endpoint = config.get("MONGO","endpoint").geturl()
-    mongo_uri = config.get(group_tenant, "mongo_uri").fill(mongo_endpoint=mongo_endpoint, tenant=args.tenant)
+    mongo_endpoint = config.get("MONGO", "endpoint").geturl()
+    mongo_uri = config.get(group_tenant, "mongo_uri").fill(
+        mongo_endpoint=mongo_endpoint, tenant=args.tenant)
     cmd_command.append(mongo_uri.geturl())
 
     if args.method == "insert":
-        argo_mongo_client = ArgoMongoClient(args, config, ["endpoint_ar", "service_ar", "endpoint_group_ar"])
+        argo_mongo_client = ArgoMongoClient(
+            args, config, ["endpoint_ar", "service_ar", "endpoint_group_ar"])
         argo_mongo_client.mongo_clean_ar(mongo_uri, dry_run)
 
     # MongoDB method to be used when storing the results, either insert or upsert
@@ -198,15 +239,20 @@ def main(args=None):
         log.info("Tenant: "+args.tenant+" doesn't exist.")
         sys.exit(1)
 
-    # check and upload recomputations 
+    # check and upload recomputations
     upload_recomputations(args.tenant, args.report, args.date, config)
 
     # optional call to update profiles
     if args.profile_check:
+        dateParam = None
+        if args.historic:
+            dateParam = args.date
         profile_mgr = ArgoProfileManager(config)
-        profile_type_checklist = ["operations", "aggregations", "reports", "thresholds"]
+        profile_type_checklist = [
+            "operations", "aggregations", "reports", "thresholds", "metrics"]
         for profile_type in profile_type_checklist:
-            profile_mgr.profile_update_check(args.tenant, args.report, profile_type)
+            profile_mgr.profile_update_check(
+                args.tenant, args.report, profile_type, dateParam)
 
     # dictionary containing the argument's name and the command assosciated with each name
     hdfs_commands = compose_hdfs_commands(year, month, day, args, config)
@@ -234,10 +280,12 @@ if __name__ == "__main__":
         "-u", "--sudo", help="Run the submition as superuser",  action="store_true")
     parser.add_argument("--profile-check", help="check if profiles are up to date before running job",
                         dest="profile_check", action="store_true")
+    parser.add_argument("--historic-profiles", help="use historic profiles",
+                        dest="historic", action="store_true")
     parser.add_argument("--thresholds", help="check and use threshold rule file if exists",
                         dest="thresholds", action="store_true")
-    parser.add_argument("--dry-run",help="Runs in test mode without actually submitting the job",
-        action="store_true", dest="dry_run")
+    parser.add_argument("--dry-run", help="Runs in test mode without actually submitting the job",
+                        action="store_true", dest="dry_run")
 
     # Pass the arguments to main method
     sys.exit(main(parser.parse_args()))

--- a/bin/utils/test_update_profiles.py
+++ b/bin/utils/test_update_profiles.py
@@ -13,9 +13,9 @@ class TestClass(unittest.TestCase):
 
         test_cases = [
             {"tenant": "TA", "report": "Critical", "profile_type": "operations",
-             "expected": "/user/foo/argo/tenants/TA/sync/TA_ops.json"},
+             "expected": "/user/foo/argo/tenants/TA/sync/TA_Critical_ops.json"},
             {"tenant": "TA", "report": "Super-Critical", "profile_type": "operations",
-             "expected": "/user/foo/argo/tenants/TA/sync/TA_ops.json"},
+             "expected": "/user/foo/argo/tenants/TA/sync/TA_Super-Critical_ops.json"},
             {"tenant": "TA", "report": "Critical", "profile_type": "reports",
              "expected": "/user/foo/argo/tenants/TA/sync/TA_Critical_cfg.json"},
             {"tenant": "TA", "report": "Critical", "profile_type": "aggregations",
@@ -27,12 +27,43 @@ class TestClass(unittest.TestCase):
             {"tenant": "TB", "report": "Critical", "profile_type": "aggregations",
              "expected": "/user/foo/argo/tenants/TB/sync/TB_Critical_ap.json"},
             {"tenant": "TB", "report": "Critical", "profile_type": "reports",
-             "expected": "/user/foo/argo/tenants/TB/sync/TB_Critical_cfg.json"}
+             "expected": "/user/foo/argo/tenants/TB/sync/TB_Critical_cfg.json"},
+            {"tenant": "TB", "report": "Critical", "profile_type": "metrics",
+             "expected": "/user/foo/argo/tenants/TB/sync/TB_Critical_metrics.json"}
         ]
 
         for test_case in test_cases:
-            actual = hdfs.gen_profile_path(test_case["tenant"], test_case["report"], test_case["profile_type"])
+            actual = hdfs.gen_profile_path(
+                test_case["tenant"], test_case["report"], test_case["profile_type"])
             expected = test_case["expected"]
+            self.assertEquals(expected, actual)
+
+        # Test with dates
+        test_cases_dates = [
+            {"tenant": "TA", "report": "Critical", "profile_type": "operations", "date": "2019-12-11",
+             "expected": "/user/foo/argo/tenants/TA/sync/TA_Critical_ops_2019-12-11.json"},
+            {"tenant": "TA", "report": "Super-Critical", "profile_type": "operations", "date": "2019-10-04",
+             "expected": "/user/foo/argo/tenants/TA/sync/TA_Super-Critical_ops_2019-10-04.json"},
+            {"tenant": "TA", "report": "Critical", "profile_type": "reports", "date": "2019-05-11",
+             "expected": "/user/foo/argo/tenants/TA/sync/TA_Critical_cfg.json"},
+            {"tenant": "TA", "report": "Critical", "profile_type": "aggregations", "date": "2019-06-06",
+             "expected": "/user/foo/argo/tenants/TA/sync/TA_Critical_ap_2019-06-06.json"},
+            {"tenant": "TA", "report": "Crit", "profile_type": "reports", "date": "2019-07-04",
+             "expected": "/user/foo/argo/tenants/TA/sync/TA_Crit_cfg.json"},
+            {"tenant": "TA", "report": "Super-Critical", "profile_type": "aggregations", "date": "2019-03-04",
+             "expected": "/user/foo/argo/tenants/TA/sync/TA_Super-Critical_ap_2019-03-04.json"},
+            {"tenant": "TB", "report": "Critical", "profile_type": "aggregations", "date": "2019-01-04",
+             "expected": "/user/foo/argo/tenants/TB/sync/TB_Critical_ap_2019-01-04.json"},
+            {"tenant": "TB", "report": "Critical", "profile_type": "reports", "date": "2019-01-05",
+             "expected": "/user/foo/argo/tenants/TB/sync/TB_Critical_cfg.json"},
+            {"tenant": "TB", "report": "Critical", "profile_type": "metrics", "date": "2019-02-24",
+             "expected": "/user/foo/argo/tenants/TB/sync/TB_Critical_metrics_2019-02-24.json"}
+        ]
+
+        for test_case_date in test_cases_dates:
+            actual = hdfs.gen_profile_path(
+                test_case_date["tenant"], test_case_date["report"], test_case_date["profile_type"], test_case_date["date"])
+            expected = test_case_date["expected"]
             self.assertEquals(expected, actual)
 
     def test_api(self):
@@ -60,10 +91,15 @@ class TestClass(unittest.TestCase):
             {"resource": "tenants", "item_uuid": None,
              "expected": "https://foo.host/api/v2/admin/tenants"},
             {"resource": "tenants", "item_uuid": "12",
-             "expected": "https://foo.host/api/v2/admin/tenants/12"}
-            ]
+             "expected": "https://foo.host/api/v2/admin/tenants/12"},
+            {"resource": "metrics", "item_uuid": None,
+             "expected": "https://foo.host/api/v2/metric_profiles"},
+            {"resource": "metrics", "item_uuid": "12",
+             "expected": "https://foo.host/api/v2/metric_profiles/12"}
+        ]
 
         for test_case in test_cases:
-            actual = argo_api.get_url(test_case["resource"], test_case["item_uuid"])
+            actual = argo_api.get_url(
+                test_case["resource"], test_case["item_uuid"])
             expected = test_case["expected"]
             self.assertEquals(expected, actual)

--- a/docs/submission-scripts.md
+++ b/docs/submission-scripts.md
@@ -1,15 +1,17 @@
 # Python utility scripts for easier flink job submission/handling
 
-| Script | Description | Shortcut |
-|--------|-------------|---------- |
-| metric_ingestion_submit.py | Python wrapper over flink sumbit metric ingestion job.| [Details](#ingest-metric) |
-| sync_ingestion_submit.py | Python wrapper over flink submit sync ingestion job.| [Details](#ingest-synbc) |
-| ar_job_submit.py | Python wrapper over the flink batch AR job. | [Details](#batch-ar) |
-| status_job_submit.py | Python wrapper over the flink batch Status jon. | [Details](#batch-status) |
+| Script                      | Description                                            | Shortcut                  |
+| --------------------------- | ------------------------------------------------------ | ------------------------- |
+| metric_ingestion_submit.py  | Python wrapper over flink sumbit metric ingestion job. | [Details](#ingest-metric) |
+| sync_ingestion_submit.py    | Python wrapper over flink submit sync ingestion job.   | [Details](#ingest-synbc)  |
+| ar_job_submit.py            | Python wrapper over the flink batch AR job.            | [Details](#batch-ar)      |
+| status_job_submit.py        | Python wrapper over the flink batch Status jon.        | [Details](#batch-status)  |
 | stream_status_job_submit.py | Python wrapper over flink sumbit status streaming job. | [Details](#stream-status) |
 
 <a id="ingest-metric"></a>
+
 ## Metric Ingestion Submit Script
+
 Python wrapper over flink sumbit metric ingestion job.
 Metric Ingestion job receives metric data from an AMS endpoint subscription and stores them to a proper hdfs destination.
 
@@ -22,7 +24,9 @@ Metric Ingestion job receives metric data from an AMS endpoint subscription and 
 `-u : If specified the flink command will run without sudo`
 
 <a id="ingest-sync"></a>
+
 ## Sync Ingestion Submit Script
+
 Same as Metric Ingestion but for connector data
 This job connects to AMS and stores connector data (by report) in an hdfs destination
 
@@ -35,7 +39,9 @@ This job connects to AMS and stores connector data (by report) in an hdfs destin
 `-u : If specified the flink command will run without sudo`
 
 <a id="batch-ar"></a>
+
 ## A/R Batch Job
+
 A/R job submission is a batch job that will run and finish on the cluster
 
 `ar_job_submit.py -t <Tenant> -c <ConfigPath> -u<Sudoless> -r<Report> -d<Date> -m<Method>`
@@ -54,10 +60,14 @@ A/R job submission is a batch job that will run and finish on the cluster
 
 `--profile-check: (optional) Check if profiles used in computation are out of date and update them`
 
+`--historic: (optional) Ar job submission script will use the historic versions of the available profiles according to the (-d) date parameter`
+
 `--thresholds: (optional) Check if threshold rules are defined and use them during computations`
 
 <a id="batch-status"></a>
+
 ## Status Batch Job
+
 Status job submission is a batch job that will run and finish on the cluster
 
 `status_job_submit.py -t <Tenant> -c <ConfigPath> -u<Sudoless> -r<Report> -d<Date> -m<Method>`
@@ -79,7 +89,9 @@ Status job submission is a batch job that will run and finish on the cluster
 `--thresholds: (optional) Check if threshold rules are defined and use them during computations`
 
 <a id = "stream-status"></a>
+
 ## Status Stream Job
+
 Status streaming job receives metric and sync data from AMS calculates and generates status events which are forwarded to kafka
 
 `stream_status_job_submit.py -t <Tenant> -c <ConfigPath> -u<Sudoless> -r<Report> -d<Date>`
@@ -98,12 +110,12 @@ Status streaming job receives metric and sync data from AMS calculates and gener
 
 ### Important
 
-- Sometimes connector data (metric profiles,endpoint,group endpoints,weights) appear delayed (in comparison with the metric data) or might be missing. We have a check mechanism that looks back (up to three days) for connector data that might be missing and uses that.
+-   Sometimes connector data (metric profiles,endpoint,group endpoints,weights) appear delayed (in comparison with the metric data) or might be missing. We have a check mechanism that looks back (up to three days) for connector data that might be missing and uses that.
 
-
-- Flink job receives a parameter of insert or upsert when storing results. Give the ability to honor that parameter and when insert is used, call a clean mongo script for removing (if present) any mongo a/r report data for that very day
+*   Flink job receives a parameter of insert or upsert when storing results. Give the ability to honor that parameter and when insert is used, call a clean mongo script for removing (if present) any mongo a/r report data for that very day
 
 ## Configuration file
+
 ```
 [HDFS]
 HDFS credentials

--- a/docs/update_profiles.md
+++ b/docs/update_profiles.md
@@ -3,14 +3,14 @@
 Argo-streaming engine maintains profile files stored in flink shared storage per tenant and report.
 These profiles are essential for computing a/r and status results during flink-jobs and are not provided
 automatically by connectors. Profiles include:
-- operations_profile: `TENANT_ops.json` which includes truth tables about the fundamental aggregation operations applied
-  on monitor status timelines (such as 'AND', 'OR' .etc between statuses of 'OK', 'WARNING', 'CRITICAL', 'MISSING' etc.)
-- aggregation_profile: `TENANT_REPORT_aps.json` which includes information on what operations ('AND','OR') and how are
-  applied on different service levels
-- report configuration profile: `TENANT_REPORT_cfg.json` which includes information on the report it self, what profiles
-it uses and how filters data
-- threhsolds_profile (optional): `TENANT_REPORT_thresholds.json` which includes thresholds rules to be applied during computation
 
+-   operations_profile: `TENANT_ops.json` which includes truth tables about the fundamental aggregation operations applied
+    on monitor status timelines (such as 'AND', 'OR' .etc between statuses of 'OK', 'WARNING', 'CRITICAL', 'MISSING' etc.)
+-   aggregation_profile: `TENANT_REPORT_aps.json` which includes information on what operations ('AND','OR') and how are
+    applied on different service levels
+-   report configuration profile: `TENANT_REPORT_cfg.json` which includes information on the report it self, what profiles
+    it uses and how filters data
+-   threhsolds_profile (optional): `TENANT_REPORT_thresholds.json` which includes thresholds rules to be applied during computation
 
 Each report uses an operations profile. The operation profile is defined also in argo-web-api instance at the following url
 `GET https://argo-web-api.host.example/api/v2/operations_profiles/{{profile_uuid}}`
@@ -24,15 +24,15 @@ Each report optionally contains a thresholds profile. The thresholds profile is 
 Each report contains a configuration profile. The report is defined also in argo-web-api instance at the following url
 `GET https://argo-web-api.host.example/api/v2/reports/{{report_uuid}}`
 
-
-
-Providing a specific `tenant` and a specific `report`, script `update_profiles` checks corresponding profiles on hdfs  against
+Providing a specific `tenant` and a specific `report`, script `update_profiles` checks corresponding profiles on hdfs against
 latest profiles provided by argo-web-api. If they don't match it uploads the latest argo-web-api profile definition in hdfs
 
 # Submission scripts automatic invoke
+
 Script logic is programmatically called in a/r and status job submission scripts
 
 # Invoke manually from command line
+
 Script logic can be invoked from command line by issuing
 `$ ./update_profiles -t TENANT -r REPORT`
 
@@ -52,9 +52,14 @@ optional arguments:
                         report
   -c STRING, --config STRING
                         config
+  -d STRING, --date STRING date
 ```
 
+If `-d` parameter is set, update profile script will check for historic version of the profiles and will update
+them accordingly to HDFS
+
 # Config file parameters used
+
 Update_profiles script will search for the main argo-streaming.conf file but uses only the following
 configuration parameters:
 
@@ -85,6 +90,7 @@ TENANT_B_key = secret2
 ```
 
 # Dependencies
+
 Update_profiles script is deployed alongside the other scripts included in the `./bin/` folder of argo-streaming engine
 and relies on the same dependencies. Specifically it uses `requests` lib for contacting argo-web-api and python `snakebite` lib
 for checking hdfs files. Because `snakebite` lib lacks upload mechanism the script relies on a binary client wrapper to upload


### PR DESCRIPTION
…bmission script

## Goal
Since argo-web-api update to support historic versions in profiles such as operations, aggregations etc... argo a/r job submission script can be updated to use on demand historic version of those profiles directly from the api 

## Implementation
- Refactor `util/update_profiles.py` to support date parameter for retrieving historic versions
- Update `ar_job_submit` script with optional parameter `--historic`. When `--historic` is used along with `--profile-check` ar_job_submit` script will first retrieve the historic versions of the profiles and upload them to hdfs and then will use the correct references to them when calling a/r flink job