### PR TITLE
ARGO-3424 Add tags for each metric to th mongo db output, on the calculation of status metric trends

### DIFF
--- a/flink_jobs_v2/ApiResourceManager/src/main/java/argo/amr/ApiResourceManager.java
+++ b/flink_jobs_v2/ApiResourceManager/src/main/java/argo/amr/ApiResourceManager.java
@@ -298,8 +298,7 @@ public class ApiResourceManager {
         String fullURL = String.format(path, this.endpoint, this.reportName);
         String content = this.requestManager.getResource(fullURL);
         if (!content.equals("{}")) {
-
-            this.data.put(ApiResource.MTAGS, this.apiResponseParser.getJsonData(content, false));
+            this.data.put(ApiResource.MTAGS, this.apiResponseParser.getJsonData(content, true));
         }
     }
 

--- a/flink_jobs_v2/batch_status/src/main/java/argo/batch/ArgoStatusBatch.java
+++ b/flink_jobs_v2/batch_status/src/main/java/argo/batch/ArgoStatusBatch.java
@@ -1,7 +1,5 @@
 package argo.batch;
 
-import org.slf4j.LoggerFactory;
-
 import argo.amr.ApiResource;
 import argo.amr.ApiResourceManager;
 import argo.ar.CalcEndpointAR;
@@ -36,26 +34,23 @@ import flipflops.Trends;
 import flipflops.ZeroEndpointTrendsFilter;
 import flipflops.ZeroGroupTrendsFilter;
 import flipflops.ZeroMetricTrendsFilter;
-
-import org.slf4j.Logger;
-
-import java.util.List;
 import org.apache.flink.api.common.functions.MapFunction;
-
 import org.apache.flink.api.common.operators.Order;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.AvroInputFormat;
 import org.apache.flink.api.java.operators.DataSource;
-import org.apache.flink.api.java.tuple.Tuple7;
-
+import org.apache.flink.api.java.tuple.Tuple8;
 import org.apache.flink.api.java.utils.ParameterTool;
-
 import org.apache.flink.core.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import profilesmanager.ReportManager;
 import trends.GroupTrendsCounter;
 import trends.MetricTrendsCounter;
 import trends.ServiceTrendsCounter;
+
+import java.util.List;
 
 /**
  * Implements an ARGO Status Batch Job in flink
@@ -161,6 +156,11 @@ public class ArgoStatusBatch {
         if (amr.getResourceJSON(ApiResource.RECOMPUTATIONS) != null) {
             recDS = env.fromElements(amr.getResourceJSON(ApiResource.RECOMPUTATIONS));
         }
+        DataSource<String> mtagsDS = env.fromElements("");
+        if (amr.getResourceJSON(ApiResource.MTAGS) != null) {
+
+            mtagsDS = env.fromElements(amr.getResourceJSON(ApiResource.MTAGS));
+        }
 
         DataSource<String> confDS = env.fromElements(amr.getResourceJSON(ApiResource.CONFIG));
 
@@ -179,7 +179,6 @@ public class ArgoStatusBatch {
             // grab information about thresholds rules from argo-web-api
             thrDS = env.fromElements(amr.getResourceJSON(ApiResource.THRESHOLDS));
         }
-
         ReportManager confMgr = new ReportManager();
         confMgr.loadJsonString(cfgDS.collect());
 
@@ -271,10 +270,13 @@ public class ArgoStatusBatch {
 
         if (calcStatus) {
             //Calculate endpoint timeline timestamps 
+            stDetailDS = stDetailDS.flatMap(new MapStatusMetricTags()).withBroadcastSet(mtagsDS, "mtags");
+
             DataSet<StatusMetric> stEndpointDS = statusEndpointTimeline.flatMap(new CalcStatusEndpoint(params)).withBroadcastSet(mpsDS, "mps").withBroadcastSet(opsDS, "ops")
                     .withBroadcastSet(egpDS, "egp").withBroadcastSet(ggpDS, "ggp")
                     .withBroadcastSet(apsDS, "aps");
 // Create status service data set
+
             DataSet<StatusMetric> stServiceDS = statusServiceTimeline.flatMap(new CalcStatusService(params)).withBroadcastSet(mpsDS, "mps")
                     .withBroadcastSet(egpDS, "egp").withBroadcastSet(ggpDS, "ggp").withBroadcastSet(opsDS, "ops")
                     .withBroadcastSet(apsDS, "aps");
@@ -287,7 +289,7 @@ public class ArgoStatusBatch {
             // Initialize four mongo outputs (metric,endpoint,service,endpoint_group)
             MongoStatusOutput metricMongoOut = new MongoStatusOutput(dbURI, "status_metrics", dbMethod, MongoStatusOutput.StatusType.STATUS_METRIC, reportID);
             MongoStatusOutput endpointMongoOut = new MongoStatusOutput(dbURI, "status_endpoints", dbMethod, MongoStatusOutput.StatusType.STATUS_ENDPOINT, reportID);
-            MongoStatusOutput serviceMongoOut = new MongoStatusOutput(dbURI, "status_services", dbMethod, MongoStatusOutput.StatusType.STATUS_ENDPOINT, reportID);
+            MongoStatusOutput serviceMongoOut = new MongoStatusOutput(dbURI, "status_services", dbMethod, MongoStatusOutput.StatusType.STATUS_SERVICE, reportID);
             MongoStatusOutput endGroupMongoOut = new MongoStatusOutput(dbURI, "status_endpoint_groups", dbMethod, MongoStatusOutput.StatusType.STATUS_ENDPOINT_GROUP, reportID);
 
             stDetailDS.output(metricMongoOut);
@@ -335,6 +337,7 @@ public class ArgoStatusBatch {
 
                 MongoTrendsOutput metricFlipFlopMongoOut = new MongoTrendsOutput(dbURI, "flipflop_trends_metrics", MongoTrendsOutput.TrendsType.TRENDS_METRIC, reportID, runDate, clearMongo);
                 DataSet<Trends> trends = noZeroServiceEndpointMetricGroupData.map(new MapMetricTrends());
+                trends = trends.flatMap(new MapTrendTags()).withBroadcastSet(mtagsDS, "mtags");
                 trends.output(metricFlipFlopMongoOut);
 
                 DataSet<EndpointTrends> noZeroserviceEndpointGroupData = serviceEndpointGroupData.filter(new ZeroEndpointTrendsFilter());
@@ -377,7 +380,8 @@ public class ArgoStatusBatch {
 
             if (calcTrends) {
                 //flatMap dataset to tuples and count the apperances of each status type to the timeline 
-                DataSet< Tuple7< String, String, String, String, String, Integer, Integer>> metricStatusTrendsData = serviceEndpointMetricGroupData.flatMap(new MetricTrendsCounter()).withBroadcastSet(opsDS, "ops");
+                DataSet< Tuple8< String, String, String, String, String, Integer, Integer, String>> metricStatusTrendsData = serviceEndpointMetricGroupData.flatMap(new MetricTrendsCounter()).withBroadcastSet(opsDS, "ops");
+               metricStatusTrendsData= metricStatusTrendsData.flatMap(new MapTupleTags()).withBroadcastSet(mtagsDS, "mtags");
                 //filter dataset for each status type and write to mongo db
                 filterByStatusAndWriteMongo(MongoTrendsOutput.TrendsType.TRENDS_STATUS_METRIC, "status_trends_metrics", metricStatusTrendsData, "critical");
                 filterByStatusAndWriteMongo(MongoTrendsOutput.TrendsType.TRENDS_STATUS_METRIC, "status_trends_metrics", metricStatusTrendsData, "warning");
@@ -385,7 +389,7 @@ public class ArgoStatusBatch {
 
                 /*=============================================================================================*/
                 //flatMap dataset to tuples and count the apperances of each status type to the timeline 
