### PR TITLE
ARGO-3257 Use run.date argument as proper date query parameter when r…

### DIFF
--- a/flink_jobs/batch_ar/src/main/java/argo/batch/ArgoArBatch.java
+++ b/flink_jobs/batch_ar/src/main/java/argo/batch/ArgoArBatch.java
@@ -82,6 +82,7 @@ public class ArgoArBatch {
 		}
 		
 		amr.setReportID(reportID);
+		amr.setDate(params.getRequired("run.date"));
 		amr.getRemoteAll();
 		
 		

--- a/flink_jobs/batch_status/src/main/java/argo/batch/ArgoStatusBatch.java
+++ b/flink_jobs/batch_status/src/main/java/argo/batch/ArgoStatusBatch.java
@@ -71,7 +71,9 @@ public class ArgoStatusBatch {
 		}
 
 		amr.setReportID(reportID);
+		amr.setDate(params.getRequired("run.date"));
 		amr.getRemoteAll();
+		
 		
 
 		DataSource<String>cfgDS = env.fromElements(amr.getResourceJSON(ApiResource.CONFIG));


### PR DESCRIPTION
…equesting resources from argo-web-api

# Issue 
Batch status and ar jobs get the latest argo-web-api resources (profiles,topology etc) regardless of the --run.date parameter of the job. This causes wrong results when recomputing in the past

# Fix
Properly pass run.date job argument string to the initialized ApiResourceManager instance object at the beginning of the job

