### PR TITLE
ARGO-2950 Write results to  mongo db

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,21 +373,21 @@ Streaming Status | Streaming status using data from `{{ams-endpoint}}`/v1/projec
 Flink batch Job that calculate status trends for critical,warning,unknown status
 Job requires parameters:
 
-`--yesterdayData`               :file location of previous day's data
-`--todayData`                 :file location of today day's data
-`--metricDataPath`            :file location of  metric profile data
-`--groupEndpointsPath`        :file location of topology information
-`--N`              		 :(optional) number of displayed top results
-`--criticalResults`           :file location of critical status results
-`--warningResults`            :file location of warning status results
-`--unknownStatus`             :file location of unknown status results
+`--yesterdayData`             : file location of previous day's data
+`--todayData`                 : file location of today day's data
+`--metricDataPath`            : file location of  metric profile data
+`--groupEndpointsPath`        : file location of topology information
+`--N`              	       : (optional) number of displayed top results
+`--criticaluri`               : uri to the mongo db collection, to store critical status results
+`--warninguri`                : uri to the mongo db collection, to store warning status results
+`--unknownuri`                : uri to the mongo db collection, to store unknown status results
 
 Flink batch Job that calculate flip flop trends for service endpoints metrics
 Job requires parameters:
 
-`--yesterdayData`               :file location of previous day's data
-`--todayData`                 :file location of today day's data
-`--metricDataPath`            :file location of  metric profile data
-`--groupEndpointsPath`        :file location of topology information
-`--N`              		 :(optional) number of displayed top results
-`--flipflopResults`           :file location of flip flop results
+`--yesterdayData`              : file location of previous day's data
+`--todayData`                  : file location of today day's data
+`--metricDataPath`             : file location of  metric profile data
+`--groupEndpointsPath`         : file location of topology information
+`--N`              		: (optional) number of displayed top results
+`--flipflopuri`                : uri to the mongo db , to store flip flop results

--- a/flink_jobs/status_trends/pom.xml
+++ b/flink_jobs/status_trends/pom.xml
@@ -33,6 +33,8 @@ under the License.
         <slf4j.version>1.7.7</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
         <scala.binary.version>2.10</scala.binary.version>
+        <mongodb.hadoop.version>1.3.0</mongodb.hadoop.version>
+        <hadoop.version>2.6.0</hadoop.version>
     </properties>
 
     <repositories>
@@ -74,6 +76,23 @@ under the License.
     -->
 
     <dependencies>
