### PR TITLE
ARGO-3211 Compute Status Trends for upper levels

### DIFF
--- a/flink_jobs/Timelines/src/main/java/timelines/Timeline.java
+++ b/flink_jobs/Timelines/src/main/java/timelines/Timeline.java
@@ -482,5 +482,29 @@ public class Timeline {
 
         return result;
     }
+    
+    /**
+ * Calculates the times a specific status appears on the timeline
+ * @param status , the status to calculate the appearances
+ * @return  , the num of the times the specific status appears on the timeline
+ */
+
+    public int countStatusAppearances(int status) {
+        
+        System.out.println("status is : "+status);
+        int count=0;
+        for (Map.Entry<DateTime, Integer> entry : this.samples.entrySet()) {
+            System.out.println("value status is : "+entry.getValue());
+            if (status == entry.getValue()) {
+                
+
+                count++;
+            }
+
+        }
+        return count;
+
+    }
+
 
 }

--- a/flink_jobs/Timelines/src/test/java/timelines/TimelineTest.java
+++ b/flink_jobs/Timelines/src/test/java/timelines/TimelineTest.java
@@ -496,4 +496,20 @@ public class TimelineTest {
         return map;
     }
 
+      /**
+     * Test of countStatusAppearances method, of class Timeline.
+     */
+    @Test
+    public void testCountStatusAppearances() throws ParseException {
+        System.out.println("countStatusAppearances");
+        int status = 0;
+        Timeline instance = new Timeline();
+        instance.insertDateTimeStamps(createTimestampList());
+        int expResult =1;
+        int result = instance.countStatusAppearances(status);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+       //fail("The test case is a prototype.");
+    }
+
 }

--- a/flink_jobs/status_trends/src/main/java/argo/batch/BatchStatusTrends.java
+++ b/flink_jobs/status_trends/src/main/java/argo/batch/BatchStatusTrends.java
@@ -126,7 +126,7 @@ public class BatchStatusTrends {
             noZeroStatusTrends = noZeroStatusTrends.sortPartition(5, Order.DESCENDING).setParallelism(1);
         }
 
