### PR TITLE
ARGO-3186 Convert daily dates to integer format to help trends range …

### DIFF
--- a/flink_jobs/status_trends/src/main/java/argo/batch/MongoTrendsOutput.java
+++ b/flink_jobs/status_trends/src/main/java/argo/batch/MongoTrendsOutput.java
@@ -32,7 +32,7 @@ public class MongoTrendsOutput implements OutputFormat<Trends> {
 //	private MongoMethod method;
     private TrendsType trendsType;
     private String report;
-    private String date;
+    private int date;
     private MongoClient mClient;
     private MongoDatabase mDB;
     private MongoCollection<Document> mCol;
@@ -41,7 +41,7 @@ public class MongoTrendsOutput implements OutputFormat<Trends> {
     // constructor
     public MongoTrendsOutput(String uri, String col, TrendsType trendsType, String report, String date, boolean clearMongo) {
 
-        this.date = date;
+        this.date = Integer.parseInt(date.replace("-", ""));
         this.trendsType = trendsType;
         this.report = report;
 


### PR DESCRIPTION
…queries in argo-web-api

Convert "2021-05-25" date strings to integers --> `20210525` to better optimize range queries in trend-related argo-web-api calls