### PR TITLE
ARGO-3152 ARGO-3153 minor fixes

### DIFF
--- a/flink_jobs/status_trends/src/main/java/argo/filter/zero/flipflops/ZeroEndpointTrendsFilter.java
+++ b/flink_jobs/status_trends/src/main/java/argo/filter/zero/flipflops/ZeroEndpointTrendsFilter.java
@@ -1,0 +1,36 @@
+package argo.filter.zero.flipflops;
+
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+import argo.functions.calctimelines.ServiceFilter;
+import argo.pojos.EndpointTrends;
+import argo.pojos.MetricTrends;
+import org.apache.flink.api.common.functions.FilterFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author cthermolia
+ *
+ * StatusFilter, filters data by status
+ */
+public class ZeroEndpointTrendsFilter implements FilterFunction<EndpointTrends> {
+
+    static Logger LOG = LoggerFactory.getLogger(ServiceFilter.class);
+
+   
+    //if the status field value in Tuple equals the given status returns true, else returns false
+    @Override
+    public boolean filter(EndpointTrends t) throws Exception {
+        if (t.getFlipflops()>0) {
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/flink_jobs/status_trends/src/main/java/argo/filter/zero/flipflops/ZeroGroupFunctionFilter.java
+++ b/flink_jobs/status_trends/src/main/java/argo/filter/zero/flipflops/ZeroGroupFunctionFilter.java
@@ -1,0 +1,33 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package argo.filter.zero.flipflops;
+
+import argo.functions.calctimelines.ServiceFilter;
+import argo.pojos.GroupFunctionTrends;
+import org.apache.flink.api.common.functions.FilterFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author cthermolia
+ */
+    
+    public class ZeroGroupFunctionFilter implements FilterFunction<GroupFunctionTrends> {
+
+    static Logger LOG = LoggerFactory.getLogger(ZeroGroupFunctionFilter.class);
+
+   
+    //if the status field value in Tuple equals the given status returns true, else returns false
+    @Override
+    public boolean filter(GroupFunctionTrends t) throws Exception {
+        if (t.getFlipflops()>0) {
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/flink_jobs/status_trends/src/main/java/argo/filter/zero/flipflops/ZeroGroupTrendsFilter.java
+++ b/flink_jobs/status_trends/src/main/java/argo/filter/zero/flipflops/ZeroGroupTrendsFilter.java
@@ -1,0 +1,34 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package argo.filter.zero.flipflops;
+
+import argo.pojos.GroupTrends;
+import org.apache.flink.api.common.functions.FilterFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author cthermolia
+ */
+    
+    
+    public class ZeroGroupTrendsFilter implements FilterFunction<GroupTrends> {
+
+    static Logger LOG = LoggerFactory.getLogger(ZeroGroupTrendsFilter.class);
+
+   
+    //if the status field value in Tuple equals the given status returns true, else returns false
+    @Override
+    public boolean filter(GroupTrends t) throws Exception {
+        if (t.getFlipflops()>0) {
+            return true;
+        }
+        return false;
+    }
+
+    
+}

--- a/flink_jobs/status_trends/src/main/java/argo/filter/zero/flipflops/ZeroMetricTrendsFilter.java
+++ b/flink_jobs/status_trends/src/main/java/argo/filter/zero/flipflops/ZeroMetricTrendsFilter.java
@@ -1,0 +1,35 @@
+package argo.filter.zero.flipflops;
+
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+import argo.functions.calctimelines.ServiceFilter;
+import argo.pojos.MetricTrends;
+import org.apache.flink.api.common.functions.FilterFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author cthermolia
+ *
+ * StatusFilter, filters data by status
+ */
+public class ZeroMetricTrendsFilter implements FilterFunction<MetricTrends> {
+
+    static Logger LOG = LoggerFactory.getLogger(ServiceFilter.class);
+
+   
+    //if the status field value in Tuple equals the given status returns true, else returns false
+    @Override
+    public boolean filter(MetricTrends t) throws Exception {
+        if (t.getFlipflops()>0) {
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/flink_jobs/status_trends/src/main/java/argo/filter/zero/flipflops/ZeroServiceTrendsFilter.java
+++ b/flink_jobs/status_trends/src/main/java/argo/filter/zero/flipflops/ZeroServiceTrendsFilter.java
@@ -1,0 +1,32 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package argo.filter.zero.flipflops;
+
+import argo.functions.calctimelines.ServiceFilter;
+import argo.pojos.ServiceTrends;
+import org.apache.flink.api.common.functions.FilterFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author cthermolia
+ */
+    public class ZeroServiceTrendsFilter implements FilterFunction<ServiceTrends> {
+    
+    static Logger LOG = LoggerFactory.getLogger(ZeroServiceTrendsFilter.class);
+
+   
+    //if the status field value in Tuple equals the given status returns true, else returns false
+    @Override
+    public boolean filter(ServiceTrends t) throws Exception {
+        if (t.getFlipflops()>0) {
+            return true;
+        }
+        return false;
+    }
+    
+}

--- a/flink_jobs/status_trends/src/main/java/argo/functions/calctimelines/TimelineMerger.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/calctimelines/TimelineMerger.java
@@ -45,6 +45,8 @@ public class TimelineMerger {
 
         TreeMap<Date, String> resultMap = operateStatusTimeline(statusMap);
         Timeline mergedTimeline = new Timeline(resultMap);
+        mergedTimeline.optimize();
+        
         return mergedTimeline;
     }
 

--- a/flink_jobs/status_trends/src/main/java/argo/functions/calctrends/CalcGroupFlipFlop.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/calctrends/CalcGroupFlipFlop.java
@@ -50,9 +50,10 @@ public class CalcGroupFlipFlop implements GroupReduceFunction< GroupFunctionTren
 
         Timeline timeline = timelineMerger.mergeTimelines(timelist);
         int flipflops = timeline.calculateStatusChanges();
-
-        GroupTrends groupTrends = new GroupTrends(group, timeline, flipflops);
-        out.collect(groupTrends);
+        if (group != null  && flipflops > 0) {
+            GroupTrends groupTrends = new GroupTrends(group, timeline, flipflops);
+            out.collect(groupTrends);
+        }
 
     }
 

--- a/flink_jobs/status_trends/src/main/java/argo/functions/calctrends/CalcMetricFlipFlopTrends.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/calctrends/CalcMetricFlipFlopTrends.java
@@ -64,10 +64,11 @@ public class CalcMetricFlipFlopTrends implements GroupReduceFunction<MetricData,
         }
         Timeline timeline = new Timeline(timeStatusMap);
         timeline.manageFirstLastTimestamps(); //handle the first timestamp to contain the previous days timestamp status if necessary and the last timestamp to contain the status of the last timelines's entry
-        Integer flipflop = timeline.calculateStatusChanges();
+        timeline.optimize();
+        Integer flipflops = timeline.calculateStatusChanges();
 
         if (group != null && service != null && hostname != null && metric != null) {
-            MetricTrends metricTrends = new MetricTrends(group, service, hostname, metric, timeline, flipflop);
+            MetricTrends metricTrends = new MetricTrends(group, service, hostname, metric, timeline, flipflops);
             out.collect(metricTrends);
         }
     }

--- a/flink_jobs/status_trends/src/main/java/argo/functions/calctrends/CalcServiceFlipFlop.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/calctrends/CalcServiceFlipFlop.java
@@ -44,7 +44,6 @@ public class CalcServiceFlipFlop implements GroupReduceFunction< EndpointTrends,
         ArrayList<ServiceTrends> list = new ArrayList<>();
         //construct a timeline containing all the timestamps of each metric timeline
 
-       
         ArrayList<Timeline> timelineList = new ArrayList<>();
         for (EndpointTrends endpointTrend : in) {
             group = endpointTrend.getGroup();
@@ -54,12 +53,12 @@ public class CalcServiceFlipFlop implements GroupReduceFunction< EndpointTrends,
         String operation = serviceOperationMap.get(service);
         TimelineMerger timelineMerger = new TimelineMerger(operation, operationsParser);
 
-///        HashMap<String, String> opTruthTable = operationTruthTables.get(operation);
         Timeline timeline = timelineMerger.mergeTimelines(timelineList);
         int flipflops = timeline.calculateStatusChanges();
-
-        ServiceTrends serviceTrends = new ServiceTrends(group, service, timeline, flipflops);
-        out.collect(serviceTrends);
+        if (group != null && service != null) {
+            ServiceTrends serviceTrends = new ServiceTrends(group, service, timeline, flipflops);
+            out.collect(serviceTrends);
+        }
 
     }
 

--- a/flink_jobs/status_trends/src/main/java/argo/pojos/MetricTrends.java
+++ b/flink_jobs/status_trends/src/main/java/argo/pojos/MetricTrends.java
@@ -11,7 +11,7 @@ package argo.pojos;
  * MetricTrends, describes the computed trend information extracted from the set of the timelines at the level of group service endpoints metrics groups 
 
  */
-public class MetricTrends {
+public class MetricTrends{
 
     String group;
     String service;

--- a/flink_jobs/status_trends/src/main/java/argo/pojos/Timeline.java
+++ b/flink_jobs/status_trends/src/main/java/argo/pojos/Timeline.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.TreeMap;
 
 /**
@@ -49,7 +50,7 @@ public class Timeline {
         if (timelineMap == null) {
             timelineMap = new TreeMap<>();
         }
-        timelineMap.put(Utils.convertStringtoDate(format,date), status);
+        timelineMap.put(Utils.convertStringtoDate(format, date), status);
     }
 
     public String retrieveStatus(String dateStr) throws ParseException {
@@ -128,8 +129,8 @@ public class Timeline {
         if (timelineMap == null) {
             return;
         }
-        Map.Entry<Date, String> firstEntry = timelineMap.firstEntry(); 
-        Map.Entry<Date, String> lastEntry = timelineMap.lastEntry(); 
+        Map.Entry<Date, String> firstEntry = timelineMap.firstEntry();
+        Map.Entry<Date, String> lastEntry = timelineMap.lastEntry();
         String status = firstEntry.getValue();
         Date timestamp = Utils.createDate(format, lastEntry.getKey(), 0, 0, 0); // create a timestamp of the date with time 00:00:00
         if (Utils.isPreviousDate(format, timestamp, firstEntry.getKey())) {  //if exists a previous day timestamp get the status of the timestamp, else set the status=MISSING
@@ -144,6 +145,40 @@ public class Timeline {
         status = lastEntry.getValue(); // get the last timestamp status
         timestamp = Utils.createDate(format, lastEntry.getKey(), 23, 59, 59);//create timestamp on 23:59:59 time
         timelineMap.put(timestamp, status); // add or update (with same status) the map
+
+    }
+
+    public void optimize() {
+        String previousStr = null;
+        Date previousDate = null;
+        int count = 0;
+        boolean tobeadded = false;
+        TreeMap<Date, String> optimizedMap = new TreeMap<>();
+        for (Entry<Date, String> dt : timelineMap.entrySet()) {
+            if (count == 0) {
+                previousStr = dt.getValue();
+                previousDate = dt.getKey();
+            } else {
+                if (!dt.getValue().equals(previousStr)) {
+                    tobeadded=true;
+                
+                }
+            }
+                if(tobeadded){
+                    optimizedMap.put(previousDate, previousStr);
+
+                    previousStr = dt.getValue();
+                    previousDate = dt.getKey();
+                    tobeadded = false;
+                } 
+            
+            count++;
+        }
+        if (!tobeadded && previousDate!=null && previousStr!=null) {
+            optimizedMap.put(previousDate, previousStr);
+        }
+
+        timelineMap = optimizedMap;
 
     }
 


### PR DESCRIPTION
Fixes made so as results with zero flip flops are not added to total results
Also setParallelism is removed from main of the classes. The parallelism can be defined by the command running the job on cluster
Parallelism is set to 1 , in the jobs code implementation , before ranking the results. This is done in order to apply ranking on the total results and not on each one provided by each parallel execution. 