-        MongoTrendsOutput metricMongoOut = new MongoTrendsOutput(mongoUri, uri, MongoTrendsOutput.TrendsType.TRENDS_STATUS, reportId, profilesDateStr, clearMongo);
+        MongoTrendsOutput metricMongoOut = new MongoTrendsOutput(mongoUri, uri, MongoTrendsOutput.TrendsType.TRENDS_STATUS_METRIC, reportId, profilesDateStr, clearMongo);
 
         DataSet<Trends> trends = noZeroStatusTrends.map(new MapFunction<Tuple6<String, String, String, String, String, Integer>, Trends>() {
 

--- a/flink_jobs/status_trends/src/main/java/argo/batch/BatchTrendsCalculations.java
+++ b/flink_jobs/status_trends/src/main/java/argo/batch/BatchTrendsCalculations.java
@@ -1,0 +1,309 @@
+package argo.batch;
+
+import argo.avro.MetricData;
+import argo.filter.zero.flipflops.ZeroEndpointTrendsFilter;
+import argo.filter.zero.flipflops.ZeroGroupTrendsFilter;
+import argo.filter.zero.flipflops.ZeroMetricTrendsFilter;
+import argo.filter.zero.flipflops.ZeroServiceTrendsFilter;
+import argo.functions.calctimelines.CalcLastTimeStatus;
+import argo.functions.calctimelines.MapServices;
+import argo.functions.calctimelines.ServiceFilter;
+import argo.functions.calctimelines.StatusFilter;
+import argo.functions.calctimelines.TopologyMetricFilter;
+import argo.functions.calctrends.CalcEndpointFlipFlopTrends;
+import argo.functions.calctrends.CalcGroupFlipFlop;
+import argo.functions.calctrends.CalcGroupFunctionFlipFlop;
+import argo.functions.calctrends.CalcMetricFlipFlopTrends;
+import argo.functions.calctrends.CalcServiceFlipFlop;
+import argo.pojos.EndpointTrends;
+import argo.pojos.GroupFunctionTrends;
+import argo.pojos.GroupTrends;
+import argo.pojos.MetricTrends;
+import argo.pojos.ServiceTrends;
+import argo.profiles.ProfilesLoader;
+import argo.status.trends.EndpointTrendsCounter;
+import argo.status.trends.GroupTrendsCounter;
+import argo.status.trends.MetricTrendsCounter;
+import argo.status.trends.ServiceTrendsCounter;
+import argo.utils.Utils;
+import de.javakaffee.kryoserializers.jodatime.JodaDateTimeSerializer;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.operators.Order;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.AvroInputFormat;
+import org.apache.flink.api.java.tuple.Tuple6;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.core.fs.Path;
+import org.joda.time.DateTime;
+
+/**
+ * Implements an ARGO Trends Job in flink , to count the number of status
+ * changes and also the num of appearances of the status CRITICAL,WARNING,UNKNOWN.
+ * that occur to all levels of the topology hierarchy 
+ * 
+ *
+ * Submit job in flink cluster using the following parameters * --date:the date
+ * for which the job runs and need to return results , e.g yyyy-MM-dd
+ * --yesterdayData: path to the metric profile data, of the previous day , for
+ * which the jobs runs profile (For hdfs use: hdfs://namenode:port/path/to/file)
+ * --todayData: path to the metric profile data, of the current day , for which
+ * the jobs runs profile (For hdfs use: hdfs://namenode:port/path/to/file)
+ * --mongoUri: path to MongoDB destination (eg
+ * mongodb://localhost:27017/database --apiUri: path to the mongo db the , for
+ * which the jobs runs profile (For hdfs use: hdfs://namenode:port/path/to/file)
+ * --key: ARGO web api token --reportId: the id of the report the job will need
+ * to process --apiUri: ARGO wep api to connect to e.g msg.example.com Optional:
+ * -- clearMongo: option to clear the mongo db before saving the new result or
+ * not, e.g true -- N : the number of the result the job will provide, if the
+ * parameter exists , e.g 10
+ *
+ */
+public class BatchTrendsCalculations {
+
+    private static DataSet<MetricData> yesterdayData;
+    private static DataSet<MetricData> todayData;
+    private static Integer rankNum;
+    private static final String groupTrends = "flipflop_trends_endpoint_groups";
+    private static final String metricTrends = "flipflop_trends_metrics";
+    private static final String endpointTrends = "flipflop_trends_endpoints";
+    private static final String serviceTrends = "flipflop_trends_services";
+    private static String mongoUri;
+    private static ProfilesLoader profilesLoader;
+    private static DateTime profilesDate;
+    private static String format = "yyyy-MM-dd";
+    private static String reportId;
+    private static boolean clearMongo = false;
+    private static String profilesDateStr;
+    private static final String statusTrendsMetricCol = "status_trends_metrics";
+    private static final String statusTrendsEndpointCol = "status_trends_endpoints";
+    private static final String statusTrendsServiceCol = "status_trends_services";
+    private static final String statusTrendsGroupCol = "status_trends_groups";
+
+    public static void main(String[] args) throws Exception {
+        // set up the batch execution environment
+        final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+        env.addDefaultKryoSerializer(DateTime.class, JodaDateTimeSerializer.class);
+        ParameterTool params = ParameterTool.fromArgs(args);
+        //check if all required parameters exist and if not exit program
+        if (!Utils.checkParameters(params, "yesterdayData", "todayData", "mongoUri", "apiUri", "key", "date", "reportId")) {
+            System.exit(0);
+        }
+
+        if (params.get("clearMongo") != null && params.getBoolean("clearMongo") == true) {
+            clearMongo = true;
+        }
+        reportId = params.getRequired("reportId");
+        profilesDate = Utils.convertStringtoDate(format, params.getRequired("date"));
+        profilesDateStr = Utils.convertDateToString(format, profilesDate);
+
+        if (params.get("N") != null) {
+            rankNum = params.getInt("N");
+        }
+        mongoUri = params.get("mongoUri");
+        profilesLoader = new ProfilesLoader(params);
+        yesterdayData = readInputData(env, params, "yesterdayData");
+        todayData = readInputData(env, params, "todayDatas");
+
+        // calculate on data 
+        calcFlipFlops();
+
+// execute program
+        StringBuilder jobTitleSB = new StringBuilder();
+        jobTitleSB.append("Calculation of Flip Flops & Status Trends for: ");
+        jobTitleSB.append(profilesLoader.getReportParser().getTenant());
+        jobTitleSB.append("/");
+        jobTitleSB.append(profilesLoader.getReportParser().getReport());
+        jobTitleSB.append("/");
+        jobTitleSB.append(profilesDate);
+        env.execute(jobTitleSB.toString());
+
+    }
+
+// filter yesterdaydata and exclude the ones not contained in topology and metric profile data and get the last timestamp data for each service endpoint metric
+// filter todaydata and exclude the ones not contained in topology and metric profile data , union yesterday data and calculate status changes for each service endpoint metric
+// rank results
+//    private static DataSet<GroupTrends> calcFlipFlops() {
+    private static void calcFlipFlops() {
+
+        DataSet<MetricData> filteredYesterdayData = yesterdayData.filter(new TopologyMetricFilter(profilesLoader.getMetricProfileParser(), profilesLoader.getTopologyEndpointParser(), profilesLoader.getTopolGroupParser(), profilesLoader.getAggregationProfileParser())).groupBy("hostname", "service", "metric").reduceGroup(new CalcLastTimeStatus());
+        DataSet<MetricData> filteredTodayData = todayData.filter(new TopologyMetricFilter(profilesLoader.getMetricProfileParser(), profilesLoader.getTopologyEndpointParser(), profilesLoader.getTopolGroupParser(), profilesLoader.getAggregationProfileParser()));
+
+        //group data by service enpoint metric and return for each group , the necessary info and a treemap containing timestamps and status
+        DataSet<MetricTrends> serviceEndpointMetricGroupData = filteredTodayData.union(filteredYesterdayData).groupBy("hostname", "service", "metric").reduceGroup(new CalcMetricFlipFlopTrends(profilesLoader.getOperationParser(), profilesLoader.getTopologyEndpointParser(),profilesLoader.getTopolGroupParser(), profilesLoader.getAggregationProfileParser(), profilesDate));
+
+        DataSet<MetricTrends> noZeroServiceEndpointMetricGroupData = serviceEndpointMetricGroupData.filter(new ZeroMetricTrendsFilter());
+        if (rankNum != null) { //sort and rank data
+            noZeroServiceEndpointMetricGroupData = noZeroServiceEndpointMetricGroupData.sortPartition("flipflops", Order.DESCENDING).setParallelism(1).first(rankNum);
+        } else {
+            noZeroServiceEndpointMetricGroupData = noZeroServiceEndpointMetricGroupData.sortPartition("flipflops", Order.DESCENDING).setParallelism(1);
+        }
+
+        MongoTrendsOutput metricMongoOut = new MongoTrendsOutput(mongoUri, metricTrends, MongoTrendsOutput.TrendsType.TRENDS_METRIC, reportId, profilesDateStr, clearMongo);
+
+        DataSet<Trends> trends = noZeroServiceEndpointMetricGroupData.map(new MapFunction<MetricTrends, Trends>() {
+
+            @Override
+            public Trends map(MetricTrends in) throws Exception {
+                return new Trends(in.getGroup(), in.getService(), in.getEndpoint(), in.getMetric(), in.getFlipflops());
+            }
+        });
+        trends.output(metricMongoOut);
+        //flatMap dataset to tuples and count the apperances of each status type to the timeline 
+        DataSet<Tuple6<String, String, String, String, String, Integer>> metricStatusTrendsData = serviceEndpointMetricGroupData.flatMap(new MetricTrendsCounter(profilesLoader.getOperationParser()));
+        //filter dataset for each status type and write to mongo db
+        filterByStatusAndWriteMongo(MongoTrendsOutput.TrendsType.TRENDS_STATUS_METRIC, statusTrendsMetricCol, metricStatusTrendsData, "critical");
+        filterByStatusAndWriteMongo(MongoTrendsOutput.TrendsType.TRENDS_STATUS_METRIC, statusTrendsMetricCol, metricStatusTrendsData, "warning");
+        filterByStatusAndWriteMongo(MongoTrendsOutput.TrendsType.TRENDS_STATUS_METRIC, statusTrendsMetricCol, metricStatusTrendsData, "unknown");
+
+        /**
+         * *****************************************************************************************************************
+         */
+        //group data by service endpoint  and count flip flops
+        DataSet<EndpointTrends> serviceEndpointGroupData = serviceEndpointMetricGroupData.groupBy("group", "endpoint", "service").reduceGroup(new CalcEndpointFlipFlopTrends(profilesLoader.getAggregationProfileParser().getMetricOpByProfile(), profilesLoader.getOperationParser()));
+        DataSet<EndpointTrends> noZeroserviceEndpointGroupData = serviceEndpointGroupData.filter(new ZeroEndpointTrendsFilter());
+
+        if (rankNum != null) { //sort and rank data
+            noZeroserviceEndpointGroupData = noZeroserviceEndpointGroupData.sortPartition("flipflops", Order.DESCENDING).setParallelism(1).first(rankNum);
+        } else {
+            noZeroserviceEndpointGroupData = noZeroserviceEndpointGroupData.sortPartition("flipflops", Order.DESCENDING).setParallelism(1);
+        }
+        metricMongoOut = new MongoTrendsOutput(mongoUri, endpointTrends, MongoTrendsOutput.TrendsType.TRENDS_ENDPOINT, reportId, profilesDateStr, clearMongo);
+
+        trends = noZeroserviceEndpointGroupData.map(new MapFunction<EndpointTrends, Trends>() {
+
+            @Override
+            public Trends map(EndpointTrends in) throws Exception {
+                return new Trends(in.getGroup(), in.getService(), in.getEndpoint(), in.getFlipflops());
+            }
+        });
+        trends.output(metricMongoOut);
+        //flatMap dataset to tuples and count the apperances of each status type to the timeline 
+        DataSet<Tuple6<String, String, String, String, String, Integer>> endpointStatusTrendsData = serviceEndpointGroupData.flatMap(new EndpointTrendsCounter(profilesLoader.getOperationParser()));
+        //filter dataset for each status type and write to mongo db
+        filterByStatusAndWriteMongo(MongoTrendsOutput.TrendsType.TRENDS_STATUS_ENDPOINT, statusTrendsEndpointCol, endpointStatusTrendsData, "critical");
+        filterByStatusAndWriteMongo(MongoTrendsOutput.TrendsType.TRENDS_STATUS_ENDPOINT, statusTrendsEndpointCol, endpointStatusTrendsData, "warning");
+        filterByStatusAndWriteMongo(MongoTrendsOutput.TrendsType.TRENDS_STATUS_ENDPOINT, statusTrendsEndpointCol, endpointStatusTrendsData, "unknown");
+
+        /**
+         * **************************************************************************************************************************
+         */
+        //group data by service   and count flip flops
+        DataSet<ServiceTrends> serviceGroupData = serviceEndpointGroupData.filter(new ServiceFilter(profilesLoader.getAggregationProfileParser())).groupBy("group", "service").reduceGroup(new CalcServiceFlipFlop(profilesLoader.getOperationParser(), profilesLoader.getAggregationProfileParser()));
+        DataSet<ServiceTrends> noZeroserviceGroupData = serviceGroupData.filter(new ZeroServiceTrendsFilter());
+
+        if (rankNum != null) { //sort and rank data
+            noZeroserviceGroupData = noZeroserviceGroupData.sortPartition("flipflops", Order.DESCENDING).setParallelism(1).first(rankNum);
+        } else {
+            noZeroserviceGroupData = noZeroserviceGroupData.sortPartition("flipflops", Order.DESCENDING).setParallelism(1);
+        }
+        metricMongoOut = new MongoTrendsOutput(mongoUri, serviceTrends, MongoTrendsOutput.TrendsType.TRENDS_SERVICE, reportId, profilesDateStr, clearMongo);
+
+        trends = noZeroserviceGroupData.map(new MapFunction<ServiceTrends, Trends>() {
+
+            @Override
+            public Trends map(ServiceTrends in) throws Exception {
+                return new Trends(in.getGroup(), in.getService(), in.getFlipflops());
+            }
+        });
+        trends.output(metricMongoOut);
+        //flatMap dataset to tuples and count the apperances of each status type to the timeline 
+        DataSet<Tuple6<String, String, String, String, String, Integer>> serviceStatusTrendsData = serviceGroupData.flatMap(new ServiceTrendsCounter(profilesLoader.getOperationParser()));
+        //filter dataset for each status type and write to mongo db
+        filterByStatusAndWriteMongo(MongoTrendsOutput.TrendsType.TRENDS_STATUS_SERVICE, statusTrendsServiceCol, serviceStatusTrendsData, "critical");
+        filterByStatusAndWriteMongo(MongoTrendsOutput.TrendsType.TRENDS_STATUS_SERVICE, statusTrendsServiceCol, serviceStatusTrendsData, "warning");
+        filterByStatusAndWriteMongo(MongoTrendsOutput.TrendsType.TRENDS_STATUS_SERVICE, statusTrendsServiceCol, serviceStatusTrendsData, "unknown");
+
+        /**
+         * ****************************************************************************************************
+         */
+//flat map data to add function as described in aggregation profile groups
+        serviceGroupData = serviceGroupData.flatMap(new MapServices(profilesLoader.getAggregationProfileParser()));
+
+        //group data by group,function   and count flip flops
+        DataSet<GroupFunctionTrends> groupFunction = serviceGroupData.groupBy("group", "function").reduceGroup(new CalcGroupFunctionFlipFlop(profilesLoader.getOperationParser(), profilesLoader.getAggregationProfileParser()));
+        //  DataSet<GroupFunctionTrends> noZerogroupFunction =groupFunction.filter(new ZeroGroupFunctionFilter());
+
+        //group data by group   and count flip flops
+        DataSet<GroupTrends> groupData = groupFunction.groupBy("group").reduceGroup(new CalcGroupFlipFlop(profilesLoader.getOperationParser(), profilesLoader.getAggregationProfileParser()));
+        DataSet<GroupTrends> noZerogroupData = groupData.filter(new ZeroGroupTrendsFilter());
+
+        if (rankNum != null) { //sort and rank data
+            noZerogroupData = noZerogroupData.sortPartition("flipflops", Order.DESCENDING).setParallelism(1).first(rankNum);
+        } else {
+            noZerogroupData = noZerogroupData.sortPartition("flipflops", Order.DESCENDING).setParallelism(1);
+        }
+
+        metricMongoOut = new MongoTrendsOutput(mongoUri, groupTrends, MongoTrendsOutput.TrendsType.TRENDS_GROUP, reportId, profilesDateStr, clearMongo);
+
+        trends = noZerogroupData.map(new MapFunction<GroupTrends, Trends>() {
+
+            @Override
+            public Trends map(GroupTrends in) throws Exception {
+                return new Trends(in.getGroup(), in.getFlipflops());
+            }
+        });
+        trends.output(metricMongoOut);
+        //flatMap dataset to tuples and count the apperances of each status type to the timeline 
+        DataSet<Tuple6<String, String, String, String, String, Integer>> groupStatusTrendsData = groupData.flatMap(new GroupTrendsCounter(profilesLoader.getOperationParser()));
+        //filter dataset for each status type and write to mongo db
+        filterByStatusAndWriteMongo(MongoTrendsOutput.TrendsType.TRENDS_STATUS_GROUP, statusTrendsGroupCol, groupStatusTrendsData, "critical");
+        filterByStatusAndWriteMongo(MongoTrendsOutput.TrendsType.TRENDS_STATUS_GROUP, statusTrendsGroupCol, groupStatusTrendsData, "warning");
+        filterByStatusAndWriteMongo(MongoTrendsOutput.TrendsType.TRENDS_STATUS_GROUP, statusTrendsGroupCol, groupStatusTrendsData, "unknown");
+
+    }
+
+    //read input from file
+    private static DataSet<MetricData> readInputData(ExecutionEnvironment env, ParameterTool params, String path) {
+        DataSet<MetricData> inputData;
+        Path input = new Path(params.getRequired(path));
+
+        AvroInputFormat<MetricData> inputAvroFormat = new AvroInputFormat<MetricData>(input, MetricData.class
+        );
+        inputData = env.createInput(inputAvroFormat);
+        return inputData;
+    }
+ 
+    //filters the dataset to appear result by status type and status appearances>0 and write to mongo db
+    private static void filterByStatusAndWriteMongo(MongoTrendsOutput.TrendsType mongoTrendsType, String uri, DataSet<Tuple6< String, String, String, String, String, Integer>> data, String status) {
+
+        DataSet<Tuple6<String, String, String, String, String, Integer>> filteredData = data.filter(new StatusFilter(status)); //filter dataset by status type and status appearances>0
+
+        if (rankNum != null) {
+            filteredData = filteredData.sortPartition(5, Order.DESCENDING).setParallelism(1).first(rankNum);
+        } else {
+            filteredData = filteredData.sortPartition(5, Order.DESCENDING).setParallelism(1);
+        }
+        writeStatusTrends(filteredData, uri, mongoTrendsType, data, status); //write to mongo db
+    }
+
+    // write status trends to mongo db
+    private static void writeStatusTrends(DataSet<Tuple6<String, String, String, String, String, Integer>> outputData, String uri, final MongoTrendsOutput.TrendsType mongoCase, DataSet<Tuple6< String, String, String, String, String, Integer>> data, String status) {
+
+        //MongoTrendsOutput.TrendsType.TRENDS_STATUS_ENDPOINT
+        MongoTrendsOutput metricMongoOut = new MongoTrendsOutput(mongoUri, uri, mongoCase, reportId, profilesDateStr, clearMongo);
+
+        DataSet<Trends> trends = outputData.map(new MapFunction<Tuple6<String, String, String, String, String, Integer>, Trends>() {
+
+            @Override
+            public Trends map(Tuple6<String, String, String, String, String, Integer> in) throws Exception {
+                switch (mongoCase) {
+                    case TRENDS_STATUS_METRIC:
+                        return new Trends(in.f0.toString(), in.f1.toString(), in.f2.toString(), in.f3.toString(), in.f4.toString(), in.f5);
+                    case TRENDS_STATUS_ENDPOINT:
+                        return new Trends(in.f0.toString(), in.f1.toString(), in.f2.toString(), null, in.f4.toString(), in.f5);
+                    case TRENDS_STATUS_SERVICE:
+                        return new Trends(in.f0.toString(), in.f1.toString(), null, null, in.f4.toString(), in.f5);
+                    case TRENDS_STATUS_GROUP:
+                        return new Trends(in.f0.toString(), null, null, null, in.f4.toString(), in.f5);
+                    default:
+                        return null;
+                }
+            }
+        });
+        trends.output(metricMongoOut);
+
+        //   writeToMongo(collectionUri, filteredData);
+    }
+
+}

--- a/flink_jobs/status_trends/src/main/java/argo/batch/MongoTrendsOutput.java
+++ b/flink_jobs/status_trends/src/main/java/argo/batch/MongoTrendsOutput.java
@@ -20,7 +20,7 @@ public class MongoTrendsOutput implements OutputFormat<Trends> {
 
     // Select the type of status input
     public enum TrendsType {
-        TRENDS_STATUS, TRENDS_METRIC, TRENDS_ENDPOINT, TRENDS_SERVICE, TRENDS_GROUP
+        TRENDS_STATUS_METRIC, TRENDS_STATUS_ENDPOINT,TRENDS_STATUS_SERVICE, TRENDS_STATUS_GROUP,TRENDS_METRIC, TRENDS_ENDPOINT, TRENDS_SERVICE, TRENDS_GROUP
     }
 
     private static final long serialVersionUID = 1L;
@@ -117,11 +117,29 @@ public class MongoTrendsOutput implements OutputFormat<Trends> {
                 doc.append("metric", record.getMetric());
                 doc.append("flipflop", record.getFlipflop());
                 break;
-            case TRENDS_STATUS:
+            case TRENDS_STATUS_METRIC:
                 doc.append("group", record.getGroup());
                 doc.append("service", record.getService());
                 doc.append("endpoint", record.getEndpoint());
                 doc.append("metric", record.getMetric());
+                doc.append("status", record.getStatus());
+                doc.append("trends", record.getTrends());
+                break;
+              case TRENDS_STATUS_ENDPOINT:
+                doc.append("group", record.getGroup());
+                doc.append("service", record.getService());
+                doc.append("endpoint", record.getEndpoint());
+                doc.append("status", record.getStatus());
+                doc.append("trends", record.getTrends());
+                break;
+                  case TRENDS_STATUS_SERVICE:
+                doc.append("group", record.getGroup());
+                doc.append("service", record.getService());
+                doc.append("status", record.getStatus());
+                doc.append("trends", record.getTrends());
+                break;
+                  case TRENDS_STATUS_GROUP:
+                doc.append("group", record.getGroup());
                 doc.append("status", record.getStatus());
                 doc.append("trends", record.getTrends());
                 break;

--- a/flink_jobs/status_trends/src/main/java/argo/functions/calctimelines/StatusFilter.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/calctimelines/StatusFilter.java
@@ -11,7 +11,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * StatusFilter, filters data by status
+
+ * StatusFilter, filters data by status and status appearances
  */
 public class StatusFilter implements FilterFunction<Tuple6<String, String, String, String, String, Integer>> {
 
@@ -21,12 +22,12 @@ public class StatusFilter implements FilterFunction<Tuple6<String, String, Strin
     public StatusFilter(String status) {
         this.status = status;
     }
-    //if the status field value in Tuple equals the given status returns true, else returns false
+    //if the status field value in Tuple equals the given status  and status appearances>0 returns true, else returns false
 
     @Override
     public boolean filter(Tuple6<String, String, String, String, String, Integer> t) throws Exception {
 
-        if (t.f4.toString().equalsIgnoreCase(status)) {
+        if (t.f4.toString().equalsIgnoreCase(status) && t.f5>0) {
             return true;
         }
         return false;

--- a/flink_jobs/status_trends/src/main/java/argo/functions/calctrends/CalcEndpointFlipFlopTrends.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/calctrends/CalcEndpointFlipFlopTrends.java
@@ -58,6 +58,7 @@ public class CalcEndpointFlipFlopTrends extends RichGroupReduceFunction<MetricTr
             Timeline timeline = time.getTimeline();
             timelinelist.put(time.getMetric(), timeline);
 
+
         }
         // merge the timelines into one timeline ,  
 
@@ -68,6 +69,7 @@ public class CalcEndpointFlipFlopTrends extends RichGroupReduceFunction<MetricTr
 
         Timeline mergedTimeline = timelineAggregator.getOutput(); //collect all timelines that correspond to the group service endpoint group , merge them in order to create one timeline
         Integer flipflops = mergedTimeline.calcStatusChanges();//calculate flip flops on the concluded merged timeline
+
         if (group != null && service != null && hostname != null) {
             EndpointTrends endpointTrends = new EndpointTrends(group, service, hostname, mergedTimeline, flipflops);
             out.collect(endpointTrends);

--- a/flink_jobs/status_trends/src/main/java/argo/functions/calctrends/CalcStatusTrends.java
+++ b/flink_jobs/status_trends/src/main/java/argo/functions/calctrends/CalcStatusTrends.java
@@ -53,11 +53,9 @@ public class CalcStatusTrends implements GroupReduceFunction<MetricData, Tuple6<
 
         //for each MetricData in group check the status and increase counter accordingly
         for (MetricData md : in) {
-            // group = groupEndpoints.get(md.getHostname().toString() + "-" + md.getService().toString()); //retrieve the group for the service, as contained in file group_endpoints. if group is null exit 
-            String avProfileName = this.aggregationProfileParser.getAvProfileItem().getName();
+        String avProfileName = this.aggregationProfileParser.getAvProfileItem().getName();
 
             groups = topologyEndpointParser.getGroupFull(aggregationProfileParser.getProfileGroupType(avProfileName).toUpperCase(), md.getHostname().toString(), md.getService().toString());
-
 
             hostname = md.getHostname().toString();
             service = md.getService().toString();

--- a/flink_jobs/status_trends/src/main/java/argo/pojos/EndpointTrends.java
+++ b/flink_jobs/status_trends/src/main/java/argo/pojos/EndpointTrends.java
@@ -18,7 +18,7 @@ public class EndpointTrends {
     String endpoint;
     Timeline timeline;
     Integer flipflops;
-
+ 
     public EndpointTrends() {
     }
 
@@ -30,6 +30,9 @@ public class EndpointTrends {
         this.flipflops = flipflops;
     }
 
+ 
+
+    
     public String getGroup() {
         return group;
     }

--- a/flink_jobs/status_trends/src/main/java/argo/pojos/MetricTrends.java
+++ b/flink_jobs/status_trends/src/main/java/argo/pojos/MetricTrends.java
@@ -19,19 +19,36 @@ public class MetricTrends {
     String metric;
     Timeline timeline;
     Integer flipflops;
-
+    Integer criticalNum;
+    Integer warningNum;
+    Integer unknownNum;
+    
     public MetricTrends() {
     }
 
-    public MetricTrends(String group, String service, String hostname, String metric, timelines.Timeline timeline, Integer flipflop) {
+    public MetricTrends(String group, String service, String endpoint, String metric, Timeline timeline, Integer flipflops, Integer criticalNum, Integer warningNum, Integer unknownNum) {
         this.group = group;
         this.service = service;
-        this.endpoint = hostname;
+        this.endpoint = endpoint;
         this.metric = metric;
         this.timeline = timeline;
-        this.flipflops = flipflop;
+        this.flipflops = flipflops;
+        this.criticalNum = criticalNum;
+        this.warningNum = warningNum;
+        this.unknownNum = unknownNum;
+    }
+    
+    
+
+    public Integer getUnknownNum() {
+        return unknownNum;
     }
 
+    public void setUnknownNum(Integer unknownNum) {
+        this.unknownNum = unknownNum;
+    }
+
+   
     public String getGroup() {
         return group;
     }
@@ -79,5 +96,23 @@ public class MetricTrends {
     public void setFlipflops(Integer flipflops) {
         this.flipflops = flipflops;
     }
+
+    public Integer getCriticalNum() {
+        return criticalNum;
+    }
+
+    public void setCriticalNum(Integer criticalNum) {
+        this.criticalNum = criticalNum;
+    }
+
+    public Integer getWarningNum() {
+        return warningNum;
+    }
+
+    public void setWarningNum(Integer warningNum) {
+        this.warningNum = warningNum;
+    }
+
+
 
 }

--- a/flink_jobs/status_trends/src/main/java/argo/status/trends/EndpointTrendsCounter.java
+++ b/flink_jobs/status_trends/src/main/java/argo/status/trends/EndpointTrendsCounter.java
@@ -1,0 +1,65 @@
+package argo.status.trends;
+
+
+
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+import argo.pojos.EndpointTrends;
+import argo.profiles.OperationsParser;
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.java.tuple.Tuple6;
+import org.apache.flink.util.Collector;
+import timelines.Timeline;
+
+
+/**
+ * EndpointTrendsCounter calculates on the dataset's timeline the num of appearances of the status
+ * CRITICAL, WARNING,UNKNOWN and produces a dataset of tuples that contain these calculations
+ */
+public class EndpointTrendsCounter implements FlatMapFunction<EndpointTrends, Tuple6< String,String, String, String, String, Integer>> {
+
+    private OperationsParser operationsParser;
+
+    public EndpointTrendsCounter(OperationsParser operationsParser) {
+        this.operationsParser = operationsParser;
+    }
+
+    /**
+     * if the service exist in one or more function groups , timeline trends are
+     * produced for each function that the service belongs and the function info
+     * is added to the timelinetrend
+     *
+     * @param t
+     * @param out
+     * @throws Exception
+     */
+    @Override
+    public void flatMap(EndpointTrends t, Collector< Tuple6<String, String, String, String, String, Integer>> out) throws Exception {
+
+        int criticalstatus = operationsParser.getIntStatus("CRITICAL");
+        int warningstatus = operationsParser.getIntStatus("WARNING");
+        int unknownstatus = operationsParser.getIntStatus("UNKNOWN");
+
+        Timeline timeline = t.getTimeline();
+        int criticalSum = timeline.countStatusAppearances(criticalstatus);
+        int warningSum = timeline.countStatusAppearances(warningstatus);
+        int unknownSum = timeline.countStatusAppearances(unknownstatus);
+
+        Tuple6< String,String, String, String, String, Integer> tupleCritical = new Tuple6<  String,String, String, String, String, Integer>(
+                t.getGroup(), t.getService(),t.getEndpoint(),null, "CRITICAL", criticalSum);
+        out.collect(tupleCritical);
+
+        Tuple6<  String,String, String, String, String, Integer> tupleWarning = new Tuple6< String, String, String, String, String, Integer>(
+                t.getGroup(), t.getService(),t.getEndpoint(), null,"WARNING", warningSum);
+        
+        out.collect(tupleWarning);
+
+        Tuple6<  String,String, String, String, String, Integer> tupleUnknown = new Tuple6<  String,String, String, String, String, Integer>(
+                t.getGroup(), t.getService(),t.getEndpoint(),null, "UNKNWON", unknownSum);
+            out.collect(tupleUnknown);
+    
+    }
+}

--- a/flink_jobs/status_trends/src/main/java/argo/status/trends/GroupTrendsCounter.java
+++ b/flink_jobs/status_trends/src/main/java/argo/status/trends/GroupTrendsCounter.java
@@ -1,0 +1,61 @@
+package argo.status.trends;
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+import argo.pojos.GroupTrends;
+import argo.profiles.OperationsParser;
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.java.tuple.Tuple6;
+import org.apache.flink.util.Collector;
+import timelines.Timeline;
+
+/**
+ * GroupTrendsCounter calculates on the dataset's timeline the num of appearances of the status
+ * CRITICAL, WARNING,UNKNOWN and produces a dataset of tuples that contain these calculations
+ */
+public class GroupTrendsCounter implements FlatMapFunction<GroupTrends, Tuple6< String,String, String, String, String, Integer>> {
+
+    private OperationsParser operationsParser;
+
+    public GroupTrendsCounter(OperationsParser operationsParser) {
+        this.operationsParser = operationsParser;
+    }
+
+    /**
+     * if the service exist in one or more function groups , timeline trends are
+     * produced for each function that the service belongs and the function info
+     * is added to the timeline trend
+     *
+     * @param t
+     * @param out
+     * @throws Exception
+     */
+    @Override
+    public void flatMap(GroupTrends t, Collector< Tuple6<String, String, String, String, String, Integer>> out) throws Exception {
+
+        int criticalstatus = operationsParser.getIntStatus("CRITICAL");
+        int warningstatus = operationsParser.getIntStatus("WARNING");
+        int unknownstatus = operationsParser.getIntStatus("UNKNOWN");
+
+        Timeline timeline = t.getTimeline();
+        int criticalSum = timeline.countStatusAppearances(criticalstatus);
+        int warningSum = timeline.countStatusAppearances(warningstatus);
+        int unknownSum = timeline.countStatusAppearances(unknownstatus);
+
+        Tuple6< String,String, String, String, String, Integer> tupleCritical = new Tuple6<  String,String, String, String, String, Integer>(
+                t.getGroup(), null,null,null, "CRITICAL", criticalSum);
+        out.collect(tupleCritical);
+
+        Tuple6<  String,String, String, String, String, Integer> tupleWarning = new Tuple6< String, String, String, String, String, Integer>(
+                t.getGroup(), null,null, null,"WARNING", warningSum);
+        
+        out.collect(tupleWarning);
+
+        Tuple6<  String,String, String, String, String, Integer> tupleUnknown = new Tuple6<  String,String, String, String, String, Integer>(
+                t.getGroup(), null,null,null, "UNKNOWN", unknownSum);
+            out.collect(tupleUnknown);
+    
+    }
+}

--- a/flink_jobs/status_trends/src/main/java/argo/status/trends/MetricTrendsCounter.java
+++ b/flink_jobs/status_trends/src/main/java/argo/status/trends/MetricTrendsCounter.java
@@ -1,0 +1,53 @@
+package argo.status.trends;
+
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+import argo.pojos.MetricTrends;
+import argo.profiles.OperationsParser;
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.java.tuple.Tuple6;
+import org.apache.flink.util.Collector;
+
+/**
+ * MetricTrendsCounter calculates on the dataset's timeline the num of
+ * appearances of the status CRITICAL, WARNING,UNKNOWN and produces a dataset of
+ * tuples that contain these calculations
+ */
+public class MetricTrendsCounter implements FlatMapFunction<MetricTrends, Tuple6<String, String, String, String, String, Integer>> {
+
+    private OperationsParser operationsParser;
+
+    public MetricTrendsCounter(OperationsParser operationsParser) {
+        this.operationsParser = operationsParser;
+    }
+
+    /**
+     * if the service exist in one or more function groups , timeline trends are
+     * produced for each function that the service belongs and the function info
+     * is added to the timelinetrend
+     *
+     * @param t
+     * @param out
+     * @throws Exception
+     */
+    @Override
+    public void flatMap(MetricTrends t, Collector< Tuple6<String, String, String, String, String, Integer>> out) throws Exception {
+
+        Tuple6<String, String, String, String, String, Integer> tupleCritical = new Tuple6<String, String, String, String, String, Integer>(
+                t.getGroup(), t.getService(), t.getEndpoint(), t.getMetric(), "CRITICAL", t.getCriticalNum());
+        out.collect(tupleCritical);
+
+        Tuple6<String, String, String, String, String, Integer> tupleWarning = new Tuple6<String, String, String, String, String, Integer>(
+                t.getGroup(), t.getService(), t.getEndpoint(), t.getMetric(), "WARNING", t.getWarningNum());
+
+        out.collect(tupleWarning);
+
+        Tuple6<String, String, String, String, String, Integer> tupleUnknown = new Tuple6<String, String, String, String, String, Integer>(
+                t.getGroup(), t.getService(), t.getEndpoint(), t.getMetric(), "UNKNWON", t.getUnknownNum());
+        out.collect(tupleUnknown);
+
+    }
+}

--- a/flink_jobs/status_trends/src/main/java/argo/status/trends/ServiceTrendsCounter.java
+++ b/flink_jobs/status_trends/src/main/java/argo/status/trends/ServiceTrendsCounter.java
@@ -1,0 +1,65 @@
+package argo.status.trends;
+
+
+
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+import argo.pojos.ServiceTrends;
+import argo.profiles.OperationsParser;
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.java.tuple.Tuple6;
+import org.apache.flink.util.Collector;
+import timelines.Timeline;
+
+
+/**
+ * ServiceTrendsCounter calculates on the dataset's timeline the num of appearances of the status
+ * CRITICAL, WARNING,UNKNOWN and produces a dataset of tuples that contain these calculations
+ */
+public class ServiceTrendsCounter implements FlatMapFunction<ServiceTrends, Tuple6< String,String, String, String, String, Integer>> {
+
+    private OperationsParser operationsParser;
+
+    public ServiceTrendsCounter(OperationsParser operationsParser) {
+        this.operationsParser = operationsParser;
+    }
+
+    /**
+     * if the service exist in one or more function groups , timeline trends are
+     * produced for each function that the service belongs and the function info
+     * is added to the timeline trend
+     *
+     * @param t
+     * @param out
+     * @throws Exception
+     */
+    @Override
+    public void flatMap(ServiceTrends t, Collector< Tuple6<String, String, String, String, String, Integer>> out) throws Exception {
+
+        int criticalstatus = operationsParser.getIntStatus("CRITICAL");
+        int warningstatus = operationsParser.getIntStatus("WARNING");
+        int unknownstatus = operationsParser.getIntStatus("UNKNOWN");
+
+        Timeline timeline = t.getTimeline();
+        int criticalSum = timeline.countStatusAppearances(criticalstatus);
+        int warningSum = timeline.countStatusAppearances(warningstatus);
+        int unknownSum = timeline.countStatusAppearances(unknownstatus);
+
+        Tuple6< String,String, String, String, String, Integer> tupleCritical = new Tuple6<  String,String, String, String, String, Integer>(
+                t.getGroup(), t.getService(),null,null, "CRITICAL", criticalSum);
+        out.collect(tupleCritical);
+
+        Tuple6<  String,String, String, String, String, Integer> tupleWarning = new Tuple6< String, String, String, String, String, Integer>(
+                t.getGroup(), t.getService(),null, null,"WARNING", warningSum);
+        
+        out.collect(tupleWarning);
+
+        Tuple6<  String,String, String, String, String, Integer> tupleUnknown = new Tuple6<  String,String, String, String, String, Integer>(
+                t.getGroup(), t.getService(),null,null, "UNKNOWN", unknownSum);
+            out.collect(tupleUnknown);
+    
+    }
+}

--- a/flink_jobs/status_trends/src/main/java/timelines/Timeline.java
+++ b/flink_jobs/status_trends/src/main/java/timelines/Timeline.java
@@ -8,6 +8,7 @@ package timelines;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
@@ -309,6 +310,30 @@ public class Timeline {
         }
 
         return result;
+    }
+
+    /**
+     * Calculates the times a specific status appears on the timeline
+     *
+     * @param status , the status to calculate the appearances
+     * @return , the num of the times the specific status appears on the
+     * timeline
+     */
+
+    public int countStatusAppearances(int status) {
+
+        System.out.println("status is : " + status);
+        int count = 0;
+        for (Entry<DateTime, Integer> entry : this.samples.entrySet()) {
+            System.out.println("value status is : " + entry.getValue());
+            if (status == entry.getValue()) {
+
+                count++;
+            }
+
+        }
+        return count;
+
     }
 
 }


### PR DESCRIPTION
Added to existing implementation,  the  BatchTrendsCalculations class, to calculate in one flink job, both the computations of status changes (flip flops) and computations on status appearances for CRITICAL , WARNING, UNKNOWN status , for all levels of hierarchy.

Also in Timelines Project , in Timeline class the countStatusAppearances() functions is added in order to compute the num of the appearances of a specific status on the timeline