### PR TITLE
ARGO-2952 Calculate the top N flip-flopping service endpoints metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,3 +381,13 @@ Job requires parameters:
 `--criticalResults`           :file location of critical status results
 `--warningResults`            :file location of warning status results
 `--unknownStatus`             :file location of unknown status results
+
+Flink batch Job that calculate flip flop trends for service endpoints metrics
+Job requires parameters:
+
+`--yesterdayData`               :file location of previous day's data
+`--todayData`                 :file location of today day's data
+`--metricDataPath`            :file location of  metric profile data
+`--groupEndpointsPath`        :file location of topology information
+`--N`              		 :(optional) number of displayed top results
+`--flipflopResults`           :file location of flip flop results

--- a/flink_jobs/status_trends/src/main/java/argo/functions/FlipFlopStatusCounter.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/FlipFlopStatusCounter.java
@@ -1,0 +1,113 @@
+package argo.functions;
+
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+import argo.avro.MetricData;
+import argo.utils.Utils;
+import java.text.ParseException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TreeMap;
+import org.apache.flink.api.common.functions.RichGroupReduceFunction;
+import org.apache.flink.api.java.tuple.Tuple5;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author cthermolia
+ *
+ * FlipFlopStatusCounter, count status changes for each service endpoint metric
+ */
+public class FlipFlopStatusCounter extends RichGroupReduceFunction<MetricData, Tuple5<String, String, String, String, Integer>> {
+
+    static Logger LOG = LoggerFactory.getLogger(FlipFlopStatusCounter.class);
+
+    private transient HashMap<String, String> groupEndpoints;
+    private String groupEndpointsPath;
+
+    public FlipFlopStatusCounter(ParameterTool params) {
+        this.groupEndpointsPath = params.getRequired("groupEndpointsPath");
+    }
+
+    @Override
+    public void open(Configuration config) throws Exception {
+        groupEndpoints = Utils.readGroupEndpointJson(groupEndpointsPath); //contains the information of the (group, service) matches
+    }
+
+    /**
+     *
+     * @param in, the MetricData dataset
+     * @param out, the coll ection of Tuple5, keeping counter for each group
+     * service hostname metric
+     * @throws Exception
+     */
+    @Override
+    public void reduce(Iterable<MetricData> in, Collector<Tuple5<String, String, String, String, Integer>> out) throws Exception {
+        TreeMap<String, String> timeStatusMap = new TreeMap<>();
+        String group = null;
+        String hostname = null;
+        String service = null;
+        String metric = null;
+
+        for (MetricData md : in) {
+            hostname = md.getHostname().toString();
+            service = md.getService().toString();
+            metric = md.getMetric().toString();
+            group = groupEndpoints.get(md.getHostname().toString() + "-" + md.getService().toString()); //retrieve the group for the service, as contained in file
+            timeStatusMap.put(md.getTimestamp().toString(), md.getStatus().toString());
+        }
+        timeStatusMap = handleFirstLastTimestamps(timeStatusMap);
+        int flipflop = calcFlipFlops(timeStatusMap);
+        if (group != null && service != null && hostname != null && metric != null) {
+            Tuple5<String, String, String, String, Integer> tuple = new Tuple5<String, String, String, String, Integer>(
+                    group, service, hostname, metric, flipflop
+            );
+            out.collect(tuple);
+        }
+    }
+
+// add to map an entry of (T00:00:00, status) and an entry of (T23:59:59, status) 
+    private TreeMap<String, String> handleFirstLastTimestamps(TreeMap<String, String> map) throws ParseException {
+        Map.Entry<String, String> firstEntry = map.firstEntry();
+        Map.Entry<String, String> lastEntry = map.lastEntry();
+        String status = firstEntry.getValue();
+        String timestamp = Utils.createDate(lastEntry.getKey(), 0, 0, 0);
+        if (Utils.isPreviousDate(timestamp, firstEntry.getKey())) {  //if exists a previous day timestamp get the status of the timestamp, else set the status=MISSING
+            status = firstEntry.getValue();
+        } else {
+            status = "MISSING";
+        }
+
+        map.put(timestamp, status);
+
+        status = lastEntry.getValue();
+        timestamp = Utils.createDate(lastEntry.getKey(), 23, 59, 59);
+        map.put(timestamp, status);
+        map.remove(firstEntry.getKey());
+        return map;
+    }
+// calculate status changes
+
+    private int calcFlipFlops(TreeMap<String, String> map) {
+
+        String previousStatus = null;
+        int flipflop = 0;
+        for (Entry<String, String> entry : map.entrySet()) {
+            String status = entry.getValue();
+            if (previousStatus != null && !status.equalsIgnoreCase(previousStatus)) {
+                flipflop++;
+            }
+            previousStatus = status;
+        }
+        return flipflop;
+    }
+
+}

