### PR TITLE
ARGO-3563 Fix cli args

### DIFF
--- a/flink_jobs/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
+++ b/flink_jobs/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
@@ -169,7 +169,7 @@ public class AmsStreamStatus {
 	
 		String apiEndpoint = parameterTool.getRequired("api.endpoint");
 		String apiToken = parameterTool.getRequired("api.token");
-		String reportID = parameterTool.getRequired("report.id");
+		String reportID = parameterTool.getRequired("report.uuid");
 		int apiInterval = parameterTool.getInt("api.interval");
 		
 		ApiResourceManager amr = new ApiResourceManager(apiEndpoint,apiToken);
@@ -324,8 +324,8 @@ public class AmsStreamStatus {
 			amr.getRemoteAll();
 			
 
-			ArrayList<MetricProfile> mpsList = (ArrayList<MetricProfile>) (Arrays.asList(amr.getListMetrics()));
-			ArrayList<GroupEndpoint> egpList = (ArrayList<GroupEndpoint>) (Arrays.asList(amr.getListGroupEndpoints()));
+			ArrayList<MetricProfile> mpsList = new ArrayList<MetricProfile>(Arrays.asList(amr.getListMetrics()));
+			ArrayList<GroupEndpoint> egpList = new ArrayList<GroupEndpoint>(Arrays.asList(amr.getListGroupEndpoints()));
 
 			mps = new MetricProfileManager();
 			mps.loadFromList(mpsList);
@@ -487,9 +487,9 @@ public class AmsStreamStatus {
 			
 			String opsJSON = amr.getResourceJSON(ApiResource.OPS);
 			String apsJSON = amr.getResourceJSON(ApiResource.AGGREGATION);
-			ArrayList<Downtime> downList = (ArrayList<Downtime>)(Arrays.asList(amr.getListDowntimes()));
-			ArrayList<MetricProfile> mpsList = (ArrayList<MetricProfile>)(Arrays.asList(amr.getListMetrics()));
-			ArrayList<GroupEndpoint> egpListFull = (ArrayList<GroupEndpoint>)(Arrays.asList(amr.getListGroupEndpoints()));
+			ArrayList<Downtime> downList = new ArrayList<Downtime>(Arrays.asList(amr.getListDowntimes()));
+			ArrayList<MetricProfile> mpsList = new ArrayList<MetricProfile>(Arrays.asList(amr.getListMetrics()));
+			ArrayList<GroupEndpoint> egpListFull = new ArrayList<GroupEndpoint>(Arrays.asList(amr.getListGroupEndpoints()));
 			
 			// create a new status manager
 			sm = new StatusManager();

--- a/flink_jobs/stream_status/src/main/java/argo/streaming/StatusConfig.java
+++ b/flink_jobs/stream_status/src/main/java/argo/streaming/StatusConfig.java
@@ -57,12 +57,8 @@ public class StatusConfig implements Serializable {
 	   this.apiEndpoint = pt.getRequired("api.endpoint");
 	   
 	   
-	   this.aps = pt.getRequired("sync.apr");
-	   this.mps = pt.getRequired("sync.mps");
-	   this.egp = pt.getRequired("sync.egp");
-	   this.ops = pt.getRequired("sync.ops");
+
 	   this.runDate = pt.getRequired("run.date");
-	   this.downtime = pt.getRequired("sync.downtime");
 	   this.report = pt.getRequired("report");
 	   // Optional timeout parameter
 	   if (pt.has("timeout")){
@@ -82,8 +78,8 @@ public class StatusConfig implements Serializable {
 	   // Optional set daily parameter
 	   
 	   this.apiEndpoint = pt.getRequired("api.endpoint");
-	   this.apiToken = pt.getRequired("apiToken");
-	   this.reportID = pt.getRequired("reportID");
+	   this.apiToken = pt.getRequired("api.token");
+	   this.reportID = pt.getRequired("report.uuid");
 	   
 	   if (pt.has("api.proxy")) this.apiProxy = pt.get("api.proxy","");
 	   if (pt.has("api.verify")) this.apiVerify = pt.getBoolean("api.verify",false);


### PR DESCRIPTION
Fixes:
- Remove unnecessary cli arguments that shouldn't be required anymore
- Fix some cli arguments to be consistent with same arguments in batch jobs
- Fix ArrayList initialisation with sync-data from api (at the beginning of pipeline)