### PR TITLE
ARGO-3480 Fix has_threshold_rule to output boolean value in mongo instead of string

### DIFF
--- a/flink_jobs_v2/batch_status/src/main/java/argo/batch/MongoStatusOutput.java
+++ b/flink_jobs_v2/batch_status/src/main/java/argo/batch/MongoStatusOutput.java
@@ -100,11 +100,7 @@ public class MongoStatusOutput implements OutputFormat<StatusMetric> {
 	 * Service or Endpoint Group ones.       
 	 */
 	private Document prepDoc(StatusMetric record) {
-	
-	           String hasThr = "NO";
-            if (record.getHasThr()) {
-                hasThr = "YES";
-            }    
+	 
 		Document doc = new Document("report",this.report)
 				.append("endpoint_group", record.getGroup());
 				
@@ -155,7 +151,7 @@ public class MongoStatusOutput implements OutputFormat<StatusMetric> {
 		doc.append("status",record.getStatus())
 				.append("timestamp",record.getTimestamp())
 				.append("date_integer",record.getDateInt())
-		                .append("has_threshold_rule", hasThr);
+		                .append("has_threshold_rule", record.getHasThr());
 		return doc;
 	}
 	


### PR DESCRIPTION
Fixed has_threshold_rule field in mongo output to be boolean instead of string . Change at MongoStatusOutput class