### PR TITLE
ARGO-3240 Add timeout configuration when connecting to argo-web-api

### DIFF
--- a/flink_jobs/batch_ar/src/main/java/argo/amr/ApiResourceManager.java
+++ b/flink_jobs/batch_ar/src/main/java/argo/amr/ApiResourceManager.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -12,7 +11,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.net.ssl.SSLContext;
 
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.fluent.Executor;
@@ -59,6 +57,7 @@ public class ApiResourceManager {
 	private String reportName;
 	private String weightsID;
 	private boolean verify;
+	private int timeoutSec;
 
 
 	public ApiResourceManager(String endpoint, String token) {
@@ -74,8 +73,18 @@ public class ApiResourceManager {
 		this.proxy = "";
 		this.weightsID = "";
 		this.verify = true;
+		this.timeoutSec = 5;
 
 	}
+	
+	public int getTimeoutSec() {
+		return timeoutSec;
+	}
+	
+	public void setTimeoutSec(int timeoutSec) {
+		this.timeoutSec = timeoutSec;
+	}
+	
 	
 	public boolean getVerify() {
 		return verify;
@@ -186,7 +195,7 @@ public class ApiResourceManager {
 			r = r.viaProxy(proxy);
 		}
 		
-		r = r.connectTimeout(1000).socketTimeout(1000);
+		r = r.connectTimeout(this.timeoutSec * 1000).socketTimeout(this.timeoutSec * 1000);
 		
 		String content = "{}";
 		
@@ -195,6 +204,7 @@ public class ApiResourceManager {
 				CloseableHttpClient httpClient = HttpClients.custom().setSSLSocketFactory(selfSignedSSLF()).build();
 				Executor executor = Executor.newInstance(httpClient);
 				content = executor.execute(r).returnContent().asString();
+				httpClient.close();
 			} else {
 				
 				content = r.execute().returnContent().asString();

--- a/flink_jobs/batch_ar/src/main/java/argo/batch/ArgoArBatch.java
+++ b/flink_jobs/batch_ar/src/main/java/argo/batch/ArgoArBatch.java
@@ -25,31 +25,18 @@ import org.apache.flink.core.fs.Path;
 
 /**
  * Represents an ARGO A/R Batch Job in flink
- * <p>
- * The specific batch job calculates the availability and reliability results based on the input metric data
- * and sync files
- * </p>
- * Required arguments:
- * <ul>
- * <li>--pdata : file location of previous day's metric data (local or
- * hdfs)</li>
- * <li>--mdata : file location of target day's metric data (local or hdfs)</li>
- * <li>--egp : file location of endpoint group topology file (local or
- * hdfs)</li>
- * <li>--ggp : file location of group of groups topology file (local or
- * hdfs)</li>
- * <li>--mps : file location of metric profile (local or hdfs)</li>
- * <li>--aps : file location of aggregations profile (local or hdfs)</li>
- * <li>--ops : file location of operations profile (local or hdfs)</li>
- * <li>--rec : file location of recomputations file (local or hdfs)</li>
- * <li>--weights : file location of weights file (local or hdfs)</li>
- * <li>--downtimes : file location of downtimes file (local or hdfs)</li>
- * <li>--conf : file location of report configuration json file (local or
- * hdfs)</li>
- * <li>--run.date : target date in DD-MM-YYYY format</li>
- * <li>--mongo.uri : mongo uri for outputting the results</li>
- * <li>--mongo.method : mongo method for storing the results</li>
- * <ul>
+ * 
+ * Submit job in flink cluster using the following parameters: 
+ * --pdata: path to previous day's metric data file (For hdfs use: hdfs://namenode:port/path/to/file)
+ * --mdata: path to metric data file (For hdfs use: hdfs://namenode:port/path/to/file)
+ * --run.date: target date of computation in DD-MM-YYYY format
+ * --mongo.uri: path to MongoDB destination (eg mongodb://localhost:27017/database.table
+ * --mongo.method: Method for storing results to Mongo (insert,upsert)
+ * --report.id: UUUID of the report
+ * --api.endpoint: endpoint hostname of the argo-web-api instance (api.argo.example.com)
+ * --api.token: access token to argo-web-api 
+ * --api.proxy: optional address for proxy to be used (http://proxy.example.com)
+ * --api.timeout: set timeout (in seconds) when connecting to argo-web-api
  */
 public class ArgoArBatch {
 	// setup logger
@@ -79,6 +66,10 @@ public class ArgoArBatch {
 		// set params
 		if (params.has("api.proxy")) {
 			amr.setProxy(params.get("api.proxy"));
+		}
+		
+		if (params.has("api.timeout")) {
+			amr.setTimeoutSec(params.getInt("api.timeout"));
 		}
 		
 		amr.setReportID(reportID);

--- a/flink_jobs/batch_status/src/main/java/argo/amr/ApiResourceManager.java
+++ b/flink_jobs/batch_status/src/main/java/argo/amr/ApiResourceManager.java
@@ -4,14 +4,12 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-
 
 
 import org.apache.http.client.ClientProtocolException;
@@ -59,6 +57,7 @@ public class ApiResourceManager {
 	private String reportName;
 	private String weightsID;
 	private boolean verify;
+	private int timeoutSec;
 
 
 	public ApiResourceManager(String endpoint, String token) {
@@ -74,8 +73,18 @@ public class ApiResourceManager {
 		this.proxy = "";
 		this.weightsID = "";
 		this.verify = true;
+		this.timeoutSec = 5;
 
 	}
+	
+	public int getTimeoutSec() {
+		return timeoutSec;
+	}
+	
+	public void setTimeoutSec(int timeoutSec) {
+		this.timeoutSec = timeoutSec;
+	}
+	
 	
 	public boolean getVerify() {
 		return verify;
@@ -186,7 +195,7 @@ public class ApiResourceManager {
 			r = r.viaProxy(proxy);
 		}
 		
-		r = r.connectTimeout(1000).socketTimeout(1000);
+		r = r.connectTimeout(this.timeoutSec * 1000).socketTimeout(this.timeoutSec * 1000);
 		
 		String content = "{}";
 		
@@ -195,6 +204,7 @@ public class ApiResourceManager {
 				CloseableHttpClient httpClient = HttpClients.custom().setSSLSocketFactory(selfSignedSSLF()).build();
 				Executor executor = Executor.newInstance(httpClient);
 				content = executor.execute(r).returnContent().asString();
+				httpClient.close();
 			} else {
 				
 				content = r.execute().returnContent().asString();

--- a/flink_jobs/batch_status/src/main/java/argo/batch/ArgoStatusBatch.java
+++ b/flink_jobs/batch_status/src/main/java/argo/batch/ArgoStatusBatch.java
@@ -28,19 +28,17 @@ import org.apache.flink.core.fs.Path;
 /**
  * Implements an ARGO Status Batch Job in flink
  * 
- * Submit job in flink cluster using the following parameters 
- * --mps: path tometric profile sync file (For hdfs use: hdfs://namenode:port/path/to/file)
- * --egp: path to endpoints group topology file (For hdfs use: hdfs://namenode:port/path/to/file) 
- * --ggp: path to group of groups topology file (For hdfs use: hdfs://namenode:port/path/to/file) 
+ * Submit job in flink cluster using the following parameters:
  * --pdata: path to previous day's metric data file (For hdfs use: hdfs://namenode:port/path/to/file)
  * --mdata: path to metric data file (For hdfs use: hdfs://namenode:port/path/to/file)
- * --ops: path to operations profile file (For hdfs use: hdfs://namenode:port/path/to/file)
- * --aps: path to aggregations profile file (For hdfs use: hdfs://namenode:port/path/to/file)
- * --cfg: path to report's configuration file (For hdfs use: hdfs://namenode:port/path/to/file)
- * --rec: path to recomputations file
  * --run.date: target date of computation in DD-MM-YYYY format
  * --mongo.uri: path to MongoDB destination (eg mongodb://localhost:27017/database.table
  * --mongo.method: Method for storing results to Mongo (insert,upsert)
+ * --report.id: UUUID of the report
+ * --api.endpoint: endpoint hostname of the argo-web-api instance (api.argo.example.com)
+ * --api.token: access token to argo-web-api 
+ * --api.proxy: optional address for proxy to be used (http://proxy.example.com)
+ * --api.timeout: set timeout (in seconds) when connecting to argo-web-api
  */
 public class ArgoStatusBatch {
 	// setup logger
@@ -68,6 +66,10 @@ public class ArgoStatusBatch {
 		// set params
 		if (params.has("api.proxy")) {
 			amr.setProxy(params.get("api.proxy"));
+		}
+		
+		if (params.has("api.timeout")) {
+			amr.setTimeoutSec(params.getInt("api.timeout"));
 		}
 
 		amr.setReportID(reportID);


### PR DESCRIPTION
### Goal
Add the ability to configure timeouts when connecting to argo-web-api for fetching profiles and topology

### Details
- Add timeoutSec int parameter to ApiResourceManager class
- Use timeoutSec parameter to set requests timeouts with httpClient
- Remove unused imports in ApiResourceManager
- Add a flink job cli optional parameter "--api.timeout" in batch_status and batch_ar jobs
- Update batch_status and batch_ar argument documentation