### PR TITLE
Bump dependency versions of httpclient, xerxesImpl and junit

### DIFF
--- a/flink_jobs/ams_ingest_metric/pom.xml
+++ b/flink_jobs/ams_ingest_metric/pom.xml
@@ -109,12 +109,12 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.2</version>
+			<version>4.5.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>fluent-hc</artifactId>
-			<version>4.5.2</version>
+			<version>4.5.13</version>
 		</dependency>
 
 
@@ -182,17 +182,17 @@
 					<artifactId>hbase-client</artifactId>
 					<version>1.2.0-cdh5.7.4</version>
 				</dependency>
-				<!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
 				<dependency>
 					<groupId>org.apache.httpcomponents</groupId>
 					<artifactId>httpclient</artifactId>
-					<version>4.5.2</version>
+					<version>4.5.13</version>
 				</dependency>
 				<dependency>
 					<groupId>org.apache.httpcomponents</groupId>
 					<artifactId>fluent-hc</artifactId>
-					<version>4.5.2</version>
+					<version>4.5.13</version>
 				</dependency>
+				
 
 			</dependencies>
 

--- a/flink_jobs/ams_ingest_sync/pom.xml
+++ b/flink_jobs/ams_ingest_sync/pom.xml
@@ -90,7 +90,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.2</version>
+			<version>4.5.13</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
@@ -159,24 +159,12 @@
 				<dependency>
 					<groupId>org.apache.httpcomponents</groupId>
 					<artifactId>httpclient</artifactId>
-					<version>4.5.2</version>
+					<version>4.5.13</version>
 				</dependency>
 				<dependency>
 					<groupId>com.google.code.gson</groupId>
 					<artifactId>gson</artifactId>
 					<version>2.7</version>
-				</dependency>
-				<dependency>
-					<groupId>junit</groupId>
-					<artifactId>junit</artifactId>
-					<version>4.11</version>
-					<scope>test</scope>
-				</dependency>
-				<dependency>
-					<groupId>junit-addons</groupId>
-					<artifactId>junit-addons</artifactId>
-					<version>1.4</version>
-					<scope>test</scope>
 				</dependency>
 			</dependencies>
 

--- a/flink_jobs/batch_ar/pom.xml
+++ b/flink_jobs/batch_ar/pom.xml
@@ -99,12 +99,12 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.2</version>
+			<version>4.5.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>fluent-hc</artifactId>
-			<version>4.5.2</version>
+			<version>4.5.13</version>
 		</dependency>
 
 		<dependency>
@@ -222,6 +222,17 @@
 					<groupId>org.mongodb</groupId>
 					<artifactId>mongo-java-driver</artifactId>
 					<version>3.2.2</version>
+				</dependency>
+
+				<dependency>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>httpclient</artifactId>
+					<version>4.5.13</version>
+				</dependency>
+				<dependency>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>fluent-hc</artifactId>
+					<version>4.5.13</version>
 				</dependency>
 
 			</dependencies>

--- a/flink_jobs/batch_status/pom.xml
+++ b/flink_jobs/batch_status/pom.xml
@@ -111,12 +111,12 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.2</version>
+			<version>4.5.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>fluent-hc</artifactId>
-			<version>4.5.2</version>
+			<version>4.5.13</version>
 		</dependency>
 
 
@@ -229,6 +229,17 @@
 					<groupId>org.mongodb</groupId>
 					<artifactId>mongo-java-driver</artifactId>
 					<version>3.2.2</version>
+				</dependency>
+
+				<dependency>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>httpclient</artifactId>
+					<version>4.5.13</version>
+				</dependency>
+				<dependency>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>fluent-hc</artifactId>
+					<version>4.5.13</version>
 				</dependency>
 
 			</dependencies>

--- a/flink_jobs/old-models/ams_ingest_metric/pom.xml
+++ b/flink_jobs/old-models/ams_ingest_metric/pom.xml
@@ -109,12 +109,12 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.2</version>
+			<version>4.5.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>fluent-hc</artifactId>
-			<version>4.5.2</version>
+			<version>4.5.13</version>
 		</dependency>
 
 
