### PR TITLE
ARGO-3584 Add api timeout configuration in status streaming job

### DIFF
--- a/flink_jobs/stream_status/src/main/java/argo/amr/ApiResourceManager.java
+++ b/flink_jobs/stream_status/src/main/java/argo/amr/ApiResourceManager.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -12,7 +11,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.net.ssl.SSLContext;
 
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.fluent.Executor;
@@ -59,6 +57,7 @@ public class ApiResourceManager {
 	private String reportName;
 	private String weightsID;
 	private boolean verify;
+	private int timeoutSec;
 
 
 	public ApiResourceManager(String endpoint, String token) {
@@ -74,8 +73,18 @@ public class ApiResourceManager {
 		this.proxy = "";
 		this.weightsID = "";
 		this.verify = true;
+		this.timeoutSec = 30; // Timeout limit when contacting argo-web-api
 
 	}
+	
+	public int getTimeoutSec() {
+		return timeoutSec;
+	}
+	
+	public void setTimeoutSec(int timeoutSec) {
+		this.timeoutSec = timeoutSec;
+	}
+	
 	
 	public boolean getVerify() {
 		return verify;
@@ -186,7 +195,7 @@ public class ApiResourceManager {
 			r = r.viaProxy(proxy);
 		}
 		
-		r = r.connectTimeout(1000).socketTimeout(1000);
+		r = r.connectTimeout(this.timeoutSec * 1000).socketTimeout(this.timeoutSec * 1000);
 		
 		String content = "{}";
 		
@@ -195,6 +204,7 @@ public class ApiResourceManager {
 				CloseableHttpClient httpClient = HttpClients.custom().setSSLSocketFactory(selfSignedSSLF()).build();
 				Executor executor = Executor.newInstance(httpClient);
 				content = executor.execute(r).returnContent().asString();
+				httpClient.close();
 			} else {
 				
 				content = r.execute().returnContent().asString();

--- a/flink_jobs/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
+++ b/flink_jobs/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
@@ -181,6 +181,10 @@ public class AmsStreamStatus {
 			amr.setProxy(parameterTool.get("api.proxy"));
 		}
 		
+		if (parameterTool.has("api.timeout")) {
+			amr.setTimeoutSec(parameterTool.getInt("api.timeout"));
+		}
+		
 		amr.setReportID(reportID);
 		amr.getRemoteAll();
 		


### PR DESCRIPTION
### Issue
Streaming status job failed due to timeouts when trying to retrieve topology info from argo-web-api. This was observed in tenants with large topology data. 

### Fix
- [x] As already implemented in batch jobs, add timeout configuration parameters to ApiResourceManager class. Add a default of 5 second timeout 