-                DataSet< Tuple7< String, String, String, String, String, Integer, Integer>> endpointStatusTrendsData = serviceEndpointGroupData.flatMap(new EndpointTrendsCounter()).withBroadcastSet(opsDS, "ops");
+                DataSet< Tuple8< String, String, String, String, String, Integer, Integer, String>> endpointStatusTrendsData = serviceEndpointGroupData.flatMap(new EndpointTrendsCounter()).withBroadcastSet(opsDS, "ops");
                 //filter dataset for each status type and write to mongo db
 
                 filterByStatusAndWriteMongo(MongoTrendsOutput.TrendsType.TRENDS_STATUS_ENDPOINT, "status_trends_endpoints", endpointStatusTrendsData, "critical");
@@ -395,7 +399,7 @@ public class ArgoStatusBatch {
                 /**
                  * **************************************************************************************************
                  */
-                DataSet< Tuple7< String, String, String, String, String, Integer, Integer>> serviceStatusTrendsData = serviceGroupData.flatMap(new ServiceTrendsCounter()).withBroadcastSet(opsDS, "ops");
+                DataSet< Tuple8< String, String, String, String, String, Integer, Integer, String>> serviceStatusTrendsData = serviceGroupData.flatMap(new ServiceTrendsCounter()).withBroadcastSet(opsDS, "ops");
                 //filter dataset for each status type and write to mongo db
                 filterByStatusAndWriteMongo(MongoTrendsOutput.TrendsType.TRENDS_STATUS_SERVICE, "status_trends_services", serviceStatusTrendsData, "critical");
                 filterByStatusAndWriteMongo(MongoTrendsOutput.TrendsType.TRENDS_STATUS_SERVICE, "status_trends_services", serviceStatusTrendsData, "warning");
@@ -406,7 +410,7 @@ public class ArgoStatusBatch {
                  */
                 //group data by group   and count flip flops
                 //flatMap dataset to tuples and count the apperances of each status type to the timeline 
-                DataSet< Tuple7< String, String, String, String, String, Integer, Integer>> groupStatusTrendsData = groupData.flatMap(new GroupTrendsCounter()).withBroadcastSet(opsDS, "ops");
+                DataSet< Tuple8< String, String, String, String, String, Integer, Integer, String>> groupStatusTrendsData = groupData.flatMap(new GroupTrendsCounter()).withBroadcastSet(opsDS, "ops");
                 //filter dataset for each status type and write to mongo db
                 filterByStatusAndWriteMongo(MongoTrendsOutput.TrendsType.TRENDS_STATUS_GROUP, "status_trends_groups", groupStatusTrendsData, "critical");
                 filterByStatusAndWriteMongo(MongoTrendsOutput.TrendsType.TRENDS_STATUS_GROUP, "status_trends_groups", groupStatusTrendsData, "warning");
@@ -427,38 +431,38 @@ public class ArgoStatusBatch {
 
     }
 
-    private static void filterByStatusAndWriteMongo(MongoTrendsOutput.TrendsType mongoTrendsType, String uri, DataSet< Tuple7< String, String, String, String, String, Integer, Integer>> data, String status) {
+    private static void filterByStatusAndWriteMongo(MongoTrendsOutput.TrendsType mongoTrendsType, String uri, DataSet< Tuple8< String, String, String, String, String, Integer, Integer, String>> data, String status) {
 
-        DataSet< Tuple7< String, String, String, String, String, Integer, Integer>> filteredData = data.filter(new StatusAndDurationFilter(status)); //filter dataset by status type and status appearances>0
+        DataSet< Tuple8< String, String, String, String, String, Integer, Integer, String>> filteredData = data.filter(new StatusAndDurationFilter(status)); //filter dataset by status type and status appearances>0
 
         if (rankNum != null) {
-            filteredData = filteredData.sortPartition(6, Order.DESCENDING).setParallelism(1).first(rankNum);
+            filteredData = filteredData.sortPartition(7, Order.DESCENDING).setParallelism(1).first(rankNum);
         } else {
-            filteredData = filteredData.sortPartition(6, Order.DESCENDING).setParallelism(1);
+            filteredData = filteredData.sortPartition(7, Order.DESCENDING).setParallelism(1);
         }
         writeStatusTrends(filteredData, uri, mongoTrendsType, data, status); //write to mongo db
 
     }
 
     // write status trends to mongo db
-    private static void writeStatusTrends(DataSet< Tuple7< String, String, String, String, String, Integer, Integer>> outputData, String uri, final MongoTrendsOutput.TrendsType mongoCase, DataSet< Tuple7< String, String, String, String, String, Integer, Integer>> data, String status) {
+    private static void writeStatusTrends(DataSet< Tuple8< String, String, String, String, String, Integer, Integer, String>> outputData, String uri, final MongoTrendsOutput.TrendsType mongoCase, DataSet< Tuple8< String, String, String, String, String, Integer, Integer, String>> data, String status) {
 
         //MongoTrendsOutput.TrendsType.TRENDS_STATUS_ENDPOINT
         MongoTrendsOutput metricMongoOut = new MongoTrendsOutput(dbURI, uri, mongoCase, reportID, runDate, clearMongo);
 
-        DataSet<Trends> trends = outputData.map(new MapFunction< Tuple7< String, String, String, String, String, Integer, Integer>, Trends>() {
+        DataSet<Trends> trends = outputData.map(new MapFunction< Tuple8< String, String, String, String, String, Integer, Integer, String>, Trends>() {
 
             @Override
-            public Trends map(Tuple7< String, String, String, String, String, Integer, Integer> in) throws Exception {
+            public Trends map(Tuple8< String, String, String, String, String, Integer, Integer, String> in) throws Exception {
                 switch (mongoCase) {
                     case TRENDS_STATUS_METRIC:
-                        return new Trends(in.f0, in.f1, in.f2, in.f3, in.f4, in.f5, in.f6);
+                        return new Trends(in.f0, in.f1, in.f2, in.f3, in.f4, in.f5, in.f6, in.f7);
                     case TRENDS_STATUS_ENDPOINT:
-                        return new Trends(in.f0, in.f1, in.f2, null, in.f4, in.f5, in.f6);
+                        return new Trends(in.f0, in.f1, in.f2, null, in.f4, in.f5, in.f6, null);
                     case TRENDS_STATUS_SERVICE:
-                        return new Trends(in.f0, in.f1, null, null, in.f4, in.f5, in.f6);
+                        return new Trends(in.f0, in.f1, null, null, in.f4, in.f5, in.f6, null);
                     case TRENDS_STATUS_GROUP:
-                        return new Trends(in.f0, null, null, null, in.f4, in.f5, in.f6);
+                        return new Trends(in.f0, null, null, null, in.f4, in.f5, in.f6, null);
                     default:
                         return null;
                 }

--- a/flink_jobs_v2/batch_status/src/main/java/argo/batch/CalcEndpointTimeline.java
+++ b/flink_jobs_v2/batch_status/src/main/java/argo/batch/CalcEndpointTimeline.java
@@ -112,7 +112,7 @@ public class CalcEndpointTimeline extends RichGroupReduceFunction<StatusTimeline
             timestatuCol.add(timestatus);
         }
 
-        StatusTimeline statusMetricTimeline = new StatusTimeline(endpointGroup, function, service, hostname, "", timestatuCol);
+        StatusTimeline statusMetricTimeline = new StatusTimeline(endpointGroup, function, service, hostname, "", timestatuCol,"");
         out.collect(statusMetricTimeline);
 
     }

--- a/flink_jobs_v2/batch_status/src/main/java/argo/batch/CalcGroupFunctionTimeline.java
+++ b/flink_jobs_v2/batch_status/src/main/java/argo/batch/CalcGroupFunctionTimeline.java
@@ -105,7 +105,7 @@ public class CalcGroupFunctionTimeline extends RichGroupReduceFunction<StatusTim
             timestatuCol.add(timestatus);
         }
 
-        StatusTimeline statusMetricTimeline = new StatusTimeline(endpointGroup, function, "", "", "",  timestatuCol);
+        StatusTimeline statusMetricTimeline = new StatusTimeline(endpointGroup, function, "", "", "",  timestatuCol,"");
         out.collect(statusMetricTimeline);
 
     }

--- a/flink_jobs_v2/batch_status/src/main/java/argo/batch/CalcGroupTimeline.java
+++ b/flink_jobs_v2/batch_status/src/main/java/argo/batch/CalcGroupTimeline.java
@@ -99,7 +99,7 @@ public class CalcGroupTimeline extends RichGroupReduceFunction<StatusTimeline, S
             timestatuCol.add(timestatus);
         }
 
-        StatusTimeline statusMetricTimeline = new StatusTimeline(endpointGroup, "", "", "", "", timestatuCol);
+        StatusTimeline statusMetricTimeline = new StatusTimeline(endpointGroup, "", "", "", "", timestatuCol,"");
         out.collect(statusMetricTimeline);
 
     }

--- a/flink_jobs_v2/batch_status/src/main/java/argo/batch/CalcMetricTimeline.java
+++ b/flink_jobs_v2/batch_status/src/main/java/argo/batch/CalcMetricTimeline.java
@@ -30,6 +30,7 @@ import utils.Utils;
  * the datastore schema for status endpoint collection
  */
 public class CalcMetricTimeline extends RichGroupReduceFunction<StatusMetric, StatusTimeline> {
+
     private static final long serialVersionUID = 1L;
 
     final ParameterTool params;
@@ -46,6 +47,7 @@ public class CalcMetricTimeline extends RichGroupReduceFunction<StatusMetric, St
     private AggregationProfileManager apsMgr;
     private OperationsManager opsMgr;
     private String runDate;
+
     @Override
     public void open(Configuration parameters) throws IOException {
         this.runDate = params.getRequired("run.date");
@@ -73,6 +75,7 @@ public class CalcMetricTimeline extends RichGroupReduceFunction<StatusMetric, St
         String endpointGroup = "";
         String hostname = "";
         String metric = "";
+        String tags = "";
         TreeMap<DateTime, Integer> timeStatusMap = new TreeMap<>();
         for (StatusMetric item : in) {
             service = item.getService();
@@ -80,6 +83,7 @@ public class CalcMetricTimeline extends RichGroupReduceFunction<StatusMetric, St
             hostname = item.getHostname();
             function = item.getFunction();
             metric = item.getMetric();
+            tags = item.getTags();
             String ts = item.getTimestamp();
             String status = item.getStatus();
             if (i == 0) {
@@ -103,7 +107,7 @@ public class CalcMetricTimeline extends RichGroupReduceFunction<StatusMetric, St
             timestatusList.add(timestatus);
         }
 
-        StatusTimeline statusMetricTimeline = new StatusTimeline(endpointGroup, function, service, hostname, metric, timestatusList);
+        StatusTimeline statusMetricTimeline = new StatusTimeline(endpointGroup, function, service, hostname, metric, timestatusList, tags);
         out.collect(statusMetricTimeline);
 
     }

--- a/flink_jobs_v2/batch_status/src/main/java/argo/batch/CalcServiceTimeline.java
+++ b/flink_jobs_v2/batch_status/src/main/java/argo/batch/CalcServiceTimeline.java
@@ -101,7 +101,7 @@ public class CalcServiceTimeline extends RichGroupReduceFunction<StatusTimeline,
             timestatuCol.add(timestatus);
         }
 
-        StatusTimeline statusMetricTimeline = new StatusTimeline(endpointGroup, function, service, "", "", timestatuCol);
+        StatusTimeline statusMetricTimeline = new StatusTimeline(endpointGroup, function, service, "", "", timestatuCol,"");
 
         out.collect(statusMetricTimeline);
 

--- a/flink_jobs_v2/batch_status/src/main/java/argo/batch/MapServices.java
+++ b/flink_jobs_v2/batch_status/src/main/java/argo/batch/MapServices.java
@@ -1,4 +1,5 @@
 package argo.batch;
+
 import java.io.IOException;
 import java.util.List;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
@@ -12,13 +13,13 @@ import profilesmanager.AggregationProfileManager;
  */
 public class MapServices extends RichFlatMapFunction<StatusMetric, StatusMetric> {
 
-    //private AggregationProfileParser aggregationProfileParser;
     public MapServices() {
 
     }
 
     private List<String> aps;
     private AggregationProfileManager apsMgr;
+
     @Override
     public void open(Configuration parameters) throws IOException {
 
@@ -28,7 +29,7 @@ public class MapServices extends RichFlatMapFunction<StatusMetric, StatusMetric>
         // Initialize aggregation profile manager
         this.apsMgr = new AggregationProfileManager();
         this.apsMgr.loadJsonString(aps);
-        // Initialize operations manager      
+        // Initialize operations manager    
 
     }
 
@@ -46,7 +47,6 @@ public class MapServices extends RichFlatMapFunction<StatusMetric, StatusMetric>
         String service = t.getService();
 
         String function = this.apsMgr.retrieveFunctionsByService(service);
-
         StatusMetric newT = t;
         newT.setFunction(function);
         out.collect(newT);

--- a/flink_jobs_v2/batch_status/src/main/java/argo/batch/MapStatusMetricTags.java
+++ b/flink_jobs_v2/batch_status/src/main/java/argo/batch/MapStatusMetricTags.java
@@ -1,0 +1,58 @@
+package argo.batch;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+import profilesmanager.MetricTagsManager;
+
+/**
+ * MapStatusMetricTags produces StatusMetric enriched with the defined tags that
+ * correspond to the metric
+ */
+public class MapStatusMetricTags extends RichFlatMapFunction<StatusMetric, StatusMetric> {
+
+    public MapStatusMetricTags() {
+
+    }
+
+    List<String> mtags;
+    private MetricTagsManager mtagsMgr;
+
+    @Override
+    public void open(Configuration parameters) throws IOException {
+        // Initialize MetricTags manager          
+        this.mtags = getRuntimeContext().getBroadcastVariable("mtags");
+        this.mtagsMgr = new MetricTagsManager();
+        this.mtagsMgr.loadJsonString(mtags);
+    }
+
+    /**
+     * if the service exist in one or more function groups , timeline trends are
+     * produced for each function that the service belongs and the function info
+     * is added to the timelinetrend
+     *
+     * @param t
+     * @param out
+     * @throws Exception
+     */
+    @Override
+    public void flatMap(StatusMetric t, Collector<StatusMetric> out) throws Exception {
+        ArrayList<String> tags = this.mtagsMgr.getTags(t.getMetric());
+        String tagInfo = "";
+        for (String tag : tags) {
+            if (tags.indexOf(tag) == 0) {
+                tagInfo = tagInfo + tag;
+            } else {
+                tagInfo = tagInfo + "," + tag;
+            }
+        }
+        StatusMetric newT = t;
+        newT.setTags(tagInfo);
+        out.collect(newT);
+
+    }
+
+}

--- a/flink_jobs_v2/batch_status/src/main/java/argo/batch/MapTrendTags.java
+++ b/flink_jobs_v2/batch_status/src/main/java/argo/batch/MapTrendTags.java
@@ -1,0 +1,61 @@
+package argo.batch;
+
+import flipflops.Trends;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+import profilesmanager.MetricTagsManager;
+
+
+/**
+ * MapTrendTags produces Trends enriched with the defined tags that correspond to the metric
+ */
+public class MapTrendTags extends RichFlatMapFunction<Trends, Trends> {
+
+    public MapTrendTags() {
+
+    }
+
+    List<String> mtags;
+    private MetricTagsManager mtagsMgr;
+
+    @Override
+    public void open(Configuration parameters) throws IOException {
+        // Initialize MetricTags manager    
+
+        this.mtags = getRuntimeContext().getBroadcastVariable("mtags");
+        this.mtagsMgr = new MetricTagsManager();
+        this.mtagsMgr.loadJsonString(mtags);
+
+    }
+
+    /**
+     * if the service exist in one or more function groups , timeline trends are
+     * produced for each function that the service belongs and the function info
+     * is added to the timelinetrend
+     *
+     * @param t
+     * @param out
+     * @throws Exception
+     */
+    @Override
+    public void flatMap(Trends t, Collector< Trends> out) throws Exception {
+        ArrayList<String> tags = this.mtagsMgr.getTags(t.getMetric());
+        String tagInfo = "";
+        for (String tag : tags) {
+            if (tags.indexOf(tag) == 0) {
+                tagInfo = tagInfo + tag;
+            } else {
+                tagInfo = tagInfo + "," + tag;
+            }
+        }
+        Trends newT = t;
+        newT.setTags(tagInfo);
+        out.collect(newT);
+
+    }
+
+}

--- a/flink_jobs_v2/batch_status/src/main/java/argo/batch/MapTupleTags.java
+++ b/flink_jobs_v2/batch_status/src/main/java/argo/batch/MapTupleTags.java
@@ -1,0 +1,59 @@
+package argo.batch;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.java.tuple.Tuple8;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+import profilesmanager.MetricTagsManager;
+
+/**
+ * MapTupleTags produces Tuples enriched with the defined tags that correspond to the metric
+ */
+public class MapTupleTags extends RichFlatMapFunction<Tuple8< String, String, String, String, String, Integer, Integer, String> ,Tuple8< String, String, String, String, String, Integer, Integer, String> > {
+
+    public MapTupleTags() {
+
+    }
+
+    List<String> mtags;
+    private MetricTagsManager mtagsMgr;
+
+    @Override
+    public void open(Configuration parameters) throws IOException {
+              // Initialize MetricTags manager    
+        this.mtags = getRuntimeContext().getBroadcastVariable("mtags");
+
+        this.mtagsMgr = new MetricTagsManager();
+        this.mtagsMgr.loadJsonString(mtags);
+    }
+
+    /**
+     * if the service exist in one or more function groups , timeline trends are
+     * produced for each function that the service belongs and the function info
+     * is added to the timelinetrend
+     *
+     * @param t
+     * @param out
+     * @throws Exception
+     */
+    @Override
+    public void flatMap(Tuple8< String, String, String, String, String, Integer, Integer, String> t, Collector< Tuple8< String, String, String, String, String, Integer, Integer, String>> out) throws Exception {
+        ArrayList<String> tags = this.mtagsMgr.getTags(t.f3);
+        String tagInfo = "";
+        for (String tag : tags) {
+            if (tags.indexOf(tag) == 0) {
+                tagInfo = tagInfo + tag;
+            } else {
+                tagInfo = tagInfo + "," + tag;
+            }
+        }
+        Tuple8< String, String, String, String, String, Integer, Integer, String> newT = t;
+        newT.f7 = tagInfo;
+        out.collect(newT);
+
+    }
+
+}

--- a/flink_jobs_v2/batch_status/src/main/java/argo/batch/MongoStatusOutput.java
+++ b/flink_jobs_v2/batch_status/src/main/java/argo/batch/MongoStatusOutput.java
@@ -132,6 +132,7 @@ public class MongoStatusOutput implements OutputFormat<StatusMetric> {
 			doc.append("service", record.getService())
 			.append("host", record.getHostname())
 			.append("metric", record.getMetric())
+                         .append("tags", record.getTags())
 			.append("message", record.getMessage())
 			.append("summary", record.getSummary())
 			.append("time_integer",record.getTimeInt()) 

--- a/flink_jobs_v2/batch_status/src/main/java/argo/batch/PickEndpoints.java
+++ b/flink_jobs_v2/batch_status/src/main/java/argo/batch/PickEndpoints.java
@@ -171,7 +171,7 @@ public class PickEndpoints extends RichFlatMapFunction<MetricData,StatusMetric> 
 				}
 				String info  = this.egpMgr.getInfo(groupname, egroupType, md.getHostname(), md.getService());
 
-				StatusMetric sm = new StatusMetric(groupname,"",md.getService(),md.getHostname(),md.getMetric(), status,md.getTimestamp(),dateInt,timeInt,md.getSummary(),md.getMessage(),"","",actualData, ogStatus, ruleApplied,info);
+				StatusMetric sm = new StatusMetric(groupname,"",md.getService(),md.getHostname(),md.getMetric(), status,md.getTimestamp(),dateInt,timeInt,md.getSummary(),md.getMessage(),"","",actualData, ogStatus, ruleApplied,info,"");
 				out.collect(sm);
 			}
 				

--- a/flink_jobs_v2/batch_status/src/main/java/argo/batch/StatusMetric.java
+++ b/flink_jobs_v2/batch_status/src/main/java/argo/batch/StatusMetric.java
@@ -3,7 +3,7 @@ package argo.batch;
 public class StatusMetric {
 
     private String group;
-    private String function ;
+    private String function;
     private String service;
     private String hostname;
     private String metric;
@@ -19,6 +19,7 @@ public class StatusMetric {
     private String ogStatus; // original status from moniting host
     private String ruleApplied; // threshold rule applied - empty if not 
     private String info; // extra endpoint information provided by the topology
+    private String tags;
 
     public StatusMetric() {
         this.group = "";
@@ -38,10 +39,11 @@ public class StatusMetric {
         this.ogStatus = "";
         this.ruleApplied = "";
         this.info = "";
+        this.tags = "";
     }
 
     public StatusMetric(String group, String function, String service, String hostname, String metric, String status, String timestamp,
-            int dateInt, int timeInt, String summary, String message, String prevState, String prevTs, String actualData, String ogStatus, String ruleApplied, String info) {
+            int dateInt, int timeInt, String summary, String message, String prevState, String prevTs, String actualData, String ogStatus, String ruleApplied, String info, String tags) {
 
         this.group = group;
         this.function = function;
@@ -60,9 +62,16 @@ public class StatusMetric {
         this.ogStatus = ogStatus;
         this.ruleApplied = ruleApplied;
         this.info = info;
+        this.tags = tags;
     }
 
+    public String getTags() {
+        return tags;
+    }
 
+    public void setTags(String tags) {
+        this.tags = tags;
+    }
 
     public String getGroup() {
         return group;
@@ -71,6 +80,7 @@ public class StatusMetric {
     public void setGroup(String group) {
         this.group = group;
     }
+
     public String getFunction() {
         return function;
     }
@@ -202,7 +212,7 @@ public class StatusMetric {
     @Override
     public String toString() {
         return "(" + this.group + "," + this.service + "," + this.hostname + "," + this.metric + "," + this.status + "," + this.timestamp + ","
-                + this.dateInt + "," + this.timeInt + "," + this.prevState + "," + this.prevTs + "," + this.actualData + "," + this.ogStatus + "," + this.ruleApplied + "," + this.info + ")";
+                + this.dateInt + "," + this.timeInt + "," + this.prevState + "," + this.prevTs + "," + this.actualData + "," + this.ogStatus + "," + this.ruleApplied + "," + this.info + ","+ this.tags+")";
     }
 
 }

--- a/flink_jobs_v2/batch_status/src/main/java/argo/batch/StatusTimeline.java
+++ b/flink_jobs_v2/batch_status/src/main/java/argo/batch/StatusTimeline.java
@@ -19,6 +19,7 @@ public class StatusTimeline implements Serializable {
     private String service;
     private String hostname;
     private String metric;
+    private String tags;
     ArrayList<TimeStatus> timestamps;
 
     public StatusTimeline() {
@@ -26,16 +27,26 @@ public class StatusTimeline implements Serializable {
         function = "";
         service = "";
         hostname = "";
-         timestamps = new ArrayList<>();
+        tags = "";
+        timestamps = new ArrayList<>();
     }
 
-    public StatusTimeline(String group, String function, String service, String hostname, String metric, ArrayList<TimeStatus> timestamps) {
+    public StatusTimeline(String group, String function, String service, String hostname, String metric, ArrayList<TimeStatus> timestamps, String tags) {
         this.group = group;
         this.function = function;
         this.service = service;
         this.hostname = hostname;
         this.metric = metric;
         this.timestamps = timestamps;
+        this.tags = tags;
+    }
+
+    public String getTags() {
+        return tags;
+    }
+
+    public void setTags(String tags) {
+        this.tags = tags;
     }
 
     public String getGroup() {
@@ -77,8 +88,6 @@ public class StatusTimeline implements Serializable {
     public void setMetric(String metric) {
         this.metric = metric;
     }
-
-
 
     public ArrayList<TimeStatus> getTimestamps() {
         return timestamps;

--- a/flink_jobs_v2/batch_status/src/main/java/flipflops/CalcMetricFlipFlopTrends.java
+++ b/flink_jobs_v2/batch_status/src/main/java/flipflops/CalcMetricFlipFlopTrends.java
@@ -1,4 +1,5 @@
 package flipflops;
+
 /*
  * To change this license header, choose License Headers in Project Properties.
  * To change this template file, choose Tools | Templates
@@ -15,21 +16,21 @@ import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import timelines.Timeline;
+
 /**
  * Accepts a list of monitoring timelines and produces an endpoint timeline The
  * class is used as a RichGroupReduce Function in flink pipeline
  */
 public class CalcMetricFlipFlopTrends implements FlatMapFunction<StatusTimeline, MetricTrends> {
+
     private static final long serialVersionUID = 1L;
 
-  
     public CalcMetricFlipFlopTrends() {
-   
+
     }
 
     static Logger LOG = LoggerFactory.getLogger(CalcMetricFlipFlopTrends.class);
-   
- 
+
     /**
      * The main operator business logic of transforming a collection of
      * MetricTimelines to an aggregated endpoint timeline
@@ -45,16 +46,17 @@ public class CalcMetricFlipFlopTrends implements FlatMapFunction<StatusTimeline,
      * @param out A Collector list of MonTimeline to acquire the produced
      * endpoint timelines.
      */
-
- @Override
+    @Override
     public void flatMap(StatusTimeline in, Collector<MetricTrends> out) throws Exception {
-       // Initialize field values and aggregator
+        // Initialize field values and aggregator
         String metric = "";
         String hostname = "";
         String service = "";
         String endpointGroup = "";
-        metric=in.getMetric();
-        hostname=in.getHostname();
+        String tags = "";
+        tags = in.getTags();
+        metric = in.getMetric();
+        hostname = in.getHostname();
         service = in.getService();
         endpointGroup = in.getGroup();
         ArrayList<TimeStatus> timestatusList = in.getTimestamps();
@@ -72,7 +74,7 @@ public class CalcMetricFlipFlopTrends implements FlatMapFunction<StatusTimeline,
 
         if (endpointGroup != null && service != null && hostname != null && metric != null) {
 
-            MetricTrends metricTrends = new MetricTrends(endpointGroup, service, hostname, metric, timeline, flipflop);
+            MetricTrends metricTrends = new MetricTrends(endpointGroup, service, hostname, metric, timeline, flipflop,tags);
             out.collect(metricTrends);
         }
     }

--- a/flink_jobs_v2/batch_status/src/main/java/flipflops/MapMetricTrends.java
+++ b/flink_jobs_v2/batch_status/src/main/java/flipflops/MapMetricTrends.java
@@ -10,6 +10,6 @@ public class MapMetricTrends implements MapFunction<MetricTrends, Trends> {
 
     @Override
     public Trends map(MetricTrends in) throws Exception {
-        return new Trends(in.getGroup(), in.getService(), in.getEndpoint(), in.getMetric(), in.getFlipflops());
+        return new Trends(in.getGroup(), in.getService(), in.getEndpoint(), in.getMetric(), in.getFlipflops(), in.getTags());
     }
 }

--- a/flink_jobs_v2/batch_status/src/main/java/flipflops/MapServiceTrends.java
+++ b/flink_jobs_v2/batch_status/src/main/java/flipflops/MapServiceTrends.java
@@ -1,5 +1,4 @@
 package flipflops;
-
 import org.apache.flink.api.common.functions.MapFunction;
 
 public class MapServiceTrends implements MapFunction<ServiceTrends, Trends> {

--- a/flink_jobs_v2/batch_status/src/main/java/flipflops/MetricTrends.java
+++ b/flink_jobs_v2/batch_status/src/main/java/flipflops/MetricTrends.java
@@ -17,19 +17,29 @@ public class MetricTrends {
     String service;
     String endpoint;
     String metric;
+    String tags;
     Timeline timeline;
     Integer flipflops;
 
     public MetricTrends() {
     }
 
-    public MetricTrends(String group, String service, String endpoint, String metric, Timeline timeline, Integer flipflops) {
+    public MetricTrends(String group, String service, String endpoint, String metric, Timeline timeline, Integer flipflops, String tags) {
         this.group = group;
         this.service = service;
         this.endpoint = endpoint;
         this.metric = metric;
         this.timeline = timeline;
         this.flipflops = flipflops;
+        this.tags = tags;
+    }
+
+    public String getTags() {
+        return tags;
+    }
+
+    public void setTags(String tags) {
+        this.tags = tags;
     }
 
     public String getGroup() {

--- a/flink_jobs_v2/batch_status/src/main/java/flipflops/MongoTrendsOutput.java
+++ b/flink_jobs_v2/batch_status/src/main/java/flipflops/MongoTrendsOutput.java
@@ -114,6 +114,7 @@ public class MongoTrendsOutput implements OutputFormat<Trends> {
                 doc.append("service", record.getService());
                 doc.append("endpoint", record.getEndpoint());
                 doc.append("metric", record.getMetric());
+                doc.append("tags", record.getTags());
                 doc.append("flipflop", record.getFlipflop());
                 break;
             case TRENDS_STATUS_METRIC:
@@ -124,6 +125,7 @@ public class MongoTrendsOutput implements OutputFormat<Trends> {
                 doc.append("status", record.getStatus());
                 doc.append("duration", record.getDuration());
                 doc.append("trends", record.getTrends());
+                doc.append("tags", record.getTags());
                 break;
             case TRENDS_STATUS_ENDPOINT:
                 doc.append("group", record.getGroup());

--- a/flink_jobs_v2/batch_status/src/main/java/flipflops/StatusAndDurationFilter.java
+++ b/flink_jobs_v2/batch_status/src/main/java/flipflops/StatusAndDurationFilter.java
@@ -6,14 +6,14 @@ package flipflops;
  * and open the template in the editor.
  */
 import org.apache.flink.api.common.functions.FilterFunction;
-import org.apache.flink.api.java.tuple.Tuple7;
+import org.apache.flink.api.java.tuple.Tuple8;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * StatusFilter, filters data by status and status appearances
  */
-public class StatusAndDurationFilter implements FilterFunction<Tuple7<String, String, String, String, String, Integer, Integer>> {
+public class StatusAndDurationFilter implements FilterFunction<Tuple8<String, String, String, String, String, Integer, Integer,String>> {
 
     static Logger LOG = LoggerFactory.getLogger(StatusAndDurationFilter.class);
     private String status;
@@ -24,7 +24,7 @@ public class StatusAndDurationFilter implements FilterFunction<Tuple7<String, St
     //if the status field value in Tuple equals the given status  and status appearances>0 returns true, else returns false
 
     @Override
-    public boolean filter(Tuple7<String, String, String, String, String, Integer, Integer> t) throws Exception {
+    public boolean filter(Tuple8<String, String, String, String, String,  Integer, Integer,String> t) throws Exception {
 
         if (t.f4.toString().equalsIgnoreCase(status) && t.f6 > 0) {
             return true;

--- a/flink_jobs_v2/batch_status/src/main/java/flipflops/Trends.java
+++ b/flink_jobs_v2/batch_status/src/main/java/flipflops/Trends.java
@@ -6,6 +6,7 @@ package flipflops;
  * and open the template in the editor.
  */
 public class Trends {
+
     private String group;
     private String service;
     private String endpoint;
@@ -15,15 +16,17 @@ public class Trends {
     private String status;
     private int trends;
     private int duration;
+    private String tags;
 
-    public Trends(String group, String service, String endpoint, String metric, String status, int trends, int duration) {
+    public Trends(String group, String service, String endpoint, String metric, String status, int trends, int duration, String tags) {
         this.group = group;
         this.service = service;
         this.endpoint = endpoint;
         this.metric = metric;
         this.status = status;
         this.trends = trends;
-        this.duration=duration;
+        this.duration = duration;
+        this.tags = tags;
     }
 
     public Trends(String group, String service, String endpoint, String metric, String status, int trends) {
@@ -35,15 +38,14 @@ public class Trends {
         this.status = status;
         this.trends = trends;
     }
-    
-    
 
-    public Trends(String group, String service, String endpoint, String metric, int flipflop) {
+    public Trends(String group, String service, String endpoint, String metric, int flipflop,String tags) {
         this.group = group;
         this.service = service;
         this.endpoint = endpoint;
         this.metric = metric;
         this.flipflop = flipflop;
+        this.tags = tags;
     }
 
     public Trends(String group, int flipflop) {
@@ -63,6 +65,15 @@ public class Trends {
         this.endpoint = endpoint;
         this.flipflop = flipflop;
     }
+
+    public String getTags() {
+        return tags;
+    }
+
+    public void setTags(String tags) {
+        this.tags = tags;
+    }
+
 
     public String getGroup() {
         return group;
@@ -103,8 +114,7 @@ public class Trends {
     public void setFlipflop(int flipflop) {
         this.flipflop = flipflop;
     }
-    
-    
+
     public String getStatus() {
         return status;
     }
@@ -128,7 +138,5 @@ public class Trends {
     public void setDuration(int duration) {
         this.duration = duration;
     }
-    
-    
-    
+
 }

--- a/flink_jobs_v2/batch_status/src/main/java/trends/EndpointTrendsCounter.java
+++ b/flink_jobs_v2/batch_status/src/main/java/trends/EndpointTrendsCounter.java
@@ -5,12 +5,12 @@ package argo.trends;
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-import argo.batch.StatusMetricTimeline;
 import flipflops.EndpointTrends;
 import java.io.IOException;
 import java.util.List;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.java.tuple.Tuple7;
+import org.apache.flink.api.java.tuple.Tuple8;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Collector;
 import profilesmanager.OperationsManager;
@@ -22,7 +22,7 @@ import timelines.TimelineIntegrator;
  * appearances of the status CRITICAL, WARNING,UNKNOWN and produces a dataset of
  * tuples that contain these calculations
  */
-public class EndpointTrendsCounter extends RichFlatMapFunction<EndpointTrends, Tuple7< String, String, String, String, String, Integer, Integer>> {
+public class EndpointTrendsCounter extends RichFlatMapFunction<EndpointTrends, Tuple8< String, String, String, String, String, Integer, Integer,String>> {
 
    private List<String> ops;
 
@@ -51,7 +51,7 @@ public class EndpointTrendsCounter extends RichFlatMapFunction<EndpointTrends, T
      * @throws Exception
      */
     @Override
-    public void flatMap(EndpointTrends t, Collector<  Tuple7< String, String, String, String, String, Integer, Integer>> out) throws Exception {
+    public void flatMap(EndpointTrends t, Collector<  Tuple8< String, String, String, String, String, Integer, Integer,String>> out) throws Exception {
 
         int criticalstatus = this.opsMgr.getIntStatus("CRITICAL");
         int warningstatus = this.opsMgr.getIntStatus("WARNING");
@@ -64,17 +64,20 @@ public class EndpointTrendsCounter extends RichFlatMapFunction<EndpointTrends, T
         int[] unknownstatusInfo = timelineIntegrator.countStatusAppearances(timeline.getSamples(), unknownstatus);
 
 
-        Tuple7< String, String, String, String, String, Integer, Integer> tupleCritical = new Tuple7<  String, String, String, String, String, Integer, Integer>(
-                t.getGroup(), t.getService(), t.getEndpoint(), null, "CRITICAL", criticalstatusInfo[0], criticalstatusInfo[1]);
+        Tuple8< String, String, String, String, String, Integer, Integer, String> tupleCritical = new Tuple8<  String, String, String, String, String, Integer, Integer, String>(
+                t.getGroup(), t.getService(), t.getEndpoint(), null, "CRITICAL", criticalstatusInfo[0], criticalstatusInfo[1],"");
+
         out.collect(tupleCritical);
 
-        Tuple7<  String, String, String, String, String, Integer, Integer> tupleWarning = new Tuple7< String, String, String, String, String, Integer, Integer>(
-                t.getGroup(), t.getService(), t.getEndpoint(), null, "WARNING", warningstatusInfo[0], warningstatusInfo[1]);
+        Tuple8<  String, String, String, String, String, Integer, Integer, String> tupleWarning = new Tuple8< String, String, String, String, String, Integer, Integer, String>(
+                t.getGroup(), t.getService(), t.getEndpoint(), null, "WARNING", warningstatusInfo[0], warningstatusInfo[1],"");
 
         out.collect(tupleWarning);
 
-        Tuple7<  String, String, String, String, String, Integer, Integer> tupleUnknown = new Tuple7<  String, String, String, String, String, Integer, Integer>(
-                t.getGroup(), t.getService(), t.getEndpoint(), null, "UNKNOWN", unknownstatusInfo[0], unknownstatusInfo[1]);
+        Tuple8<  String, String, String, String, String, Integer, Integer, String> tupleUnknown = new Tuple8<  String, String, String, String, String, Integer, Integer, String>(
+                t.getGroup(), t.getService(), t.getEndpoint(), null, "UNKNOWN", unknownstatusInfo[0], unknownstatusInfo[1],"");
+
+
         out.collect(tupleUnknown);
 
     }

--- a/flink_jobs_v2/batch_status/src/main/java/trends/GroupTrendsCounter.java
+++ b/flink_jobs_v2/batch_status/src/main/java/trends/GroupTrendsCounter.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.util.List;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.java.tuple.Tuple7;
+import org.apache.flink.api.java.tuple.Tuple8;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Collector;
 import profilesmanager.OperationsManager;
@@ -24,7 +25,7 @@ import timelines.TimelineIntegrator;
  * appearances of the status CRITICAL, WARNING,UNKNOWN and produces a dataset of
  * tuples that contain these calculations
  */
-public class  GroupTrendsCounter extends RichFlatMapFunction<GroupTrends, Tuple7< String, String, String, String, String, Integer, Integer>> {
+public class  GroupTrendsCounter extends RichFlatMapFunction<GroupTrends, Tuple8< String, String, String, String, String, Integer, Integer,String>> {
 
    private List<String> ops;
 
@@ -52,7 +53,7 @@ public class  GroupTrendsCounter extends RichFlatMapFunction<GroupTrends, Tuple7
      * @throws Exception
      */
     @Override
-    public void flatMap(GroupTrends t, Collector<  Tuple7< String, String, String, String, String, Integer, Integer>> out) throws Exception {
+    public void flatMap(GroupTrends t, Collector< Tuple8< String, String, String, String, String, Integer, Integer,String>> out) throws Exception {
 
 
         int criticalstatus = this.opsMgr.getIntStatus("CRITICAL");
@@ -66,17 +67,18 @@ public class  GroupTrendsCounter extends RichFlatMapFunction<GroupTrends, Tuple7
         int[] unknownstatusInfo = timelineIntegrator.countStatusAppearances(timeline.getSamples(), unknownstatus);
 
 
-        Tuple7< String, String, String, String, String, Integer, Integer> tupleCritical = new Tuple7<  String, String, String, String, String, Integer, Integer>(
-                t.getGroup(), null, null, null, "CRITICAL", criticalstatusInfo[0], criticalstatusInfo[1]);
+        Tuple8< String, String, String, String, String, Integer, Integer,String> tupleCritical = new Tuple8< String, String, String, String, String, Integer, Integer,String>(
+                t.getGroup(), null, null, null, "CRITICAL", criticalstatusInfo[0], criticalstatusInfo[1],"");
         out.collect(tupleCritical);
 
-        Tuple7<  String, String, String, String, String, Integer, Integer> tupleWarning = new Tuple7< String, String, String, String, String, Integer, Integer>(
-                t.getGroup(), null, null, null, "WARNING", warningstatusInfo[0], warningstatusInfo[1]);
+       Tuple8< String, String, String, String, String, Integer, Integer,String> tupleWarning = new Tuple8< String, String, String, String, String, Integer, Integer,String>(
+                t.getGroup(), null, null, null, "WARNING", warningstatusInfo[0], warningstatusInfo[1],"");
+
 
         out.collect(tupleWarning);
 
-        Tuple7<  String, String, String, String, String, Integer, Integer> tupleUnknown = new Tuple7<  String, String, String, String, String, Integer, Integer>(
-                t.getGroup(), null, null, null, "UNKNOWN", unknownstatusInfo[0], unknownstatusInfo[1]);
+        Tuple8< String, String, String, String, String, Integer, Integer,String> tupleUnknown = new Tuple8< String, String, String, String, String, Integer, Integer,String>(
+                t.getGroup(), null, null, null, "UNKNOWN", unknownstatusInfo[0], unknownstatusInfo[1],"");
         out.collect(tupleUnknown);
 
     }

--- a/flink_jobs_v2/batch_status/src/main/java/trends/MetricTrendsCounter.java
+++ b/flink_jobs_v2/batch_status/src/main/java/trends/MetricTrendsCounter.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.util.List;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.java.tuple.Tuple7;
+import org.apache.flink.api.java.tuple.Tuple8;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Collector;
 import profilesmanager.OperationsManager;
@@ -21,7 +22,7 @@ import timelines.TimelineIntegrator;
  * appearances of the status CRITICAL, WARNING,UNKNOWN and produces a dataset of
  * tuples that contain these calculations
  */
-public class MetricTrendsCounter extends RichFlatMapFunction<MetricTrends, Tuple7<String, String, String, String, String, Integer, Integer>> {
+public class MetricTrendsCounter extends RichFlatMapFunction<MetricTrends, Tuple8<String, String, String, String, String, Integer, Integer,String>> {
 
     private List<String> ops;
 
@@ -49,7 +50,7 @@ public class MetricTrendsCounter extends RichFlatMapFunction<MetricTrends, Tuple
      * @throws Exception
      */
     @Override
-    public void flatMap(MetricTrends t, Collector<Tuple7<String, String, String, String, String, Integer, Integer>> out) throws Exception {
+    public void flatMap(MetricTrends t, Collector<Tuple8<String, String, String, String, String, Integer, Integer,String>> out) throws Exception {
         int criticalstatus = this.opsMgr.getIntStatus("CRITICAL");
         int warningstatus = this.opsMgr.getIntStatus("WARNING");
         int unknownstatus = this.opsMgr.getIntStatus("UNKNOWN");
@@ -60,16 +61,16 @@ public class MetricTrendsCounter extends RichFlatMapFunction<MetricTrends, Tuple
         int[] warningstatusInfo = timelineIntegrator.countStatusAppearances(timeline.getSamples(), warningstatus);
         int[] unknownstatusInfo = timelineIntegrator.countStatusAppearances(timeline.getSamples(), unknownstatus);
 
-        Tuple7< String, String, String, String, String, Integer, Integer> tupleCritical = new Tuple7<  String, String, String, String, String, Integer, Integer>(
-                t.getGroup(), t.getService(), t.getEndpoint(), t.getMetric(), "CRITICAL", criticalstatusInfo[0], criticalstatusInfo[1]);
+        Tuple8<String, String, String, String, String, Integer, Integer,String> tupleCritical = new Tuple8<  String, String, String, String, String, Integer, Integer,String>(
+                t.getGroup(), t.getService(), t.getEndpoint(), t.getMetric(), "CRITICAL", criticalstatusInfo[0], criticalstatusInfo[1],t.getTags());
         out.collect(tupleCritical);
 
-        Tuple7<  String, String, String, String, String, Integer, Integer> tupleWarning = new Tuple7< String, String, String, String, String, Integer, Integer>(
-                t.getGroup(), t.getService(), t.getEndpoint(), t.getMetric(), "WARNING", warningstatusInfo[0], warningstatusInfo[1]);
+        Tuple8<String, String, String, String, String, Integer, Integer,String> tupleWarning = new Tuple8< String, String, String, String, String, Integer, Integer,String>(
+                t.getGroup(), t.getService(), t.getEndpoint(), t.getMetric(), "WARNING", warningstatusInfo[0], warningstatusInfo[1],t.getTags());
         out.collect(tupleWarning);
 
-        Tuple7<  String, String, String, String, String, Integer, Integer> tupleUnknown = new Tuple7<  String, String, String, String, String, Integer, Integer>(
-                t.getGroup(), t.getService(), t.getEndpoint(), t.getMetric(), "UNKNOWN", unknownstatusInfo[0], unknownstatusInfo[1]);
+        Tuple8<String, String, String, String, String, Integer, Integer,String> tupleUnknown = new Tuple8<  String, String, String, String, String, Integer, Integer,String>(
+                t.getGroup(), t.getService(), t.getEndpoint(), t.getMetric(), "UNKNOWN", unknownstatusInfo[0], unknownstatusInfo[1],t.getTags());
         out.collect(tupleUnknown);
     }
 }

--- a/flink_jobs_v2/batch_status/src/main/java/trends/ServiceTrendsCounter.java
+++ b/flink_jobs_v2/batch_status/src/main/java/trends/ServiceTrendsCounter.java
@@ -6,8 +6,11 @@ import argo.batch.StatusMetricTimeline;
 import flipflops.ServiceTrends;
 import java.io.IOException;
 import java.util.List;
+
+import flipflops.ServiceTrends;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.java.tuple.Tuple7;
+import org.apache.flink.api.java.tuple.Tuple8;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Collector;
 import profilesmanager.OperationsManager;
@@ -25,7 +28,7 @@ import timelines.TimelineIntegrator;
  * appearances of the status CRITICAL, WARNING,UNKNOWN and produces a dataset of
  * tuples that contain these calculations
  */
-public class  ServiceTrendsCounter extends RichFlatMapFunction<ServiceTrends, Tuple7< String, String, String, String, String, Integer, Integer>> {
+public class  ServiceTrendsCounter extends RichFlatMapFunction<ServiceTrends, Tuple8< String, String, String, String, String, Integer, Integer,String>> {
 
     private List<String> ops;
 
@@ -53,7 +56,7 @@ public class  ServiceTrendsCounter extends RichFlatMapFunction<ServiceTrends, Tu
      * @throws Exception
      */
     @Override
-    public void flatMap(ServiceTrends t, Collector< Tuple7< String, String, String, String, String, Integer, Integer>> out) throws Exception {
+    public void flatMap(ServiceTrends t, Collector<Tuple8< String, String, String, String, String, Integer, Integer,String>> out) throws Exception {
 
         int criticalstatus = this.opsMgr.getIntStatus("CRITICAL");
         int warningstatus = this.opsMgr.getIntStatus("WARNING");
@@ -67,17 +70,17 @@ public class  ServiceTrendsCounter extends RichFlatMapFunction<ServiceTrends, Tu
         int[] unknownstatusInfo = timelineIntegrator.countStatusAppearances(timeline.getSamples(), unknownstatus);
 
      
-        Tuple7< String, String, String, String, String, Integer, Integer> tupleCritical = new Tuple7<  String, String, String, String, String, Integer, Integer>(
-                t.getGroup(), t.getService(), null, null, "CRITICAL", criticalstatusInfo[0], criticalstatusInfo[1]);
+        Tuple8< String, String, String, String, String, Integer, Integer,String> tupleCritical = new Tuple8< String, String, String, String, String, Integer, Integer,String>(
+                t.getGroup(), t.getService(), null, null, "CRITICAL", criticalstatusInfo[0], criticalstatusInfo[1],"");
         out.collect(tupleCritical);
 
-        Tuple7<  String, String, String, String, String, Integer, Integer> tupleWarning = new Tuple7< String, String, String, String, String, Integer, Integer>(
-                t.getGroup(), t.getService(), null, null, "WARNING", warningstatusInfo[0], warningstatusInfo[1]);
+        Tuple8< String, String, String, String, String, Integer, Integer,String> tupleWarning = new Tuple8< String, String, String, String, String, Integer, Integer,String>(
+                t.getGroup(), t.getService(), null, null, "WARNING", warningstatusInfo[0], warningstatusInfo[1],"");
 
         out.collect(tupleWarning);
 
-        Tuple7<  String, String, String, String, String, Integer, Integer> tupleUnknown = new Tuple7<  String, String, String, String, String, Integer, Integer>(
-                t.getGroup(), t.getService(), null, null, "UNKNOWN", unknownstatusInfo[0], unknownstatusInfo[1]);
+      Tuple8< String, String, String, String, String, Integer, Integer,String> tupleUnknown = new Tuple8< String, String, String, String, String, Integer, Integer,String>(
+                t.getGroup(), t.getService(), null, null, "UNKNOWN", unknownstatusInfo[0], unknownstatusInfo[1],"");
         out.collect(tupleUnknown);
     }
 }


### PR DESCRIPTION
StatusMetric data are enriched with tags for each metric as they are defined in the argo-web-api. Enrichment take place at MapServices class. Mongo db output for metric levels are changed to include also the tags 