@@ -186,12 +186,12 @@
 				<dependency>
 					<groupId>org.apache.httpcomponents</groupId>
 					<artifactId>httpclient</artifactId>
-					<version>4.5.2</version>
+					<version>4.5.13</version>
 				</dependency>
 				<dependency>
 					<groupId>org.apache.httpcomponents</groupId>
 					<artifactId>fluent-hc</artifactId>
-					<version>4.5.2</version>
+					<version>4.5.13</version>
 				</dependency>
 
 			</dependencies>

--- a/flink_jobs/old-models/ams_ingest_sync/pom.xml
+++ b/flink_jobs/old-models/ams_ingest_sync/pom.xml
@@ -90,7 +90,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.2</version>
+			<version>4.5.13</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
@@ -159,24 +159,12 @@
 				<dependency>
 					<groupId>org.apache.httpcomponents</groupId>
 					<artifactId>httpclient</artifactId>
-					<version>4.5.2</version>
+					<version>4.5.13</version>
 				</dependency>
 				<dependency>
 					<groupId>com.google.code.gson</groupId>
 					<artifactId>gson</artifactId>
 					<version>2.7</version>
-				</dependency>
-				<dependency>
-					<groupId>junit</groupId>
-					<artifactId>junit</artifactId>
-					<version>4.11</version>
-					<scope>test</scope>
-				</dependency>
-				<dependency>
-					<groupId>junit-addons</groupId>
-					<artifactId>junit-addons</artifactId>
-					<version>1.4</version>
-					<scope>test</scope>
 				</dependency>
 			</dependencies>
 

--- a/flink_jobs/old-models/batch_ar/pom.xml
+++ b/flink_jobs/old-models/batch_ar/pom.xml
@@ -135,7 +135,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
+			<version>4.13.1</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink_jobs/old-models/batch_status/pom.xml
+++ b/flink_jobs/old-models/batch_status/pom.xml
@@ -136,7 +136,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
+			<version>4.13.1</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink_jobs/old-models/stream_status/pom.xml
+++ b/flink_jobs/old-models/stream_status/pom.xml
@@ -109,17 +109,17 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.2</version>
+			<version>4.5.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>fluent-hc</artifactId>
-			<version>4.5.2</version>
+			<version>4.5.13</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
+			<version>4.13.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -132,7 +132,7 @@
 		<dependency>
 			<groupId>xerces</groupId>
 			<artifactId>xercesImpl</artifactId>
-			<version>2.7.1</version>
+			<version>2.12.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mongodb</groupId>
@@ -196,6 +196,16 @@
 					<artifactId>mongo-java-driver</artifactId>
 					<version>3.2.2</version>
 					<scope>compile</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>httpclient</artifactId>
+					<version>4.5.13</version>
+				</dependency>
+				<dependency>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>fluent-hc</artifactId>
+					<version>4.5.13</version>
 				</dependency>
 			</dependencies>
 

--- a/flink_jobs/status_trends/pom.xml
+++ b/flink_jobs/status_trends/pom.xml
@@ -91,12 +91,12 @@ under the License.
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.2</version>
+            <version>4.5.13</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>fluent-hc</artifactId>
-            <version>4.5.2</version>
+            <version>4.5.13</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.flink/flink-hadoop-compatibility -->

--- a/flink_jobs/stream_status/pom.xml
+++ b/flink_jobs/stream_status/pom.xml
@@ -109,12 +109,12 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.2</version>
+			<version>4.5.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>fluent-hc</artifactId>
-			<version>4.5.2</version>
+			<version>4.5.13</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
@@ -203,6 +203,16 @@
 					<artifactId>mongo-java-driver</artifactId>
 					<version>3.2.2</version>
 					<scope>compile</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>httpclient</artifactId>
+					<version>4.5.13</version>
+				</dependency>
+				<dependency>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>fluent-hc</artifactId>
+					<version>4.5.13</version>
 				</dependency>
 			</dependencies>
 


### PR DESCRIPTION
Bump versions for the following dependencies:
- httpclient from 4.5.2 to 4.5.13
- xercesImpl from 2.7.1 to 2.12.0
- junit from 4.11 to 4.13.1 

 