### PR TITLE
ARGO-3071 Compute all flip flop trends in one job and add a flag to clear mongo db

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,8 @@ Job requires parameters:
 `--apiUri`                    : uri to the web-api
 `--key`                       : users's token, used for authentication
 `--proxy`                     : (optional) proxy url 
+`--clearMongo`                : (optional) defines if the collections in mongo will be 					 cleared from previous documents or not. if false or is 					 missing collection will remain as it is 
+
 
 Flink batch Job that calculate flip flop trends for service endpoints metrics
 Job requires parameters:
@@ -391,8 +393,10 @@ Job requires parameters:
 `--apiUri`                     : uri to the web-api
 `--key`                        : users's token, used for authentication
 `--proxy`                      : (optional) proxy url 
+`--clearMongo`                 : (optional) defines if the collections in mongo will be 					  cleared from previous documents or not. if false or is 					  missing collection will remain as it is 
 
-Flink batch Job that calculate flip flop trends for service endpoints 
+
+Flink batch Job that calculate flip flop trends for service endpoints
 Job requires parameters:
 
 `--yesterdayData`              : file location of previous day's data
@@ -402,3 +406,44 @@ Job requires parameters:
 `--apiUri`                     : uri to the web-api
 `--key`                        : users's token, used for authentication
 `--proxy`                      : (optional) proxy url 
+`--clearMongo`                 : (optional) defines if the collections in mongo will be 					  cleared from previous documents or not. if false or is 					  missing collection will remain as it is 
+
+
+Flink batch Job that calculate flip flop trends for service  
+Job requires parameters:
+
+`--yesterdayData`              : file location of previous day's data
+`--todayData`                  : file location of today day's data
+`--N`              		: (optional) number of displayed top results
+`--mongoUri`                   : uri to the mongo db , to store results
+`--apiUri`                     : uri to the web-api
+`--key`                        : users's token, used for authentication
+`--proxy`                      : (optional) proxy url 
+`--clearMongo`                 : (optional) defines if the collections in mongo will be 					  cleared from previous documents or not. if false or is 					  missing collection will remain as it is 
+
+
+Flink batch Job that calculate flip flop trends for groups 
+Job requires parameters:
+
+`--yesterdayData`              : file location of previous day's data
+`--todayData`                  : file location of today day's data
+`--N`              		: (optional) number of displayed top results
+`--mongoUri`                   : uri to the mongo db , to store results
+`--apiUri`                     : uri to the web-api
+`--key`                        : users's token, used for authentication
+`--proxy`                      : (optional) proxy url 
+`--clearMongo`                 : (optional) defines if the collections in mongo will be cleared from previous documents or not. if false or is missing collection will remain as it is 
+
+Flink batch Job that calculate flip flop trends for all levels of groups
+Job requires parameters:
+
+`--yesterdayData`              : file location of previous day's data
+`--todayData`                  : file location of today day's data
+`--N`              		: (optional) number of displayed top results
+`--mongoUri`                   : uri to the mongo db , to store results
+`--apiUri`                     : uri to the web-api
+`--key`                        : users's token, used for authentication
+`--proxy`                      : (optional) proxy url 
+`--clearMongo`                 : (optional) defines if the collections in mongo will be 					  cleared from previous documents or not. if false or is 					  missing collection will remain as it is 
+
+

--- a/flink_jobs/status_trends/pom.xml
+++ b/flink_jobs/status_trends/pom.xml
@@ -94,12 +94,7 @@ under the License.
             <artifactId>flink-hadoop-compatibility_2.10</artifactId>
             <version>${flink.version}</version>
         </dependency>
-             
-        <dependency>
-            <groupId>org.mongodb</groupId>
-            <artifactId>mongo-hadoop-core</artifactId>
-            <version>${mongodb.hadoop.version}</version>
-        </dependency>
+     
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>

