### PR TITLE
ARGO-2997 Hot fix stream status mongodb temp update with correct prev…

### DIFF
--- a/flink_jobs/stream_status/src/main/java/argo/streaming/MongoStatusOutput.java
+++ b/flink_jobs/stream_status/src/main/java/argo/streaming/MongoStatusOutput.java
@@ -215,7 +215,7 @@ public class MongoStatusOutput implements OutputFormat<String> {
 		String repeat = extractJson("repeat",jRoot);
 		String message = extractJson("message",jRoot);
 		String summary = extractJson("summary",jRoot);
-		return new StatusEvent(rep,tp,dt,eGroup,service,hostname,metric,status,monHost,tsm,tsp,prevTs,prevStatus,repeat,summary,message);
+		return new StatusEvent(rep,tp,dt,eGroup,service,hostname,metric,status,monHost,tsm,tsp,prevStatus,prevTs,repeat,summary,message);
 	}
 
 	/**


### PR DESCRIPTION
…ious status and timestamp reference

:warning: this is a direct hot-fix for current released version in master branch 

Fix order of values for previous status and previous timestamp when storing temporary status value in mongodb after generation of an event. This value is the cleared and replaced by the hourly batch results of a/r and status calculations