### PR TITLE
Bump up depedencies according to github security check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ __pycache__
 .DS_STORE
 conf.cfg
 .pytest_cache
+
+# Java related
+.classpath
+.project
+.settings/

--- a/flink_jobs/ams_ingest_sync/pom.xml
+++ b/flink_jobs/ams_ingest_sync/pom.xml
@@ -100,7 +100,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
+			<version>4.13.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/flink_jobs/batch_ar/pom.xml
+++ b/flink_jobs/batch_ar/pom.xml
@@ -147,7 +147,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
+			<version>4.13.1</version>
 			<scope>test</scope>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/com.github.tomakehurst/wiremock -->

--- a/flink_jobs/batch_status/pom.xml
+++ b/flink_jobs/batch_status/pom.xml
@@ -137,7 +137,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
+			<version>4.13.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/flink_jobs/stream_status/pom.xml
+++ b/flink_jobs/stream_status/pom.xml
@@ -119,7 +119,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
+			<version>4.13.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -132,7 +132,7 @@
 		<dependency>
 			<groupId>xerces</groupId>
 			<artifactId>xercesImpl</artifactId>
-			<version>2.7.1</version>
+			<version>2.12.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mongodb</groupId>


### PR DESCRIPTION
- Bump-up junit to 4.13.1 (from 4.11)
- Bump-up xercesImpl to 2.12.0 (from 2.7.1)
- Add some eclipse project related file types to gitignore