### PR TITLE
ARGO-2985 Calculate flip flops for group of endpoints

### DIFF
--- a/flink_jobs/status_trends/src/main/java/argo/batch/BatchGroupFlipFlopTrends.java
+++ b/flink_jobs/status_trends/src/main/java/argo/batch/BatchGroupFlipFlopTrends.java
@@ -1,77 +1,58 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
 package argo.batch;
 
-/**
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with this
- * work for additional information regarding copyright ownership. The ASF
- * licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
 import argo.avro.MetricData;
 import argo.functions.calctimelines.CalcLastTimeStatus;
 import argo.functions.calctimelines.MapServices;
 import argo.functions.calctimelines.ServiceFilter;
 import argo.functions.calctimelines.TopologyMetricFilter;
 import argo.functions.calctrends.CalcEndpointFlipFlopTrends;
+import argo.functions.calctrends.CalcGroupFlipFlop;
+import argo.functions.calctrends.CalcGroupFunctionFlipFlop;
 import argo.functions.calctrends.CalcMetricFlipFlopTrends;
 import argo.functions.calctrends.CalcServiceFlipFlop;
 import argo.pojos.EndpointTrends;
+import argo.pojos.GroupFunctionTrends;
+import argo.pojos.GroupTrends;
 import argo.pojos.MetricTrends;
 import argo.pojos.ServiceTrends;
-import argo.utils.Utils;
-import com.mongodb.hadoop.io.BSONWritable;
-import java.util.ArrayList;
-
-import java.util.HashMap;
-import org.apache.flink.api.java.DataSet;
-import org.apache.flink.api.java.ExecutionEnvironment;
-import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.api.java.utils.ParameterTool;
-import org.apache.hadoop.io.Text;
 import argo.profiles.ProfilesLoader;
+import argo.utils.Utils;
 import com.mongodb.BasicDBObject;
+import com.mongodb.hadoop.io.BSONWritable;
 import com.mongodb.hadoop.mapred.MongoOutputFormat;
+import java.util.ArrayList;
+import java.util.HashMap;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.operators.Order;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.hadoop.mapred.HadoopOutputFormat;
 import org.apache.flink.api.java.io.AvroInputFormat;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.core.fs.Path;
+import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.JobConf;
 
 /**
- * Skeleton for a Flink Batch Job.
  *
- * For a full example of a Flink Batch Job, see the WordCountJob.java file in
- * the same package/directory or have a look at the website.
- *
- * You can also generate a .jar file that you can submit on your Flink cluster.
- * Just type mvn clean package in the projects root directory. You will find the
- * jar in target/argo2932-1.0.jar From the CLI you can then run ./bin/flink run
- * -c com.company.argo.BatchJob target/argo2932-1.0.jar
- *
- * For more information on the CLI see:
- *
- * http://flink.apache.org/docs/latest/apis/cli.html
+ * @author cthermolia
  */