+<!--        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${hadoop.version}</version>
+        </dependency>-->
+        <!-- https://mvnrepository.com/artifact/org.apache.flink/flink-hadoop-compatibility -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-hadoop-compatibility_2.10</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+             
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongo-hadoop-core</artifactId>
+            <version>${mongodb.hadoop.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>

--- a/flink_jobs/status_trends/src/main/java/argo/batch/BatchFlipFlopTrends.java
+++ b/flink_jobs/status_trends/src/main/java/argo/batch/BatchFlipFlopTrends.java
@@ -27,10 +27,14 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.AvroInputFormat;
 import org.apache.flink.api.java.tuple.Tuple5;
 import org.apache.flink.api.java.utils.ParameterTool;
+
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
 
 /**
  * Skeleton for a Flink Batch Job.
@@ -105,4 +109,6 @@ public class BatchFlipFlopTrends {
         inputData = env.createInput(inputAvroFormat);
         return inputData;
     }
+
+
 }

--- a/flink_jobs/status_trends/src/main/java/argo/batch/BatchStatusTrends.java
+++ b/flink_jobs/status_trends/src/main/java/argo/batch/BatchStatusTrends.java
@@ -21,17 +21,25 @@ import argo.functions.TopologyMetricFilter;
 import argo.functions.TimelineStatusCounter;
 import argo.functions.LastTimeStampGroupReduce;
 import argo.functions.StatusFilter;
+import com.mongodb.BasicDBObject;
+import com.mongodb.hadoop.io.BSONWritable;
+import com.mongodb.hadoop.mapred.MongoOutputFormat;
+import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.operators.Order;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.hadoop.mapred.HadoopOutputFormat;
 import org.apache.flink.api.java.io.AvroInputFormat;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple6;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.JobConf;
 
 /**
  * Skeleton for a Flink Batch Job.
@@ -71,9 +79,11 @@ public class BatchStatusTrends {
         DataSet<MetricData> todayData = readInputData(env, params, "todayData");
 
         DataSet<Tuple6<String, String, String, String, String, Integer>> rankedData = rankByStatus(params, todayData, yesterdayData);
-        filterByStatusAndWrite(rankedData, "critical", rankNum, params.getRequired("criticalResults"));
-        filterByStatusAndWrite(rankedData, "warning", rankNum, params.getRequired("warningResults"));
-        filterByStatusAndWrite(rankedData, "unknown", rankNum, params.getRequired("unknownResults"));
+
+
+        filterByStatusAndWrite(params.getRequired("criticaluri"), rankedData, "critical", rankNum, params.getRequired("criticalResults"));
+        filterByStatusAndWrite(params.getRequired("warninguri"), rankedData, "warning", rankNum, params.getRequired("warningResults"));
+        filterByStatusAndWrite(params.getRequired("unknownuri"), rankedData, "unknown", rankNum, params.getRequired("unknownResults"));
 
 // execute program
         env.execute("Flink Batch Java API Skeleton");
@@ -91,19 +101,17 @@ public class BatchStatusTrends {
     }
 
     // filter the data based on status (CRITICAL,WARNING,UNKNOWN), rank and write top N in seperate files for each status
-    private static void filterByStatusAndWrite(DataSet<Tuple6<String, String, String, String, String, Integer>> data, String status, Integer rankNum, String path) {
-        if (path == null) {
-            return;
-        }
+    private static void filterByStatusAndWrite(String uri, DataSet<Tuple6<String, String, String, String, String, Integer>> data, String status, Integer rankNum, String path) {
         DataSet<Tuple6<String, String, String, String, String, Integer>> filteredData = data.filter(new StatusFilter(status));
 
         if (rankNum != null) {
             filteredData = filteredData.sortPartition(5, Order.DESCENDING).first(rankNum);
         } else {
             filteredData = filteredData.sortPartition(5, Order.DESCENDING);
-
         }
-        filteredData.writeAsText(path, FileSystem.WriteMode.OVERWRITE);
+
+        writeToMongo(uri, filteredData);
+        //   filteredData.writeAsText(path, FileSystem.WriteMode.OVERWRITE);
     }
 
     // reads input from file
@@ -114,6 +122,39 @@ public class BatchStatusTrends {
         AvroInputFormat<MetricData> inputAvroFormat = new AvroInputFormat<MetricData>(input, MetricData.class);
         inputData = env.createInput(inputAvroFormat);
         return inputData;
+    }
+
+    //convert the result in bson format
+    public static DataSet<Tuple2<Text, BSONWritable>> convertResultToBSON(DataSet<Tuple6<String, String, String, String, String, Integer>> in) {
+
+        return in.map(new MapFunction<Tuple6<String, String, String, String, String, Integer>, Tuple2<Text, BSONWritable>>() {
+            int i = 0;
+
+            @Override
+            public Tuple2<Text, BSONWritable> map(Tuple6<String, String, String, String, String, Integer> in) throws Exception {
+                BasicDBObject dbObject = new BasicDBObject();
+                dbObject.put("group", in.f0.toString());
+                dbObject.put("service", in.f1.toString());
+                dbObject.put("hostname", in.f2.toString());
+                dbObject.put("metric", in.f3.toString());
+                dbObject.put("status", in.f4.toString());
+                dbObject.put("trend", in.f5.toString());
+
+                BSONWritable bson = new BSONWritable(dbObject);
+                i++;
+                return new Tuple2<Text, BSONWritable>(new Text(String.valueOf(i)), bson);
+                /* TODO */
+            }
+        });
+    }
+    //write to mongo db
+    public static void writeToMongo(String uri, DataSet<Tuple6<String, String, String, String, String, Integer>> data) {
+        DataSet<Tuple2<Text, BSONWritable>> result = convertResultToBSON(data);
+        JobConf conf = new JobConf();
+        conf.set("mongo.output.uri", uri);
+
+        MongoOutputFormat<Text, BSONWritable> mongoOutputFormat = new MongoOutputFormat<Text, BSONWritable>();
+        result.output(new HadoopOutputFormat<Text, BSONWritable>(mongoOutputFormat, conf));
     }
 
 }

--- a/flink_jobs/status_trends/src/main/java/argo/functions/FlipFlopStatusCounter.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/FlipFlopStatusCounter.java
@@ -12,13 +12,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
-import org.apache.flink.api.common.functions.RichGroupReduceFunction;
-import org.apache.flink.api.java.tuple.Tuple5;
+
 import org.apache.flink.api.java.utils.ParameterTool;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.util.Collector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.flink.api.common.functions.RichGroupReduceFunction;
+import org.apache.flink.api.java.tuple.Tuple5;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
 
 /**
  *
@@ -95,7 +96,6 @@ public class FlipFlopStatusCounter extends RichGroupReduceFunction<MetricData, T
         return map;
     }
 // calculate status changes
-
     private int calcFlipFlops(TreeMap<String, String> map) {
 
         String previousStatus = null;

--- a/flink_jobs/status_trends/src/main/java/argo/functions/TimelineStatusCounter.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/TimelineStatusCounter.java
@@ -98,5 +98,6 @@ public class TimelineStatusCounter extends RichGroupReduceFunction<MetricData, T
                     group, service, hostname, metric, "UNKNOWN", unknownSum);
             out.collect(tupleUnknown);
         }
-    }
+    }        
+
 }

--- a/flink_jobs/status_trends/src/main/java/argo/functions/TopologyMetricFilter.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/TopologyMetricFilter.java
@@ -9,7 +9,6 @@ import argo.avro.MetricData;
 import java.util.ArrayList;
 import java.util.HashMap;
 import argo.utils.Utils;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.RichFilterFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
 
@@ -28,7 +27,7 @@ import org.slf4j.LoggerFactory;
 public class TopologyMetricFilter extends RichFilterFunction<MetricData> {
 
     static Logger LOG = LoggerFactory.getLogger(TopologyMetricFilter.class);
-    
+
     private transient HashMap<String, String> groupEndpoints;
     private transient HashMap<String, ArrayList<String>> metricProfileData;
     private String groupEndpointsPath;


### PR DESCRIPTION
### Goal
Based on  #154 #155 , write the results in the mongo db instead of the files
### Implementation
Implementation includes changes to BatchStatusTrends class and BatchFlipFlopTrends class , in order to connect in a mongo db, convert the results in a mongo output format and write them in mongo db 