--- a/flink_jobs/status_trends/src/main/java/argo/batch/BatchEndpointFlipFlopTrends.java
+++ b/flink_jobs/status_trends/src/main/java/argo/batch/BatchEndpointFlipFlopTrends.java
@@ -24,22 +24,14 @@ import argo.functions.calctrends.CalcMetricFlipFlopTrends;
 import argo.pojos.EndpointTrends;
 import argo.pojos.MetricTrends;
 import argo.utils.Utils;
-import com.mongodb.hadoop.io.BSONWritable;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.utils.ParameterTool;
-import org.apache.hadoop.io.Text;
 import argo.profiles.ProfilesLoader;
-import com.mongodb.BasicDBObject;
-import com.mongodb.hadoop.mapred.MongoOutputFormat;
-import java.util.Date;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.operators.Order;
-import org.apache.flink.api.java.hadoop.mapred.HadoopOutputFormat;
 import org.apache.flink.api.java.io.AvroInputFormat;
 import org.apache.flink.core.fs.Path;
-import org.apache.hadoop.mapred.JobConf;
 
 /**
  * Skeleton for a Flink Batch Job.
@@ -56,15 +48,16 @@ import org.apache.hadoop.mapred.JobConf;
  *
  * http://flink.apache.org/docs/latest/apis/cli.html
  */