--- a/flink_jobs/status_trends/src/main/java/argo/functions/LastTimeStampGroupReduce.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/LastTimeStampGroupReduce.java
@@ -5,32 +5,35 @@ package argo.functions;
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-
 import argo.avro.MetricData;
 import java.util.TreeMap;
 import org.apache.flink.api.common.functions.GroupReduceFunction;
 import org.apache.flink.util.Collector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
- * @author cthermolia
- * LastTimeStampGroupReduce keeps data of the latest time entry
-*/
-
+ * @author cthermolia LastTimeStampGroupReduce keeps data of the latest time
+ * entry
+ */
 public class LastTimeStampGroupReduce implements GroupReduceFunction<MetricData, MetricData> {
 
- /**
- * 
- * @param in, the initial dataset of the MetricData
- * @param out , the output dataset containing the MetricData of the latest timestamp
- * @throws Exception 
- */
+    static Logger LOG = LoggerFactory.getLogger(LastTimeStampGroupReduce.class);
+
+    /**
+     *
+     * @param in, the initial dataset of the MetricData
+     * @param out , the output dataset containing the MetricData of the latest
+     * timestamp
+     * @throws Exception
+     */
     @Override
     public void reduce(Iterable<MetricData> in, Collector<MetricData> out) throws Exception {
         TreeMap<String, MetricData> timeStatusMap = new TreeMap<>();
         for (MetricData md : in) {
             timeStatusMap.put(md.getTimestamp().toString(), md);
-            
+
         }
         out.collect(timeStatusMap.lastEntry().getValue());
     }

--- a/flink_jobs/status_trends/src/main/java/argo/functions/StatusFilter.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/StatusFilter.java
@@ -7,6 +7,8 @@ package argo.functions;
 
 import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.java.tuple.Tuple6;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -16,6 +18,7 @@ import org.apache.flink.api.java.tuple.Tuple6;
  */
 public class StatusFilter implements FilterFunction<Tuple6<String, String, String, String, String, Integer>> {
 
+    static Logger LOG = LoggerFactory.getLogger(StatusFilter.class);
     private String status;
 
     public StatusFilter(String status) {

--- a/flink_jobs/status_trends/src/main/java/argo/utils/Utils.java
+++ b/flink_jobs/status_trends/src/main/java/argo/utils/Utils.java
@@ -5,6 +5,7 @@
  */
 package argo.utils;
 
+import argo.functions.FlipFlopStatusCounter;
 import java.io.FileReader;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -17,19 +18,20 @@ import java.util.Map;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
  * @author cthermolia
  */
 public class Utils {
+    static Logger LOG = LoggerFactory.getLogger(Utils.class);
 
     public static String createDate(String dateStr, int hour, int min, int sec) throws ParseException {
 
-//        Calendar cal = Calendar.getInstance();
         String format = "yyyy-MM-dd'T'HH:mm:ss'Z'";
         SimpleDateFormat sdf = new SimpleDateFormat(format);
-//        cal.setTime(sdf.parse(dateStr));
         Calendar newCalendar = Calendar.getInstance();
         newCalendar.set(2021, 0,15, hour, min, sec);
 
@@ -90,10 +92,11 @@ public class Utils {
             Object obj = iterator.next();
             if (obj instanceof JSONObject) {
                 JSONObject jsonObject = new JSONObject((Map) obj);
-                String hostname = (String) jsonObject.get("hostname");
-                String group = (String) jsonObject.get("group");
+               String hostname = (String) jsonObject.get("hostname");
+               String service = (String) jsonObject.get("service");
+               String group = (String) jsonObject.get("group");
 
-                jsonDataMap.put(hostname, group);
+                jsonDataMap.put(hostname+"-"+service, group);
             }
         }
         return jsonDataMap;


### PR DESCRIPTION
### Goal : 

Based on a daily report of service endpoint metric status's checks , calculate the status changes (flip flops) , rank for each status the results and display the top N service endpoint metrics enriched with group info based on reports's topology data. 
The results include only service endpoint metrics that are included in report's topology data and report's metric profile data

### Implementation:
Added in status_trends package , all necessary classes. Execute code in BatchFlipFlopTrends class

**flink_jobs
  |-- status_trends**