### PR TITLE
ARGO-3512 Fill timeline with EXCLUDED status for excluded metric , for a specific period

### DIFF
--- a/flink_jobs_v2/batch_status/src/main/java/argo/batch/CalcPrevStatus.java
+++ b/flink_jobs_v2/batch_status/src/main/java/argo/batch/CalcPrevStatus.java
@@ -14,39 +14,56 @@ import argo.avro.GroupEndpoint;
 import argo.avro.GroupGroup;
 
 import argo.avro.MetricProfile;
+import java.io.IOException;
+import java.text.ParseException;
+import org.joda.time.DateTime;
 import profilesmanager.MetricProfileManager;
+import profilesmanager.OperationsManager;
+import profilesmanager.RecomputationsManager;
+import utils.Utils;
 
 public class CalcPrevStatus extends RichGroupReduceFunction<StatusMetric, StatusMetric> {
-
+    
     private static final long serialVersionUID = 1L;
-
+    
     final ParameterTool params;
-
+    
     public CalcPrevStatus(ParameterTool params) {
         this.params = params;
     }
-
+    
     static Logger LOG = LoggerFactory.getLogger(ArgoStatusBatch.class);
-
+    
     private List<MetricProfile> mps;
     private List<GroupEndpoint> egp;
     private List<GroupGroup> ggp;
     private MetricProfileManager mpsMgr;
     private String runDate;
-
+    private List<String> rec;
+    private RecomputationsManager recMgr;
+    private List<String> ops;
+    private OperationsManager opsMgr;
+    
     @Override
-    public void open(Configuration parameters) {
+    public void open(Configuration parameters) throws IOException, ParseException {
         // Get data from broadcast variable
         this.runDate = params.getRequired("run.date");
-
+        
         this.mps = getRuntimeContext().getBroadcastVariable("mps");
+        this.rec = getRuntimeContext().getBroadcastVariable("rec");
+        this.ops = getRuntimeContext().getBroadcastVariable("ops");
+
         // Initialize metric profile manager
         this.mpsMgr = new MetricProfileManager();
         this.mpsMgr.loadFromList(mps);
         // Initialize endpoint group manager
-
+        this.recMgr = new RecomputationsManager();
+        this.recMgr.loadJsonString(rec);
+        this.opsMgr = new OperationsManager();
+        this.opsMgr.loadJsonString(ops);
+        
     }
-
+    
     @Override
     public void reduce(Iterable<StatusMetric> in, Collector<StatusMetric> out) throws Exception {
         // group input is sorted 
@@ -65,20 +82,29 @@ public class CalcPrevStatus extends RichGroupReduceFunction<StatusMetric, Status
                     continue;
                 }
             }
-
+            
             item.setPrevState(prevStatus);
             item.setPrevTs(prevTimestamp);
             if (item.getTimestamp().split("T")[0].compareToIgnoreCase(this.runDate) == 0) {
                 if (!item.getOgStatus().equals("")) {
                     item.setHasThr(true);
                 }
+                RecomputationsManager.ExcludedMetric excludedMetric = this.recMgr.findMetricExcluded(item.getGroup(), item.getService(), item.getHostname(), item.getMetric());
+                if (excludedMetric != null) {
+                    DateTime timestamp = Utils.convertStringtoDate("yyyy-MM-dd'T'HH:mm:ss'Z'", item.getTimestamp());
+                    DateTime startPeriod = Utils.convertStringtoDate("yyyy-MM-dd'T'HH:mm:ss'Z'", excludedMetric.getStartPeriod());
+                    DateTime endPeriod = Utils.convertStringtoDate("yyyy-MM-dd'T'HH:mm:ss'Z'", excludedMetric.getEndPeriod());
+                    if (!timestamp.isBefore(startPeriod) && !timestamp.isAfter(endPeriod)) {
+                        item.setStatus(this.opsMgr.getDefaultExcludedState());
+                    }
+                }
                 out.collect(item);
             }
-
+            
             prevStatus = item.getStatus();
             prevTimestamp = item.getTimestamp();
         }
-
+        
     }
-
+    
 }


### PR DESCRIPTION
Metrics defined in recomputations , replace their status as EXCLUDED for the specified period, into CalcPrevStatus class.
