### PR TITLE
ARGO-2578 Align streaming job interface to use ApiResourceManager and ArgoApiSource connector

### DIFF
--- a/flink_jobs/stream_status/src/main/java/argo/streaming/ArgoApiSource.java
+++ b/flink_jobs/stream_status/src/main/java/argo/streaming/ArgoApiSource.java
@@ -24,7 +24,6 @@ public class ArgoApiSource extends RichSourceFunction<Tuple2<String,String>> {
 	static Logger LOG = LoggerFactory.getLogger(ArgoApiSource.class);
 
 	private String endpoint = null;
-	private String port = null;
 	private String token = null;
 	private String reportID = null;
 	private int hourCheck = 24;
@@ -42,9 +41,8 @@ public class ArgoApiSource extends RichSourceFunction<Tuple2<String,String>> {
 	
 
 
-	public ArgoApiSource(String endpoint, String port, String token, String reportID, int hourCheck,  Long interval) {
+	public ArgoApiSource(String endpoint, String token, String reportID, int hourCheck,  Long interval) {
 		this.endpoint = endpoint;
-		this.port = port;
 		this.token = token;
 		this.reportID = reportID;
 		this.hourCheck = hourCheck;
@@ -95,7 +93,7 @@ public class ArgoApiSource extends RichSourceFunction<Tuple2<String,String>> {
 				this.timeSnapshot = ti;
 				// retrieve info from api
 				this.client.getRemoteAll();
-				// fetch metric_profile, downtimes, groupendpoints
+				// fetch metric_profile, downtimes, group endpoints
 				Tuple2<String, String> mt = new Tuple2<String, String>("metric_profile",client.getResourceJSON(ApiResource.METRIC));
 				Tuple2<String, String> gt = new Tuple2<String, String>("group_endpoints",client.getResourceJSON(ApiResource.TOPOENDPOINTS));
 				Tuple2<String, String> dt = new Tuple2<String, String>("downtimes",client.getResourceJSON(ApiResource.DOWNTIMES));

--- a/flink_jobs/stream_status/src/main/java/argo/streaming/StatusConfig.java
+++ b/flink_jobs/stream_status/src/main/java/argo/streaming/StatusConfig.java
@@ -24,6 +24,14 @@ public class StatusConfig implements Serializable {
 	
 	public String report;
 	
+	public String apiEndpoint;
+	public String apiToken;
+	public String apiProxy;
+	public Boolean apiVerify = false;
+	public int hourCheck = 24;
+	public String reportID;
+	public long interval = 100L;
+	
 	// Sync files
 	public String aps;
 	public String mps;
@@ -46,6 +54,8 @@ public class StatusConfig implements Serializable {
 	   this.amsPort = pt.getRequired("ams.port");
 	   this.amsToken = pt.getRequired("ams.token");
 	   this.amsProject = pt.getRequired("ams.project");
+	   this.apiEndpoint = pt.getRequired("api.endpoint");
+	   
 	   
 	   this.aps = pt.getRequired("sync.apr");
 	   this.mps = pt.getRequired("sync.mps");
@@ -70,6 +80,16 @@ public class StatusConfig implements Serializable {
 	   }
 	   
 	   // Optional set daily parameter
+	   
+	   this.apiEndpoint = pt.getRequired("api.endpoint");
+	   this.apiToken = pt.getRequired("apiToken");
+	   this.reportID = pt.getRequired("reportID");
+	   
+	   if (pt.has("api.proxy")) this.apiProxy = pt.get("api.proxy","");
+	   if (pt.has("api.verify")) this.apiVerify = pt.getBoolean("api.verify",false);
+	   if (pt.has("api.interval")) this.hourCheck = pt.getInt("api.interval",24);
+	   if (pt.has("ams.interval")) this.interval = pt.getLong("interval",100L);
+	   
 	   this.daily = pt.getBoolean("daily",false);
 	   
 	  }

--- a/flink_jobs/stream_status/src/main/java/argo/streaming/SyncParse.java
+++ b/flink_jobs/stream_status/src/main/java/argo/streaming/SyncParse.java
@@ -3,6 +3,7 @@ package argo.streaming;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Map.Entry;
@@ -13,8 +14,12 @@ import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
+import argo.amr.ApiResource;
 import argo.avro.Downtime;
 import argo.avro.GroupEndpoint;
 import argo.avro.MetricProfile;
@@ -95,6 +100,83 @@ public class SyncParse {
 		
 		return result;
 	}
+	
+	public static ArrayList<MetricProfile> parseMetricJSON(String content) {
+		ArrayList<MetricProfile> results = new ArrayList<MetricProfile>();
+
+		
+		JsonParser jsonParser = new JsonParser();
+		JsonElement jElement = jsonParser.parse(content);
+		JsonObject jRoot = jElement.getAsJsonObject();
+		String profileName = jRoot.get("name").getAsString();
+		JsonArray jElements = jRoot.get("services").getAsJsonArray();
+		for (int i = 0; i < jElements.size(); i++) {
+			JsonObject jItem= jElements.get(i).getAsJsonObject();
+			String service = jItem.get("service").getAsString();
+			JsonArray jMetrics = jItem.get("metrics").getAsJsonArray();
+			for (int j=0; j < jMetrics.size(); j++) {
+				String metric = jMetrics.get(j).getAsString();
+				
+				Map<String,String> tags = new HashMap<String,String>();
+				MetricProfile mp = new MetricProfile(profileName,service,metric,tags);
+				results.add(mp);
+			}
+			
+		}
+		
+		return results;
+	}
+	
+	public static ArrayList<Downtime> parseDowntimesJSON (String content) {
+		
+		ArrayList<Downtime> results = new ArrayList<Downtime>();
+		
+		JsonParser jsonParser = new JsonParser();
+		JsonElement jElement = jsonParser.parse(content);
+		JsonObject jRoot = jElement.getAsJsonObject();
+		JsonArray jElements = jRoot.get("endpoints").getAsJsonArray();
+		for (int i = 0; i < jElements.size(); i++) {
+			JsonObject jItem= jElements.get(i).getAsJsonObject();
+			String hostname = jItem.get("hostname").getAsString();
+			String service = jItem.get("service").getAsString();
+			String startTime = jItem.get("start_time").getAsString();
+			String endTime = jItem.get("end_time").getAsString();
+			
+			Downtime d = new Downtime(hostname,service,startTime,endTime);
+			results.add(d);
+		}
+		
+		return results;
+		
+	}
+	
+	public static ArrayList<GroupEndpoint> parseGroupEndpointJSON (String content) {
+		
+		ArrayList<GroupEndpoint> results = new ArrayList<GroupEndpoint>();
+		
+		JsonParser jsonParser = new JsonParser();
+		JsonElement jElement = jsonParser.parse(content);
+		JsonArray jRoot = jElement.getAsJsonArray();
+		for (int i = 0; i < jRoot.size(); i++) {
+			JsonObject jItem= jRoot.get(i).getAsJsonObject();
+			String group = jItem.get("group").getAsString();
+			String gType = jItem.get("type").getAsString();
+			String service = jItem.get("service").getAsString();
+			String hostname = jItem.get("hostname").getAsString();
+			JsonObject jTags = jItem.get("tags").getAsJsonObject();
+			Map<String,String> tags = new HashMap<String,String>();
+		    for ( Entry<String, JsonElement> kv : jTags.entrySet()) {
+		    	tags.put(kv.getKey(), kv.getValue().getAsString());
+		    }
+			GroupEndpoint ge = new GroupEndpoint(gType,group,service,hostname,tags);
+			results.add(ge);
+		}
+		
+		return results;
+		
+	}
+	
+	
 	
 
 }


### PR DESCRIPTION
# Goal
Use ApiResourceManager and the ArgoApiSource connector to retrieve sync information from argo-web-api during the init phase of the streaming pipeline and to provide daily (or hourly-based) updates of sync data to the streaming operators

# Implementation
- [x] Use ApiResourceManager to the beginning of the pipeline to initialize profile and topology information needed
- [x] Use ApiResourceManager in the init phase of the two main operator function in streaming job to provide required profile, topology and downtime information before handling any metric data
- [x] Use ArgoApiSource with a hourly interval parameter to check and retrieve profile, topology and downtime information from api and stream it to the main operators that handle metric data and generate events