-public class BatchServiceFlipFlopTrends {
+public class BatchGroupFlipFlopTrends {
+//     private static HashMap<String, HashMap<String, String>> opTruthTableMap = new HashMap<>(); // the truth table for the operations to be applied on timeline
+//    private static HashMap<String, ArrayList<String>> metricProfileData;
+//    private static HashMap<String, String> topologyEndpointData;
+//    private static ArrayList<String> topologyGroupData;
 
-    private static HashMap<String, HashMap<String, String>> opTruthTableMap = new HashMap<>(); // the truth table for the operations to be applied on timeline
-    //private static HashMap<String, ArrayList<String>> metricProfileData;
-    //private static HashMap<String, String> topologyEndpointData;
-   // private static ArrayList<String> topologyGroupData;
     private static DataSet<MetricData> yesterdayData;
     private static DataSet<MetricData> todayData;
     private static Integer rankNum;
-    private static final String serviceTrends = "serviceTrends";
+    private static final String groupTrends = "groupTrends";
     private static String mongoUri;
     private static ProfilesLoader profilesLoader;
 
@@ -79,9 +60,9 @@ public class BatchServiceFlipFlopTrends {
         // set up the batch execution environment
         final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 
-         ParameterTool params = ParameterTool.fromArgs(args);
+        ParameterTool params = ParameterTool.fromArgs(args);
         //check if all required parameters exist and if not exit program
-        if (!Utils.checkParameters(params, "yesterdayData", "todayData", "mongoUri","apiUri", "key")) {
+        if (!Utils.checkParameters(params, "yesterdayData", "todayData", "mongoUri", "apiUri", "key")) {
             System.exit(0);
         }
 
@@ -90,17 +71,16 @@ public class BatchServiceFlipFlopTrends {
             rankNum = params.getInt("N");
         }
         mongoUri = params.get("mongoUri");
-         profilesLoader = new ProfilesLoader(params);
-      //  metricProfileData = profilesLoader.getMetricProfileParser().getMetricData();
-       //topologyEndpointData = profilesLoader.getTopologyEndpointParser().getTopology(profilesLoader.getAggregationProfileParser().getEndpointGroup().toUpperCase());
+        profilesLoader = new ProfilesLoader(params);
+//        metricProfileData = profilesLoader.getMetricProfileParser().getMetricData();
+//       topologyEndpointData = profilesLoader.getTopologyEndpointParser().getTopology(profilesLoader.getAggregationProfileParser().getEndpointGroup().toUpperCase());
 //        topologyGroupData = profilesLoader.getTopolGroupParser().getTopologyGroups();
 //       
         yesterdayData = readInputData(env, params, "yesterdayData");
         todayData = readInputData(env, params, "todayData");
-       
-        
+
         // calculate on data 
-        DataSet<ServiceTrends> resultData = calcFlipFlops();
+        DataSet<GroupTrends> resultData = calcFlipFlops();
         writeToMongo(resultData);
 
 // execute program
@@ -111,7 +91,7 @@ public class BatchServiceFlipFlopTrends {
 // filter yesterdaydata and exclude the ones not contained in topology and metric profile data and get the last timestamp data for each service endpoint metric
 // filter todaydata and exclude the ones not contained in topology and metric profile data , union yesterday data and calculate status changes for each service endpoint metric
 // rank results
-    private static DataSet<ServiceTrends> calcFlipFlops() {
+    private static DataSet<GroupTrends> calcFlipFlops() {
 
         DataSet<MetricData> filteredYesterdayData = yesterdayData.filter(new TopologyMetricFilter(profilesLoader.getMetricProfileParser(), profilesLoader.getTopologyEndpointParser(), profilesLoader.getTopolGroupParser(), profilesLoader.getAggregationProfileParser())).groupBy("hostname", "service", "metric").reduceGroup(new CalcLastTimeStatus());
         DataSet<MetricData> filteredTodayData = todayData.filter(new TopologyMetricFilter(profilesLoader.getMetricProfileParser(), profilesLoader.getTopologyEndpointParser(), profilesLoader.getTopolGroupParser(), profilesLoader.getAggregationProfileParser()));
@@ -122,18 +102,23 @@ public class BatchServiceFlipFlopTrends {
         //group data by service endpoint  and count flip flops
         DataSet<EndpointTrends> serviceEndpointGroupData = serviceEndpointMetricGroupData.groupBy("group", "endpoint", "service").reduceGroup(new CalcEndpointFlipFlopTrends(profilesLoader.getAggregationProfileParser().getMetricOp(), profilesLoader.getOperationParser()));
 
-
-      //group data by service   and count flip flops
+        //group data by service   and count flip flops
         DataSet<ServiceTrends> serviceGroupData = serviceEndpointGroupData.filter(new ServiceFilter(profilesLoader.getAggregationProfileParser())).groupBy("group", "service").reduceGroup(new CalcServiceFlipFlop(profilesLoader.getOperationParser(), profilesLoader.getAggregationProfileParser()));
         //flat map data to add function as described in aggregation profile groups
-      //  serviceGroupData = serviceGroupData.flatMap(new MapServices(profilesLoader.getAggregationProfileParser().getFunctionServices()));
+        serviceGroupData = serviceGroupData.flatMap(new MapServices(profilesLoader.getAggregationProfileParser()));
+
+        //group data by group,function   and count flip flops
+        DataSet<GroupFunctionTrends> groupFunction = serviceGroupData.groupBy("group", "function").reduceGroup(new CalcGroupFunctionFlipFlop(profilesLoader.getOperationParser(), profilesLoader.getAggregationProfileParser()));
+
+        //group data by group   and count flip flops
+        DataSet<GroupTrends> groupData = groupFunction.groupBy("group").reduceGroup(new CalcGroupFlipFlop(profilesLoader.getOperationParser(), profilesLoader.getAggregationProfileParser()));
 
         if (rankNum != null) { //sort and rank data
-            serviceGroupData = serviceGroupData.sortPartition("flipflops", Order.DESCENDING).first(rankNum);
+            groupData = groupData.sortPartition("flipflops", Order.DESCENDING).first(rankNum);
         } else {
-            serviceGroupData = serviceGroupData.sortPartition("flipflops", Order.DESCENDING);
+            groupData = groupData.sortPartition("flipflops", Order.DESCENDING);
         }
-        return serviceGroupData;
+        return groupData;
 
     }    //read input from file
 
@@ -147,27 +132,16 @@ public class BatchServiceFlipFlopTrends {
         return inputData;
     }
 
-////    //initialize configuaration parameters to be used from functions
-  //  private static void initializeConfigurationParameters(ParameterTool params, ExecutionEnvironment env) {
-//
-//        Configuration conf = new Configuration();
-//        conf.setClass("opParser", OperationsParser.class);
-//      
-//        env.getConfig().setGlobalJobParameters(conf);
-//
-  // }
-
     //convert the result in bson format
-    public static DataSet<Tuple2<Text, BSONWritable>> convertResultToBSON(DataSet<ServiceTrends> in) {
+    public static DataSet<Tuple2<Text, BSONWritable>> convertResultToBSON(DataSet<GroupTrends> in) {
 
-        return in.map(new MapFunction<ServiceTrends, Tuple2<Text, BSONWritable>>() {
+        return in.map(new MapFunction<GroupTrends, Tuple2<Text, BSONWritable>>() {
             int i = 0;
 
             @Override
-            public Tuple2<Text, BSONWritable> map(ServiceTrends in) throws Exception {
+            public Tuple2<Text, BSONWritable> map(GroupTrends in) throws Exception {
                 BasicDBObject dbObject = new BasicDBObject();
-                dbObject.put("group", in.getGroup().toString());
-                dbObject.put("service", in.getService().toString());
+                dbObject.put("group", in.getGroup());
                 dbObject.put("trend", in.getFlipflops());
 
                 BSONWritable bson = new BSONWritable(dbObject);
@@ -179,8 +153,8 @@ public class BatchServiceFlipFlopTrends {
     }
 
     //write to mongo db
-    public static void writeToMongo(DataSet<ServiceTrends> data) {
-        String collectionUri = mongoUri + "." + serviceTrends;
+    public static void writeToMongo(DataSet<GroupTrends> data) {
+        String collectionUri = mongoUri + "." + groupTrends;
         DataSet<Tuple2<Text, BSONWritable>> result = convertResultToBSON(data);
         JobConf conf = new JobConf();
         conf.set("mongo.output.uri", collectionUri);

--- a/flink_jobs/status_trends/src/main/java/argo/functions/calctimelines/MapServices.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/calctimelines/MapServices.java
@@ -5,8 +5,8 @@ package argo.functions.calctimelines;
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-
 import argo.pojos.ServiceTrends;
+import argo.profiles.AggregationProfileParser;
 import java.util.ArrayList;
 import java.util.HashMap;
 import org.apache.flink.api.common.functions.FlatMapFunction;
@@ -15,35 +15,43 @@ import org.apache.flink.util.Collector;
 /**
  * @author cthermolia
  *
- * MapServices produces TimelineTrends for each service,that maps to the groups of functions as described in aggregation profile groups
- * endpoint , metric
+ * MapServices produces TimelineTrends for each service,that maps to the groups
+ * of functions as described in aggregation profile groups endpoint , metric
  */
 public class MapServices implements FlatMapFunction<ServiceTrends, ServiceTrends> {
 
     private HashMap<String, ArrayList<String>> serviceFunctions;
+    private AggregationProfileParser aggregationProfileParser;
 
-    public MapServices(HashMap<String, ArrayList<String>> serviceFunctions) {
-        this.serviceFunctions = serviceFunctions;
+//    public MapServices(HashMap<String, ArrayList<String>> serviceFunctions) {
+//        this.serviceFunctions = serviceFunctions;
+//    }
+    public MapServices(AggregationProfileParser aggregationProfileParser) {
+        this.aggregationProfileParser = aggregationProfileParser;
     }
 
     /**
-     * if the service exist in one or more function groups ,  timeline trends are produced for each function that the service belongs and the function info is added to the timelinetrend
+     * if the service exist in one or more function groups , timeline trends are
+     * produced for each function that the service belongs and the function info
+     * is added to the timelinetrend
+     *
      * @param t
      * @param out
-     * @throws Exception 
+     * @throws Exception
      */
     @Override
     public void flatMap(ServiceTrends t, Collector<ServiceTrends> out) throws Exception {
-
         String service = t.getService();
 
-        ArrayList<String> functionList = serviceFunctions.get(service);
-        for (String f : functionList) {
-            ServiceTrends newT=t;
-            newT.setFunction(f);
-            out.collect(newT);
+       // ArrayList<String> functionList = serviceFunctions.get(service);
+        ArrayList<String> functionList =aggregationProfileParser.retrieveServiceFunctions(service);
+        if (functionList != null) {
+            for (String f : functionList) {
+                ServiceTrends newT = t;
+                newT.setFunction(f);
+                out.collect(newT);
+            }
         }
-
     }
 
 }

--- a/flink_jobs/status_trends/src/main/java/argo/functions/calctimelines/ServiceFilter.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/calctimelines/ServiceFilter.java
@@ -5,9 +5,8 @@ package argo.functions.calctimelines;
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-
-
 import argo.pojos.EndpointTrends;
+import argo.profiles.AggregationProfileParser;
 import java.util.ArrayList;
 import java.util.HashMap;
 import org.apache.flink.api.common.functions.FilterFunction;
@@ -23,16 +22,20 @@ import org.slf4j.LoggerFactory;
 public class ServiceFilter implements FilterFunction<EndpointTrends> {
 
     static Logger LOG = LoggerFactory.getLogger(ServiceFilter.class);
-    private HashMap<String, String> serviceOperations;
+    //   private HashMap<String, String> serviceOperations;
+    private AggregationProfileParser aggregationProfileParser;
 
-    public ServiceFilter(HashMap<String, String> serviceOperations) {
-        this.serviceOperations = serviceOperations;
+//    public ServiceFilter(HashMap<String, String> serviceOperations) {
+//        this.serviceOperations = serviceOperations;
+//    }
+    public ServiceFilter(AggregationProfileParser aggregationProfileParser) {
+        this.aggregationProfileParser = aggregationProfileParser;
     }
-    //if the status field value in Tuple equals the given status returns true, else returns false
 
+    //if the status field value in Tuple equals the given status returns true, else returns false
     @Override
     public boolean filter(EndpointTrends t) throws Exception {
-        ArrayList<String> services = new ArrayList<>(serviceOperations.keySet());
+        ArrayList<String> services = new ArrayList<>(aggregationProfileParser.getServiceOperations().keySet());
         if (services.contains(t.getService())) {
             return true;
         }

--- a/flink_jobs/status_trends/src/main/java/argo/functions/calctimelines/TopologyMetricFilter.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/calctimelines/TopologyMetricFilter.java
@@ -6,6 +6,10 @@
 package argo.functions.calctimelines;
 
 import argo.avro.MetricData;
+import argo.profiles.AggregationProfileParser;
+import argo.profiles.MetricProfileParser;
+import argo.profiles.TopologyEndpointParser;
+import argo.profiles.TopologyGroupParser;
 import java.util.ArrayList;
 import java.util.HashMap;
 import org.apache.flink.api.common.functions.FilterFunction;
@@ -20,28 +24,50 @@ import org.apache.flink.api.common.functions.FilterFunction;
  */
 public class TopologyMetricFilter implements FilterFunction<MetricData> {
 
-    private HashMap<String, String> groupEndpoints;
-    private HashMap<String, ArrayList<String>> metricProfileData;
+//    private HashMap<String, String> topologyEndpoints;
+//    private HashMap<String, ArrayList<String>> metricProfileData;
+//
+//    private ArrayList<String> topologyGroups;
+//    
+    private MetricProfileParser metricProfileParser;
+    private TopologyEndpointParser topologyEndpointParser;
+    private TopologyGroupParser topologyGroupParser;
+    private AggregationProfileParser aggregationProfileParser;
 
-    public TopologyMetricFilter(HashMap<String, ArrayList<String>> metricProfileData, HashMap<String, String> groupEndpoints) {
-        this.metricProfileData = metricProfileData;
-        this.groupEndpoints = groupEndpoints;
-
+    public TopologyMetricFilter(MetricProfileParser metricProfileParser, TopologyEndpointParser topologyEndpointParser, TopologyGroupParser topologyGroupParser, AggregationProfileParser aggregationProfileParser) {
+        this.metricProfileParser = metricProfileParser;
+        this.topologyEndpointParser = topologyEndpointParser;
+        this.topologyGroupParser = topologyGroupParser;
+        this.aggregationProfileParser=aggregationProfileParser;
     }
 
+//    public TopologyMetricFilter(HashMap<String, ArrayList<String>> metricProfileData, HashMap<String, String> topologyEndpoints, ArrayList<String> topologyGroups) {
+//        this.metricProfileData = metricProfileData;
+//        this.topologyEndpoints = topologyEndpoints;
+//        this.topologyGroups = topologyGroups;
+//    }
     @Override
     public boolean filter(MetricData t) throws Exception {
-        String group = this.groupEndpoints.get(t.getHostname().toString() + "-" + t.getService().toString()); //retrieve the group for the service, as contained in file group_endpoints. if group is null exit 
-        boolean hasGroup = false, hasMetric = false;
-        if (group != null) {
+
+        String group=topologyEndpointParser.retrieveGroup(aggregationProfileParser.getEndpointGroup().toUpperCase(), t.getHostname() + "-" + t.getService());
+//        String group = this.topologyEndpoints.get(t.getHostname().toString() + "-" + t.getService().toString()); //retrieve the group for the service, as contained in file group_endpoints. if group is null exit 
+        boolean hasGroup = false;
+         if (topologyGroupParser.containsGroup(group) && group != null) {
             hasGroup = true;
         }
-        if (hasGroup && metricProfileData.get(t.getService().toString()) != null && metricProfileData.get(t.getService().toString()).contains(t.getMetric().toString())) { //if metric is contained in file metrics_profile_data 
-           return true;
+        if (hasGroup && metricProfileParser.containsMetric(t.getService().toString(),t.getMetric().toString())){
+
+            return true;
         }
-        
-        
+
+//        if (this.topologyGroups.contains(group) && group != null) {
+//            hasGroup = true;
+//        }
+//        if (hasGroup && metricProfileData.get(t.getService().toString()) != null && metricProfileData.get(t.getService().toString()).contains(t.getMetric().toString())) { //if metric is contained in file metrics_profile_data 
+//
+//            return true;
+//        }
+//
         return false;
     }
-
 }

--- a/flink_jobs/status_trends/src/main/java/argo/functions/calctrends/CalcEndpointFlipFlopTrends.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/calctrends/CalcEndpointFlipFlopTrends.java
@@ -40,9 +40,7 @@ public class CalcEndpointFlipFlopTrends extends RichGroupReduceFunction<MetricTr
     public void reduce(Iterable<MetricTrends> in, Collector< EndpointTrends> out) throws Exception {
         String group = null;
         String service = null;
-        String hostname = null;
-        ArrayList<EndpointTrends> list = new ArrayList<>();
-       
+        String hostname = null;    
        //store the necessary info
        //collect all timelines in a list
         ArrayList<Timeline> timelinelist = new ArrayList<>();

--- a/flink_jobs/status_trends/src/main/java/argo/functions/calctrends/CalcGroupFlipFlop.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/calctrends/CalcGroupFlipFlop.java
@@ -1,0 +1,59 @@
+package argo.functions.calctrends;
+
+
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+import argo.functions.calctimelines.TimelineMerger;
+import argo.pojos.GroupFunctionTrends;
+import argo.pojos.GroupTrends;
+import argo.pojos.Timeline;
+import argo.profiles.AggregationProfileParser;
+import argo.profiles.OperationsParser;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.TreeMap;
+import org.apache.flink.api.common.functions.GroupReduceFunction;
+import org.apache.flink.util.Collector;
+
+/**
+ *
+ * @author cthermolia
+ *
+ * CalcServiceEndpointFlipFlop, count status changes for each service endpoint
+ * group
+ */
+public class CalcGroupFlipFlop implements GroupReduceFunction< GroupFunctionTrends, GroupTrends> {
+
+    private OperationsParser operationsParser;
+    private String groupOperation;
+
+    public CalcGroupFlipFlop(OperationsParser operationsParser, AggregationProfileParser aggregationProfileParser) {
+        this.operationsParser = operationsParser;
+        this.groupOperation = aggregationProfileParser.getProfileOp();
+    }
+
+    @Override
+    public void reduce(Iterable<GroupFunctionTrends> in, Collector< GroupTrends> out) throws Exception {
+        String group = null;
+
+        ArrayList<Timeline> timelist = new ArrayList<>();
+        for (GroupFunctionTrends time : in) {
+            group = time.getGroup();
+            timelist.add(time.getTimeline());
+        }
+        TimelineMerger timelineMerger = new TimelineMerger(groupOperation, operationsParser);
+
+        Timeline timeline = timelineMerger.mergeTimelines(timelist);
+        int flipflops = timeline.calculateStatusChanges();
+
+        GroupTrends groupTrends = new GroupTrends(group, timeline, flipflops);
+        out.collect(groupTrends);
+
+    }
+
+}

--- a/flink_jobs/status_trends/src/main/java/argo/functions/calctrends/CalcGroupFunctionFlipFlop.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/calctrends/CalcGroupFunctionFlipFlop.java
@@ -1,0 +1,64 @@
+package argo.functions.calctrends;
+
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+import argo.functions.calctimelines.TimelineMerger;
+import argo.pojos.GroupFunctionTrends;
+import argo.pojos.ServiceTrends;
+import argo.pojos.Timeline;
+import argo.profiles.AggregationProfileParser;
+import argo.profiles.OperationsParser;
+import java.util.ArrayList;
+import java.util.HashMap;
+import org.apache.flink.api.common.functions.GroupReduceFunction;
+import org.apache.flink.util.Collector;
+
+/**
+ *
+ * @author cthermolia
+ *
+ * CalcGroupFunctionFlipFlop, count status changes for each group function
+ * group
+ */
+public class CalcGroupFunctionFlipFlop implements GroupReduceFunction< ServiceTrends, GroupFunctionTrends> {
+
+    private OperationsParser operationsParser;
+
+    private HashMap<String,String> functionOperations;
+
+    public CalcGroupFunctionFlipFlop(OperationsParser operationsParser, AggregationProfileParser aggregationProfileParser ) {
+        this.operationsParser = operationsParser;
+        this.functionOperations=aggregationProfileParser.getFunctionOperations();
+    }
+
+    @Override
+    public void reduce(Iterable<ServiceTrends> in, Collector< GroupFunctionTrends> out) throws Exception {
+        String group = null;
+        String function = null;
+       // ArrayList<Timeline> list = new ArrayList<>();
+        //construct a timeline containing all the timestamps of each metric timeline
+
+      
+        ArrayList<Timeline> timelist = new ArrayList<>();
+        for (ServiceTrends time : in) {
+            group = time.getGroup();
+            function=time.getFunction();
+            timelist.add(time.getTimeline());
+        }
+        String operation=functionOperations.get(function);  //for each function an operation exists , so retrieve the corresponding truth table
+        TimelineMerger timelineMerger = new TimelineMerger(operation,operationsParser);
+
+      
+        Timeline timeline= timelineMerger.mergeTimelines(timelist);
+        int flipflops = timeline.calculateStatusChanges();
+
+        GroupFunctionTrends groupFunctionTrends = new GroupFunctionTrends(group, function, timeline, flipflops);
+        out.collect(groupFunctionTrends);
+
+    }
+
+}

--- a/flink_jobs/status_trends/src/main/java/argo/functions/calctrends/CalcStatusTrends.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/calctrends/CalcStatusTrends.java
@@ -6,6 +6,8 @@ package argo.functions.calctrends;
  * and open the template in the editor.
  */
 import argo.avro.MetricData;
+import argo.profiles.AggregationProfileParser;
+import argo.profiles.TopologyEndpointParser;
 import java.text.ParseException;
 import java.util.HashMap;
 import java.util.TreeMap;
@@ -24,12 +26,19 @@ import org.apache.flink.util.Collector;
  */
 public class CalcStatusTrends implements GroupReduceFunction<MetricData, Tuple6<String, String, String, String, String, Integer>> {
 
-    private  HashMap<String, String> groupEndpoints;
+    //private  HashMap<String, String> groupEndpoints;
+    private TopologyEndpointParser topologyEndpointParser;
+    private AggregationProfileParser aggregationProfileParser;
+//    public CalcStatusTrends(HashMap<String, String> groupEndpoints) {
+//        this.groupEndpoints = groupEndpoints;
+//    }
 
-    public CalcStatusTrends(HashMap<String, String> groupEndpoints) {
-        this.groupEndpoints = groupEndpoints;
+    public CalcStatusTrends(TopologyEndpointParser topologyEndpointParser,AggregationProfileParser aggregationProfileParser) {
+        this.topologyEndpointParser = topologyEndpointParser;
+        this.aggregationProfileParser=aggregationProfileParser;
     }
 
+    
     /**
      * for each service endpoint metric Iterable check the MetricData status ,
      * keep counter for each status(CRITICAL, WARNING,UNKNOWN) and provide
@@ -53,8 +62,9 @@ public class CalcStatusTrends implements GroupReduceFunction<MetricData, Tuple6<
 
         //for each MetricData in group check the status and increase counter accordingly
         for (MetricData md : in) {
-            group = groupEndpoints.get(md.getHostname().toString() + "-" + md.getService().toString()); //retrieve the group for the service, as contained in file group_endpoints. if group is null exit 
-            hostname = md.getHostname().toString();
+           // group = groupEndpoints.get(md.getHostname().toString() + "-" + md.getService().toString()); //retrieve the group for the service, as contained in file group_endpoints. if group is null exit 
+            group=topologyEndpointParser.retrieveGroup(aggregationProfileParser.getEndpointGroup().toUpperCase(), md.getHostname().toString() + "-" + md.getService().toString());
+           hostname = md.getHostname().toString();
             service = md.getService().toString();
             status = md.getStatus().toString();
             metric = md.getMetric().toString();

--- a/flink_jobs/status_trends/src/main/java/argo/pojos/GroupFunctionTrends.java
+++ b/flink_jobs/status_trends/src/main/java/argo/pojos/GroupFunctionTrends.java
@@ -1,0 +1,65 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package argo.pojos;
+
+/**
+ *
+ * @author cthermolia
+ *
+ * GroupFunctionTrends, describes the computed trend information extracted from the
+ * timelines at the level of group function groups
+ */
+public class GroupFunctionTrends {
+
+    String group;
+    String function;
+    Timeline timeline;
+    Integer flipflops;
+
+    public GroupFunctionTrends() {
+    }
+
+    public GroupFunctionTrends(String group, String function, Timeline timeline, Integer flipflops) {
+        this.group = group;
+        this.function = function;
+        this.timeline = timeline;
+        this.flipflops = flipflops;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public void setGroup(String group) {
+        this.group = group;
+    }
+
+    public String getFunction() {
+        return function;
+    }
+
+    public void setFunction(String function) {
+        this.function = function;
+    }
+
+    public Timeline getTimeline() {
+        return timeline;
+    }
+
+    public void setTimeline(Timeline timeline) {
+        this.timeline = timeline;
+    }
+
+    public Integer getFlipflops() {
+        return flipflops;
+    }
+
+    public void setFlipflops(Integer flipflops) {
+        this.flipflops = flipflops;
+    }
+
+  
+}

--- a/flink_jobs/status_trends/src/main/java/argo/pojos/GroupTrends.java
+++ b/flink_jobs/status_trends/src/main/java/argo/pojos/GroupTrends.java
@@ -1,0 +1,54 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package argo.pojos;
+
+/**
+ *
+ * @author cthermolia MetricTrends, describes the computed trend information
+ * extracted from the set of the timelines at the level of group service
+ * endpoints metrics groups  *
+ */
+public class GroupTrends {
+
+    String group;
+
+    Timeline timeline;
+    Integer flipflops;
+
+    public GroupTrends() {
+    }
+
+    public GroupTrends(String group, Timeline timeline, Integer flipflops) {
+        this.group = group;
+        this.timeline = timeline;
+        this.flipflops = flipflops;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public void setGroup(String group) {
+        this.group = group;
+    }
+
+    public Timeline getTimeline() {
+        return timeline;
+    }
+
+    public void setTimeline(Timeline timeline) {
+        this.timeline = timeline;
+    }
+
+    public Integer getFlipflops() {
+        return flipflops;
+    }
+
+    public void setFlipflops(Integer flipflops) {
+        this.flipflops = flipflops;
+    }
+
+}

--- a/flink_jobs/status_trends/src/main/java/argo/profiles/AggregationProfileParser.java
+++ b/flink_jobs/status_trends/src/main/java/argo/profiles/AggregationProfileParser.java
@@ -7,6 +7,7 @@ package argo.profiles;
 
 import argo.utils.RequestManager;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -19,7 +20,7 @@ import org.json.simple.parser.ParseException;
  * @author cthermolia AggregationProfileParser, collects data as described in
  * the json received from web api aggregation profiles request
  */
-public class AggregationProfileParser {
+public class AggregationProfileParser implements Serializable{
 
     private String id;
     private String date;
@@ -30,11 +31,11 @@ public class AggregationProfileParser {
     private String profileOp;
     private String[] metricProfile = new String[2];
     private ArrayList<GroupOps> groups = new ArrayList<>();
-
     private HashMap<String, String> serviceOperations = new HashMap<>();
     private HashMap<String, String> functionOperations = new HashMap<>();
     private HashMap<String, ArrayList<String>> serviceFunctions = new HashMap<>();
     private final String url = "/aggregation_profiles";
+
 
     public AggregationProfileParser(String apiUri, String key, String proxy, String aggregationId, String dateStr) throws IOException, ParseException {
 
@@ -52,9 +53,7 @@ public class AggregationProfileParser {
 
         JSONArray dataList = (JSONArray) jsonObject.get("data");
 
-        //Iterator<JSONObject> iterator = dataList.iterator();
-        // while (iterator.hasNext()) {
-        //   if (iterator.next() instanceof JSONObject) {
+
         JSONObject dataObject = (JSONObject) dataList.get(0);
 
         id = (String) dataObject.get("id");
@@ -93,6 +92,7 @@ public class AggregationProfileParser {
                     ArrayList<String> serviceFunctionList=new ArrayList<>();
                     if(serviceFunctions.get(servicename)!=null){
                         serviceFunctionList=serviceFunctions.get(servicename);
+
                     }
                     serviceFunctionList.add(groupname);
                     serviceFunctions.put(servicename, serviceFunctionList);
@@ -106,10 +106,16 @@ public class AggregationProfileParser {
         //}
     }
 
+
+    public ArrayList<String> retrieveServiceFunctions(String service){
+        return serviceFunctions.get(service);
+    
+    }
     public String getServiceOperation(String service) {
         return serviceOperations.get(service);
 
     }
+
 
     public String getFunctionOperation(String function) {
         return functionOperations.get(function);
@@ -160,6 +166,8 @@ public class AggregationProfileParser {
         this.serviceOperations = serviceOperations;
     }
 
+   
+
     public HashMap<String, String> getFunctionOperations() {
         return functionOperations;
     }
@@ -175,10 +183,10 @@ public class AggregationProfileParser {
     public void setServiceFunctions(HashMap<String, ArrayList<String>> serviceFunctions) {
         this.serviceFunctions = serviceFunctions;
     }
-
   
-   
-    public static class GroupOps {
+
+    public static class GroupOps implements Serializable {
+
 
         private String name;
         private String operation;

--- a/flink_jobs/status_trends/src/main/java/argo/profiles/MetricProfileParser.java
+++ b/flink_jobs/status_trends/src/main/java/argo/profiles/MetricProfileParser.java
@@ -7,6 +7,7 @@ package argo.profiles;
 
 import argo.utils.RequestManager;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -22,7 +23,7 @@ import org.json.simple.parser.ParseException;
  * MetricProfileParser, collects data as described in the json received from web
  * api metric profiles request
  */
-public class MetricProfileParser {
+public class MetricProfileParser implements Serializable{
 
     private String id;
     private String date;
@@ -32,7 +33,10 @@ public class MetricProfileParser {
     private HashMap<String, ArrayList<String>> metricData;
     private final String url = "/metric_profiles";
 
-    public class Services {
+    public MetricProfileParser() {
+    }
+
+    public class Services implements Serializable{
 
         private String service;
         private ArrayList<String> metrics;
@@ -101,6 +105,14 @@ public class MetricProfileParser {
                 }
             }
         }
+    }
+    
+    public boolean containsMetric(String service, String metric){
+    
+        if(metricData.get(service)!=null && metricData.get(service).contains(metric)){
+            return true;
+        }
+        return false;
     }
 
     public String getId() {

--- a/flink_jobs/status_trends/src/main/java/argo/profiles/ProfilesLoader.java
+++ b/flink_jobs/status_trends/src/main/java/argo/profiles/ProfilesLoader.java
@@ -84,4 +84,13 @@ public class ProfilesLoader {
         this.aggregationProfileParser = aggregationProfileParser;
     }
 
+    public TopologyGroupParser getTopolGroupParser() {
+        return topolGroupParser;
+    }
+
+    public void setTopolGroupParser(TopologyGroupParser topolGroupParser) {
+        this.topolGroupParser = topolGroupParser;
+    }
+    
+
 }

--- a/flink_jobs/status_trends/src/main/java/argo/profiles/TopologyEndpointParser.java
+++ b/flink_jobs/status_trends/src/main/java/argo/profiles/TopologyEndpointParser.java
@@ -7,6 +7,7 @@ package argo.profiles;
 
 import argo.utils.RequestManager;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -18,23 +19,28 @@ import org.json.simple.parser.ParseException;
 /**
  *
  * @author cthermolia
- * 
- * * TopologyEndpointParser, collects data as described in the json received from web api topology endpoint request
+ *
+ * * TopologyEndpointParser, collects data as described in the json received
+ * from web api topology endpoint request
  */
-public class TopologyEndpointParser {
+public class TopologyEndpointParser implements Serializable{
 
-    private HashMap<String, ArrayList<EndpointGroup>> endpointGroups;
+    private HashMap<String, ArrayList<EndpointGroup>> topologyEndPointsPerType;
 
     private HashMap<String, HashMap<String, String>> topologyEndpoint;
     private final String url = "/topology/endpoints/by_report";
 // private final String url = "/topology/endpoints";
 
+    public TopologyEndpointParser() {
+    }
+
+    
     public TopologyEndpointParser(String apiUri, String key, String proxy, String date, String reportname) throws IOException, ParseException {
         // by_report/{report-name}?date=YYYY-MM-DD
         String uri = apiUri + url + "/" + reportname;
-             // String uri = apiUri + url;
- 
-       if (date != null) {
+        // String uri = apiUri + url;
+
+        if (date != null) {
             uri = uri + "?date=" + date;
         }
         loadTopologyEndpoints(uri, key, proxy);
@@ -46,7 +52,7 @@ public class TopologyEndpointParser {
     }
 
     private void loadTopologyEndpoints(String uri, String key, String proxy) throws IOException, ParseException {
-        endpointGroups = new HashMap<>();
+        topologyEndPointsPerType = new HashMap<>();
         topologyEndpoint = new HashMap<>();
         JSONObject jsonObject = RequestManager.request(uri, key, proxy);
 
@@ -81,20 +87,35 @@ public class TopologyEndpointParser {
                 EndpointGroup endpointGroup = new EndpointGroup(group, hostname, service, key, tag);
 
                 ArrayList<EndpointGroup> topologies = new ArrayList<>();
-                if (endpointGroups.get(type) != null) {
-                    topologies = endpointGroups.get(type);
+                if (topologyEndPointsPerType.get(type) != null) {
+                    topologies = topologyEndPointsPerType.get(type);
                 }
                 topologies.add(endpointGroup);
             }
         }
 
     }
-
-    public HashMap<String, ArrayList<EndpointGroup>> getEndpointGroups() {
-        return endpointGroups;
+    public String retrieveGroup(String type, String serviceEndpoint){
+       return  topologyEndpoint.get(type).get(serviceEndpoint);
+    
+    }
+    public HashMap<String, ArrayList<EndpointGroup>> getTopologyEndPointsPerType() {
+        return topologyEndPointsPerType;
     }
 
-    public class EndpointGroup {
+    public void setTopologyEndPointsPerType(HashMap<String, ArrayList<EndpointGroup>> topologyEndPointsPerType) {
+        this.topologyEndPointsPerType = topologyEndPointsPerType;
+    }
+
+    public HashMap<String, HashMap<String, String>> getTopologyEndpoint() {
+        return topologyEndpoint;
+    }
+
+    public void setTopologyEndpoint(HashMap<String, HashMap<String, String>> topologyEndpoint) {
+        this.topologyEndpoint = topologyEndpoint;
+    }
+
+    public class EndpointGroup  implements Serializable{
 
         private String group;
 

--- a/flink_jobs/status_trends/src/main/java/argo/profiles/TopologyGroupParser.java
+++ b/flink_jobs/status_trends/src/main/java/argo/profiles/TopologyGroupParser.java
@@ -7,6 +7,7 @@ package argo.profiles;
 
 import argo.utils.RequestManager;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -19,14 +20,20 @@ import org.json.simple.parser.ParseException;
  *
  * @author cthermolia
  *
- * TopologyGroupParser, collects data as described in the json received from web api topology group request
+ * TopologyGroupParser, collects data as described in the json received from web
+ * api topology group request
  */
-public class TopologyGroupParser {
+public class TopologyGroupParser implements Serializable{
 
-    private HashMap<String, ArrayList<TopologyGroup>> topologyGroups = new HashMap<>();
+    private HashMap<String, ArrayList<TopologyGroup>> topologyGroupsPerType = new HashMap<>();
+    private ArrayList<String> topologyGroups = new ArrayList<>();
     private final String url = "/topology/groups/by_report";
     //private final String url = "/topology/groups";
 
+    public TopologyGroupParser() {
+    }
+
+    
     public TopologyGroupParser(String apiUri, String key, String proxy, String date, String reportname) throws IOException, ParseException {
         String uri = apiUri + url + "/" + reportname;
         // String uri = apiUri + url;
@@ -50,6 +57,7 @@ public class TopologyGroupParser {
                 String group = (String) jsonDataObj.get("group");
                 String type = (String) jsonDataObj.get("type");
                 String subgroup = (String) jsonDataObj.get("subgroup");
+                topologyGroups.add(subgroup);
                 JSONObject tagsObj = (JSONObject) jsonDataObj.get("tags");
                 Tags tag = null;
                 if (tagsObj != null) {
@@ -70,22 +78,40 @@ public class TopologyGroupParser {
 
                 TopologyGroup topologyGroup = new TopologyGroup(group, type, subgroup, tag, notification);
                 ArrayList<TopologyGroup> groupList = new ArrayList<>();
-                if (topologyGroups.get(type) != null) {
-                    groupList = topologyGroups.get(type);
+                if (topologyGroupsPerType.get(type) != null) {
+                    groupList = topologyGroupsPerType.get(type);
                 }
                 groupList.add(topologyGroup);
-                topologyGroups.put(type, groupList);
+                topologyGroupsPerType.put(type, groupList);
 
             }
 
         }
     }
 
-    public HashMap<String, ArrayList<TopologyGroup>> getTopologyGroups() {
+    public boolean containsGroup(String group){
+        if(topologyGroups.contains(group)){
+            return true;
+        }
+        return false;
+    }
+    public HashMap<String, ArrayList<TopologyGroup>> getTopologyGroupsPerType() {
+        return topologyGroupsPerType;
+    }
+
+    public void setTopologyGroupsPerType(HashMap<String, ArrayList<TopologyGroup>> topologyGroupsPerType) {
+        this.topologyGroupsPerType = topologyGroupsPerType;
+    }
+
+    public ArrayList<String> getTopologyGroups() {
         return topologyGroups;
     }
 
-    public class TopologyGroup {
+    public void setTopologyGroups(ArrayList<String> topologyGroups) {
+        this.topologyGroups = topologyGroups;
+    }
+
+    public class TopologyGroup implements Serializable{
 
         private String group;
         private String type;
@@ -124,7 +150,7 @@ public class TopologyGroupParser {
 
     }
 
-    public class Tags {
+    public class Tags implements Serializable{
 
         private String scope;
         private String infrastructure;
@@ -150,7 +176,7 @@ public class TopologyGroupParser {
 
     }
 
-    public class Notifications {
+    public class Notifications implements Serializable{
 
         private String contacts;
         private String enabled;


### PR DESCRIPTION
### **Goal**
To calculate the satus flip flops for groups of services

### **Implementation**
Based on #168 group by group  and calculate the flip flops. **BatchGroupFlipFlopTrends class** is added to describe the jobs. 
Firstly a function is added to the results coming from the **CalcServiceFlipFlop class** computations, to descibe the group info in the aggregations profile data. This is done by **MapServices class**. 
Next data are grouped by group, function in **CalcGroupFunctionFlipFlop class** computations. Result are objects of **GroupFunctionTrends class**  
**ServiceTrends class** holds the information of the results and these are written in mongodb. **CalcServiceFlipFlop class** implements the calculation
Next data are grouped by group, calculations are made at **CalcGroupFlipFlop class**. Results are objects of **GroupTrends class** and are written in mongodb
Changes made at **TopologyMetricFilter class**, to add topology groups as a filter (groups from topology endpoint data pass the filter if they are contained also in topology group data (as subgroups) )