-public class BatchServEndpFlipFlopTrends {
+public class BatchEndpointFlipFlopTrends {
 
     private static DataSet<MetricData> yesterdayData;
     private static DataSet<MetricData> todayData;
     private static Integer rankNum;
-    private static final String endpointTrends = "endpointTrends";
-    private static String mongoUri;
+  private static final String endpointTrends = "flipflop_trends_endpoints";
+      private static String mongoUri;
     private static ProfilesLoader profilesLoader;
     private static String profilesDate;
+
     private static String reportId;
     private static String format = "yyyy-MM-dd";
    private static boolean clearMongo=false;
@@ -75,8 +68,11 @@ public class BatchServEndpFlipFlopTrends {
 
         ParameterTool params = ParameterTool.fromArgs(args);
         //check if all required parameters exist and if not exit program
+
+
         if (!Utils.checkParameters(params, "yesterdayData", "todayData", "mongoUri", "apiUri", "key", "reportId", "date")) {
-            System.exit(0);
+           System.exit(0);
+
         }
 
         env.setParallelism(1);
@@ -93,11 +89,8 @@ public class BatchServEndpFlipFlopTrends {
         yesterdayData = readInputData(env, params, "yesterdayData");
         todayData = readInputData(env, params, "todayData");
 
-        // calculate on data 
-       // DataSet<EndpointTrends> resultData = 
-       calcFlipFlops();
-        //writeToMongo(resultData);
 
+        calcFlipFlops();
 // execute program
         env.execute("Flink Batch Java API Skeleton");
 
@@ -111,11 +104,11 @@ public class BatchServEndpFlipFlopTrends {
 
         DataSet<MetricData> filteredYesterdayData = yesterdayData.filter(new TopologyMetricFilter(profilesLoader.getMetricProfileParser(), profilesLoader.getTopologyEndpointParser(), profilesLoader.getTopolGroupParser(), profilesLoader.getAggregationProfileParser())).groupBy("hostname", "service", "metric").reduceGroup(new CalcLastTimeStatus());
         DataSet<MetricData> filteredTodayData = todayData.filter(new TopologyMetricFilter(profilesLoader.getMetricProfileParser(), profilesLoader.getTopologyEndpointParser(), profilesLoader.getTopolGroupParser(), profilesLoader.getAggregationProfileParser()));
+      
 
         //group data by service enpoint metric and return for each group , the necessary info and a treemap containing timestamps and status
         DataSet<MetricTrends> serviceEndpointMetricGroupData = filteredTodayData.union(filteredYesterdayData).groupBy("hostname", "service", "metric").reduceGroup(new CalcMetricFlipFlopTrends(profilesLoader.getTopologyEndpointParser(), profilesLoader.getAggregationProfileParser()));
-
-        //group data by service endpoint  and count flip flops
+      //group data by service endpoint  and count flip flops
         DataSet<EndpointTrends> serviceEndpointGroupData = serviceEndpointMetricGroupData.groupBy("group", "endpoint", "service").reduceGroup(new CalcEndpointFlipFlopTrends(profilesLoader.getAggregationProfileParser().getMetricOp(), profilesLoader.getOperationParser()));
 
         if (rankNum != null) { //sort and rank data
@@ -146,52 +139,5 @@ public class BatchServEndpFlipFlopTrends {
         inputData = env.createInput(inputAvroFormat);
         return inputData;
     }
-
-////    //initialize configuaration parameters to be used from functions
-    //  private static void initializeConfigurationParameters(ParameterTool params, ExecutionEnvironment env) {
-//
-//        Configuration conf = new Configuration();
-//        conf.setClass("opParser", OperationsParser.class);
-//      
-//        env.getConfig().setGlobalJobParameters(conf);
-//
-    // }
-    //convert the result in bson format
-    public static DataSet<Tuple2<Text, BSONWritable>> convertResultToBSON(DataSet<EndpointTrends> in) {
-
-        return in.map(new MapFunction<EndpointTrends, Tuple2<Text, BSONWritable>>() {
-            int i = 0;
-
-            @Override
-            public Tuple2<Text, BSONWritable> map(EndpointTrends in) throws Exception {
-                BasicDBObject dbObject = new BasicDBObject();
-                dbObject.put("date", profilesDate);
-                dbObject.put("group", in.getGroup());
-                dbObject.put("service", in.getService());
-                dbObject.put("hostname", in.getEndpoint());
-                dbObject.put("trend", in.getFlipflops());
-
-                BSONWritable bson = new BSONWritable(dbObject);
-                i++;
-                return new Tuple2<Text, BSONWritable>(new Text(String.valueOf(i)), bson);
-                /* TODO */
-            }
-        });
-    }
-
-    //write to mongo db
-    public static void writeToMongo(DataSet<EndpointTrends> data) {
-        String collectionUri = mongoUri + "." + endpointTrends;
-        DataSet<Tuple2<Text, BSONWritable>> result = convertResultToBSON(data);
-        JobConf conf = new JobConf();
-        conf.set("mongo.output.uri", collectionUri);
-
-        MongoOutputFormat<Text, BSONWritable> mongoOutputFormat = new MongoOutputFormat<Text, BSONWritable>();
-        result.output(new HadoopOutputFormat<Text, BSONWritable>(mongoOutputFormat, conf));
-    }
-
-//    public static void createOpTruthTables(String baseUri, String key, String proxy, String operationsId) throws IOException, ParseException {
-//        
-//        opTruthTableMap = Utils.readOperationProfileJson(baseUri, key, proxy, operationsId);
-//    }
+  
 }

--- a/flink_jobs/status_trends/src/main/java/argo/batch/BatchFlipFlopCollection.java
+++ b/flink_jobs/status_trends/src/main/java/argo/batch/BatchFlipFlopCollection.java
@@ -34,19 +34,21 @@ import org.apache.flink.core.fs.Path;
  *
  * @author cthermolia
  */
-public class BatchGroupFlipFlopTrends {
+public class BatchFlipFlopCollection {
 
     private static DataSet<MetricData> yesterdayData;
     private static DataSet<MetricData> todayData;
     private static Integer rankNum;
-    private static final String groupTrends = "flipflop_trends_groups";
+    private static final String groupTrends = "flipflop_trends_endpoint_groups";
+    private static final String metricTrends = "flipflop_trends_metrics";
+    private static final String endpointTrends = "flipflop_trends_endpoints";
+    private static final String serviceTrends = "flipflop_trends_services";
     private static String mongoUri;
     private static ProfilesLoader profilesLoader;
     private static String profilesDate;
     private static String format = "yyyy-MM-dd";
-
     private static String reportId;
-   private static boolean clearMongo=false;
+    private static boolean clearMongo = false;
 
     public static void main(String[] args) throws Exception {
         // set up the batch execution environment
@@ -55,13 +57,12 @@ public class BatchGroupFlipFlopTrends {
         ParameterTool params = ParameterTool.fromArgs(args);
         //check if all required parameters exist and if not exit program
         if (!Utils.checkParameters(params, "yesterdayData", "todayData", "mongoUri", "apiUri", "key", "date", "reportId")) {
-           System.exit(0);
+            System.exit(0);
         }
 
         env.setParallelism(1);
-        if(params.get("clearMongo")!=null && params.getBoolean("clearMongo")==true){
-            clearMongo=true;
-         
+        if (params.get("clearMongo") != null && params.getBoolean("clearMongo") == true) {
+            clearMongo = true;
         }
         reportId = params.getRequired("reportId");
         profilesDate = Utils.getParameterDate(format, params.getRequired("date"));
@@ -74,7 +75,10 @@ public class BatchGroupFlipFlopTrends {
         todayData = readInputData(env, params, "todayData");
 
         // calculate on data 
+        //DataSet<GroupTrends> resultData = 
         calcFlipFlops();
+        //writeToMongo(resultData);
+
 // execute program
         env.execute("Flink Batch Java API Skeleton");
 
@@ -83,20 +87,53 @@ public class BatchGroupFlipFlopTrends {
 // filter yesterdaydata and exclude the ones not contained in topology and metric profile data and get the last timestamp data for each service endpoint metric
 // filter todaydata and exclude the ones not contained in topology and metric profile data , union yesterday data and calculate status changes for each service endpoint metric
 // rank results
-  private static void calcFlipFlops() {
+//    private static DataSet<GroupTrends> calcFlipFlops() {
+    private static void calcFlipFlops() {
 
         DataSet<MetricData> filteredYesterdayData = yesterdayData.filter(new TopologyMetricFilter(profilesLoader.getMetricProfileParser(), profilesLoader.getTopologyEndpointParser(), profilesLoader.getTopolGroupParser(), profilesLoader.getAggregationProfileParser())).groupBy("hostname", "service", "metric").reduceGroup(new CalcLastTimeStatus());
         DataSet<MetricData> filteredTodayData = todayData.filter(new TopologyMetricFilter(profilesLoader.getMetricProfileParser(), profilesLoader.getTopologyEndpointParser(), profilesLoader.getTopolGroupParser(), profilesLoader.getAggregationProfileParser()));
 
         //group data by service enpoint metric and return for each group , the necessary info and a treemap containing timestamps and status
         DataSet<MetricTrends> serviceEndpointMetricGroupData = filteredTodayData.union(filteredYesterdayData).groupBy("hostname", "service", "metric").reduceGroup(new CalcMetricFlipFlopTrends(profilesLoader.getTopologyEndpointParser(), profilesLoader.getAggregationProfileParser()));
+        MongoTrendsOutput metricMongoOut = new MongoTrendsOutput(mongoUri, metricTrends, MongoTrendsOutput.TrendsType.TRENDS_METRIC, reportId, profilesDate, clearMongo);
+
+        DataSet<Trends> trends = serviceEndpointMetricGroupData.map(new MapFunction<MetricTrends, Trends>() {
+
+            @Override
+            public Trends map(MetricTrends in) throws Exception {
+                return new Trends(in.getGroup(), in.getService(), in.getEndpoint(), in.getMetric(), in.getFlipflops());
+            }
+        });
+        trends.output(metricMongoOut);
 
         //group data by service endpoint  and count flip flops
         DataSet<EndpointTrends> serviceEndpointGroupData = serviceEndpointMetricGroupData.groupBy("group", "endpoint", "service").reduceGroup(new CalcEndpointFlipFlopTrends(profilesLoader.getAggregationProfileParser().getMetricOp(), profilesLoader.getOperationParser()));
 
+        metricMongoOut = new MongoTrendsOutput(mongoUri, endpointTrends, MongoTrendsOutput.TrendsType.TRENDS_ENDPOINT, reportId, profilesDate, clearMongo);
+
+        trends = serviceEndpointGroupData.map(new MapFunction<EndpointTrends, Trends>() {
+
+            @Override
+            public Trends map(EndpointTrends in) throws Exception {
+                return new Trends(in.getGroup(), in.getService(), in.getEndpoint(), in.getFlipflops());
+            }
+        });
+        trends.output(metricMongoOut);
+
         //group data by service   and count flip flops
         DataSet<ServiceTrends> serviceGroupData = serviceEndpointGroupData.filter(new ServiceFilter(profilesLoader.getAggregationProfileParser())).groupBy("group", "service").reduceGroup(new CalcServiceFlipFlop(profilesLoader.getOperationParser(), profilesLoader.getAggregationProfileParser()));
-        //flat map data to add function as described in aggregation profile groups
+        metricMongoOut = new MongoTrendsOutput(mongoUri, serviceTrends, MongoTrendsOutput.TrendsType.TRENDS_SERVICE, reportId, profilesDate, clearMongo);
+
+        trends = serviceGroupData.map(new MapFunction<ServiceTrends, Trends>() {
+
+            @Override
+            public Trends map(ServiceTrends in) throws Exception {
+                return new Trends(in.getGroup(), in.getService(), in.getFlipflops());
+            }
+        });
+        trends.output(metricMongoOut);
+
+//flat map data to add function as described in aggregation profile groups
         serviceGroupData = serviceGroupData.flatMap(new MapServices(profilesLoader.getAggregationProfileParser()));
 
         //group data by group,function   and count flip flops
@@ -110,9 +147,10 @@ public class BatchGroupFlipFlopTrends {
         } else {
             groupData = groupData.sortPartition("flipflops", Order.DESCENDING);
         }
-       MongoTrendsOutput metricMongoOut = new MongoTrendsOutput(mongoUri, groupTrends, MongoTrendsOutput.TrendsType.TRENDS_GROUP, reportId, profilesDate, clearMongo);
 
-        DataSet<Trends> trends = groupData.map(new MapFunction<GroupTrends, Trends>() {
+        metricMongoOut = new MongoTrendsOutput(mongoUri, groupTrends, MongoTrendsOutput.TrendsType.TRENDS_GROUP, reportId, profilesDate, clearMongo);
+
+        trends = groupData.map(new MapFunction<GroupTrends, Trends>() {
 
             @Override
             public Trends map(GroupTrends in) throws Exception {
@@ -120,9 +158,10 @@ public class BatchGroupFlipFlopTrends {
             }
         });
         trends.output(metricMongoOut);
+     
+    }  
 
-    }    //read input from file
-
+    //read input from file
     private static DataSet<MetricData> readInputData(ExecutionEnvironment env, ParameterTool params, String path) {
         DataSet<MetricData> inputData;
         Path input = new Path(params.getRequired(path));

--- a/flink_jobs/status_trends/src/main/java/argo/functions/calctimelines/MapServices.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/calctimelines/MapServices.java
@@ -5,6 +5,7 @@ package argo.functions.calctimelines;
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
+
 import argo.pojos.ServiceTrends;
 import argo.profiles.AggregationProfileParser;
 import java.util.ArrayList;
@@ -18,9 +19,14 @@ import org.apache.flink.util.Collector;
  * MapServices produces TimelineTrends for each service,that maps to the groups
  * of functions as described in aggregation profile groups endpoint , metric
  */
+
+
 public class MapServices implements FlatMapFunction<ServiceTrends, ServiceTrends> {
 
     private AggregationProfileParser aggregationProfileParser;
+
+    private HashMap<String, ArrayList<String>> serviceFunctions;
+
     public MapServices(AggregationProfileParser aggregationProfileParser) {
         this.aggregationProfileParser = aggregationProfileParser;
     }
@@ -38,7 +44,7 @@ public class MapServices implements FlatMapFunction<ServiceTrends, ServiceTrends
     public void flatMap(ServiceTrends t, Collector<ServiceTrends> out) throws Exception {
         String service = t.getService();
 
-        ArrayList<String> functionList =aggregationProfileParser.retrieveServiceFunctions(service);
+        ArrayList<String> functionList = aggregationProfileParser.retrieveServiceFunctions(service);
         if (functionList != null) {
             for (String f : functionList) {
                 ServiceTrends newT = t;
@@ -47,5 +53,4 @@ public class MapServices implements FlatMapFunction<ServiceTrends, ServiceTrends
             }
         }
     }
-
 }

--- a/flink_jobs/status_trends/src/main/java/argo/functions/calctimelines/ServiceFilter.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/calctimelines/ServiceFilter.java
@@ -5,10 +5,10 @@ package argo.functions.calctimelines;
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
+
 import argo.pojos.EndpointTrends;
 import argo.profiles.AggregationProfileParser;
 import java.util.ArrayList;
-import java.util.HashMap;
 import org.apache.flink.api.common.functions.FilterFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,7 +22,9 @@ import org.slf4j.LoggerFactory;
 public class ServiceFilter implements FilterFunction<EndpointTrends> {
 
     static Logger LOG = LoggerFactory.getLogger(ServiceFilter.class);
+
     private AggregationProfileParser aggregationProfileParser;
+
     public ServiceFilter(AggregationProfileParser aggregationProfileParser) {
         this.aggregationProfileParser = aggregationProfileParser;
     }

--- a/flink_jobs/status_trends/src/main/java/argo/functions/calctimelines/TopologyMetricFilter.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/calctimelines/TopologyMetricFilter.java
@@ -24,11 +24,6 @@ import org.apache.flink.api.common.functions.FilterFunction;
  */
 public class TopologyMetricFilter implements FilterFunction<MetricData> {
 
-//    private HashMap<String, String> topologyEndpoints;
-//    private HashMap<String, ArrayList<String>> metricProfileData;
-//
-//    private ArrayList<String> topologyGroups;
-//    
     private MetricProfileParser metricProfileParser;
     private TopologyEndpointParser topologyEndpointParser;
     private TopologyGroupParser topologyGroupParser;
@@ -38,36 +33,22 @@ public class TopologyMetricFilter implements FilterFunction<MetricData> {
         this.metricProfileParser = metricProfileParser;
         this.topologyEndpointParser = topologyEndpointParser;
         this.topologyGroupParser = topologyGroupParser;
-        this.aggregationProfileParser=aggregationProfileParser;
-    }
 
-//    public TopologyMetricFilter(HashMap<String, ArrayList<String>> metricProfileData, HashMap<String, String> topologyEndpoints, ArrayList<String> topologyGroups) {
-//        this.metricProfileData = metricProfileData;
-//        this.topologyEndpoints = topologyEndpoints;
-//        this.topologyGroups = topologyGroups;
-//    }
+        this.aggregationProfileParser = aggregationProfileParser;
+    }
     @Override
     public boolean filter(MetricData t) throws Exception {
 
-        String group=topologyEndpointParser.retrieveGroup(aggregationProfileParser.getEndpointGroup().toUpperCase(), t.getHostname() + "-" + t.getService());
-//        String group = this.topologyEndpoints.get(t.getHostname().toString() + "-" + t.getService().toString()); //retrieve the group for the service, as contained in file group_endpoints. if group is null exit 
+        String group = topologyEndpointParser.retrieveGroup(aggregationProfileParser.getEndpointGroup().toUpperCase(), t.getHostname() + "-" + t.getService());
         boolean hasGroup = false;
-         if (topologyGroupParser.containsGroup(group) && group != null) {
+        if (topologyGroupParser.containsGroup(group) && group != null) {
             hasGroup = true;
         }
-        if (hasGroup && metricProfileParser.containsMetric(t.getService().toString(),t.getMetric().toString())){
+        if (hasGroup && metricProfileParser.containsMetric(t.getService().toString(), t.getMetric().toString())) {
+
 
             return true;
         }
-
-//        if (this.topologyGroups.contains(group) && group != null) {
-//            hasGroup = true;
-//        }
-//        if (hasGroup && metricProfileData.get(t.getService().toString()) != null && metricProfileData.get(t.getService().toString()).contains(t.getMetric().toString())) { //if metric is contained in file metrics_profile_data 
-//
-//            return true;
-//        }
-//
         return false;
     }
 }

--- a/flink_jobs/status_trends/src/main/java/argo/profiles/AggregationProfileParser.java
+++ b/flink_jobs/status_trends/src/main/java/argo/profiles/AggregationProfileParser.java
@@ -20,8 +20,8 @@ import org.json.simple.parser.ParseException;
  * @author cthermolia AggregationProfileParser, collects data as described in
  * the json received from web api aggregation profiles request
  */
-public class AggregationProfileParser implements Serializable{
 
+public class AggregationProfileParser implements Serializable {
     private String id;
     private String date;
     private String name;
@@ -31,11 +31,17 @@ public class AggregationProfileParser implements Serializable{
     private String profileOp;
     private String[] metricProfile = new String[2];
     private ArrayList<GroupOps> groups = new ArrayList<>();
+
     private HashMap<String, String> serviceOperations = new HashMap<>();
     private HashMap<String, String> functionOperations = new HashMap<>();
     private HashMap<String, ArrayList<String>> serviceFunctions = new HashMap<>();
     private final String url = "/aggregation_profiles";
-   public AggregationProfileParser(String apiUri, String key, String proxy, String aggregationId, String dateStr) throws IOException, ParseException {
+
+    public AggregationProfileParser() {
+    }
+
+    
+    public AggregationProfileParser(String apiUri, String key, String proxy, String aggregationId, String dateStr) throws IOException, ParseException {
 
         String uri = apiUri + url + "/" + aggregationId;
         if (dateStr != null) {
@@ -51,7 +57,7 @@ public class AggregationProfileParser implements Serializable{
 
         JSONArray dataList = (JSONArray) jsonObject.get("data");
 
-        JSONObject dataObject = (JSONObject) dataList.get(0);
+       JSONObject dataObject = (JSONObject) dataList.get(0);
 
         id = (String) dataObject.get("id");
         date = (String) dataObject.get("date");
@@ -85,34 +91,32 @@ public class AggregationProfileParser implements Serializable{
                     String serviceoperation = (String) servObject.get("operation");
                     serviceOperations.put(servicename, serviceoperation);
                     services.put(servicename, serviceoperation);
-                   
-                    ArrayList<String> serviceFunctionList=new ArrayList<>();
-                    if(serviceFunctions.get(servicename)!=null){
-                        serviceFunctionList=serviceFunctions.get(servicename);
 
-                    }
+                    ArrayList<String> serviceFunctionList = new ArrayList<>();
+                    if (serviceFunctions.get(servicename) != null) {
+                        serviceFunctionList = serviceFunctions.get(servicename);
+                   }
                     serviceFunctionList.add(groupname);
                     serviceFunctions.put(servicename, serviceFunctionList);
                 }
-              
-                groups.add(new GroupOps(groupname, groupoperation, services));
+              groups.add(new GroupOps(groupname, groupoperation, services));
 
             }
         }
     }
 
-
-    public ArrayList<String> retrieveServiceFunctions(String service){
+    public ArrayList<String> retrieveServiceFunctions(String service) {
         return serviceFunctions.get(service);
-    
-    }
+
+   }
+
     public String getServiceOperation(String service) {
         return serviceOperations.get(service);
 
     }
 
+ public String getFunctionOperation(String function) {
 
-    public String getFunctionOperation(String function) {
         return functionOperations.get(function);
 
     }
@@ -160,9 +164,6 @@ public class AggregationProfileParser implements Serializable{
     public void setServiceOperations(HashMap<String, String> serviceOperations) {
         this.serviceOperations = serviceOperations;
     }
-
-   
-
     public HashMap<String, String> getFunctionOperations() {
         return functionOperations;
     }
@@ -178,9 +179,8 @@ public class AggregationProfileParser implements Serializable{
     public void setServiceFunctions(HashMap<String, ArrayList<String>> serviceFunctions) {
         this.serviceFunctions = serviceFunctions;
     }
-  
-
     public static class GroupOps implements Serializable {
+
         private String name;
         private String operation;
         private HashMap<String, String> services;

--- a/flink_jobs/status_trends/src/main/java/argo/profiles/TopologyGroupParser.java
+++ b/flink_jobs/status_trends/src/main/java/argo/profiles/TopologyGroupParser.java
@@ -89,7 +89,7 @@ public class TopologyGroupParser implements Serializable{
         }
     }
 
-    public boolean containsGroup(String group){
+   public boolean containsGroup(String group){
         if(topologyGroups.contains(group)){
             return true;
         }
@@ -111,8 +111,7 @@ public class TopologyGroupParser implements Serializable{
         this.topologyGroups = topologyGroups;
     }
 
-    public class TopologyGroup implements Serializable{
-
+  public class TopologyGroup implements Serializable{
         private String group;
         private String type;
         private String subgroup;

--- a/flink_jobs/status_trends/src/main/java/argo/utils/RequestManager.java
+++ b/flink_jobs/status_trends/src/main/java/argo/utils/RequestManager.java
@@ -5,7 +5,6 @@
  */
 package argo.utils;
 
-import com.google.common.net.HttpHeaders;
 import java.io.IOException;
 import org.apache.http.client.fluent.Executor;
 import org.apache.http.client.fluent.Request;
@@ -27,7 +26,7 @@ public class RequestManager {
         Request request = Request.Get(uri);
         // add request headers
         request.addHeader("x-api-key", key);
-        request.addHeader(HttpHeaders.ACCEPT, "application/json");
+        request.addHeader("Accept", "application/json");
         if (proxy != null) {
             request = request.viaProxy(proxy);
         }

--- a/flink_jobs/status_trends/src/main/java/argo/utils/Utils.java
+++ b/flink_jobs/status_trends/src/main/java/argo/utils/Utils.java
@@ -26,7 +26,7 @@ import java.util.TimeZone;
 public class Utils {
 
     static Logger LOG = LoggerFactory.getLogger(Utils.class);
-    String format = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+    //   String format = "yyyy-MM-dd'T'HH:mm:ss'Z'";
 
     public static String getParameterDate(String format, String paramDate) throws ParseException {
         Date date = convertStringtoDate(format, paramDate);
@@ -38,6 +38,7 @@ public class Utils {
 
     }
 
+    
     public static String convertDateToString(String format, Date date) throws ParseException {
 
         //String format = "yyyy-MM-dd'T'HH:mm:ss'Z'";

--- a/flink_jobs/status_trends/src/test/java/argo/functions/calctimelines/TimelineMergerTest.java
+++ b/flink_jobs/status_trends/src/test/java/argo/functions/calctimelines/TimelineMergerTest.java
@@ -158,7 +158,7 @@ public class TimelineMergerTest {
 
         TreeMap<Date, String> testTimelines = new TreeMap<>();
         //   String format = "yyyy-MM-dd'T'HH:mm:ss'Z'";
-        testTimelines.put(Utils.createDate(format, 2021, 0, 15, 0, 0, 0), EnumStatus.OK.name());
+          testTimelines.put(Utils.createDate(format, 2021, 0, 15, 0, 0, 0), EnumStatus.OK.name());
         testTimelines.put(Utils.createDate(format, 2021, 0, 15, 0, 12, 23), EnumStatus.CRITICAL.name());
         testTimelines.put(Utils.createDate(format, 2021, 0, 15, 1, 5, 10), EnumStatus.CRITICAL.name());
         testTimelines.put(Utils.createDate(format, 2021, 0, 15, 5, 20, 15), EnumStatus.CRITICAL.name());


### PR DESCRIPTION
### **Goal**
To collect all flip flop calculations in one job . and to define if while writing the results the collection to be written will be cleared or not
### 
**Implementation**
**BatchFlipFlopCollection class** was added to defile all the necessary calculations . Parameter **clearMongo** was added in calculations to define if the collection will be cleared or not. if clearMongo is false or is missing the collection in mongo will remain as it is****