### PR TITLE
ARGO-3414 Fix thresholds init issue in batch jobs that use argo-web-api

### DIFF
--- a/flink_jobs/batch_ar/src/main/java/argo/batch/ArgoArBatch.java
+++ b/flink_jobs/batch_ar/src/main/java/argo/batch/ArgoArBatch.java
@@ -100,10 +100,10 @@ public class ArgoArBatch {
 		// begin with empty threshold datasource
 		DataSource<String> thrDS = env.fromElements("");
 		
-		// if threshold filepath has been defined in cli parameters
-		if (params.has("thr")){
-			// read file and update threshold datasource
-			thrDS = env.readTextFile(params.getRequired("thr"));
+		// check if report information from argo-web-api contains a threshold profile ID
+		if (!amr.getThresholdsID().equalsIgnoreCase("")){
+			// grab information about thresholds rules from argo-web-api
+			thrDS = env.fromElements(amr.getResourceJSON(ApiResource.THRESHOLDS));
 		}
 		
 		

--- a/flink_jobs/batch_status/src/main/java/argo/batch/ArgoStatusBatch.java
+++ b/flink_jobs/batch_status/src/main/java/argo/batch/ArgoStatusBatch.java
@@ -87,10 +87,11 @@ public class ArgoStatusBatch {
 		
 		// begin with empty threshold datasource
 		DataSource<String> thrDS = env.fromElements("");
-		// if threshold filepath has been defined in cli parameters
-		if (params.has("thr")){
-			// read file and update threshold datasource
-			thrDS = env.readTextFile(params.getRequired("thr"));
+		
+		// check if report information from argo-web-api contains a threshold profile ID
+		if (!amr.getThresholdsID().equalsIgnoreCase("")){
+			// grab information about thresholds rules from argo-web-api
+			thrDS = env.fromElements(amr.getResourceJSON(ApiResource.THRESHOLDS));
 		}
 		
 		ConfigManager confMgr = new ConfigManager();


### PR DESCRIPTION
### Issue
In current argo-web-api centric jobs:
- `/flink_jobs/batch_ar/`
- `/flink_jobs/batch_status/`

there was an issue during the initialization of the jobs where the job still required a file path for the threshold profile (as used to be in hdfs) even if we parsed the information from argo-web-api. This should be removed and fixed

### Fix
Remove the threshold profile initialization from file argument at the beginning of the job and check the following:
- If information coming from api includes a threshold profile initialise it with the appropriate rules given by argo-web-api response
- If not, initialise an empty threshold profile (nothing will be affected in the computation)

