### PR TITLE
ARGO-3600 Fix bug in Timelines to include DOWNTIME periods when calculated

### DIFF
--- a/flink_jobs_v2/Timelines/src/main/java/timelines/Timeline.java
+++ b/flink_jobs_v2/Timelines/src/main/java/timelines/Timeline.java
@@ -431,7 +431,7 @@ public class Timeline {
 
         DateTime firsTime = date;
         firsTime = firsTime.withTime(0, 0, 0, 0);
-        DateTime firstEntry = this.samples.lowerKey(firsTime);
+        DateTime firstEntry = this.samples.floorKey(firsTime);
         if (this.date.isBefore(firsTime.toLocalDate())) {
 
             this.date = firsTime.toLocalDate();
@@ -557,4 +557,22 @@ public class Timeline {
         this.excludedInt = excludedInt;
     }
 
+    public void setDate(LocalDate date) {
+        this.date = date;
+    }
+
+    public void setDateStr(String date) {
+        this.date = getLocalDate(date);
+         
+    }
+
+    private LocalDate getLocalDate(String date) {
+        DateTime tmp_date = new DateTime();
+        DateTimeFormatter fmt = DateTimeFormat.forPattern("yyyy-MM-dd");
+        tmp_date = fmt.parseDateTime(date);
+        tmp_date.withTime(0, 0, 0, 0);
+        LocalDate localdate = tmp_date.toLocalDate();
+        return localdate;
+
+    }
 }

--- a/flink_jobs_v2/Timelines/src/main/java/timelines/TimelineAggregator.java
+++ b/flink_jobs_v2/Timelines/src/main/java/timelines/TimelineAggregator.java
@@ -21,7 +21,8 @@ public class TimelineAggregator {
 
     private Timeline output;
     private Map<String, Timeline> inputs;
-    private int excludedInt=-1;
+    private int excludedInt = -1;
+    private LocalDate date;
 
     /**
      *
@@ -31,6 +32,17 @@ public class TimelineAggregator {
     public TimelineAggregator(String timestamp) throws ParseException {
         this.output = new Timeline(timestamp);
         this.inputs = new HashMap<String, Timeline>();
+
+    }
+
+    private LocalDate getLocalDate(String date) {
+        DateTime tmp_date = new DateTime();
+        DateTimeFormatter fmt = DateTimeFormat.forPattern("yyyy-MM-dd");
+        tmp_date = fmt.parseDateTime(date);
+        tmp_date.withTime(0, 0, 0, 0);
+        LocalDate localdate = tmp_date.toLocalDate();
+        return localdate;
+
     }
 
     /**
@@ -38,6 +50,7 @@ public class TimelineAggregator {
      */
     public TimelineAggregator() {
         this.output = new Timeline();
+        this.output.setDate(this.date);
         this.inputs = new HashMap<String, Timeline>();
 
     }
@@ -55,13 +68,15 @@ public class TimelineAggregator {
     /**
      *
      * @param inputs, a map of timelines Constructs a TimelineAggregator object,
-     * @param excludedInt , the int value of the excludedStatus
-     * containing the timelines
+     * @param excludedInt , the int value of the excludedStatus containing the
+     * timelines
      */
-    public TimelineAggregator(Map<String, Timeline> inputs, int excludedInt) {
+    public TimelineAggregator(Map<String, Timeline> inputs, int excludedInt, String rundate) {
         this.inputs = inputs;
         this.output = new Timeline();
-        this.excludedInt=excludedInt;
+        this.date=getLocalDate(rundate);
+        this.output.setDate(this.date);
+        this.excludedInt = excludedInt;
         this.output.setExcludedInt(excludedInt);
     }
 
@@ -100,6 +115,7 @@ public class TimelineAggregator {
     public void createTimeline(String name, String timestamp, int prevState) {
         Timeline temp = new Timeline(timestamp, prevState);
         this.inputs.put(name, temp);
+
     }
 
     /**
@@ -206,4 +222,12 @@ public class TimelineAggregator {
         this.excludedInt = excludedInt;
     }
 
+    public void setDate(LocalDate date) {
+        this.date = date;
+    }
+
+    public void setDateStr(String date) {
+
+        this.date = this.getLocalDate(date);
+    }
 }

--- a/flink_jobs_v2/Timelines/src/test/java/timelines/TimelineAggregatorTest.java
+++ b/flink_jobs_v2/Timelines/src/test/java/timelines/TimelineAggregatorTest.java
@@ -184,7 +184,7 @@ public class TimelineAggregatorTest {
         map.put(name, new Timeline(timestamp));
         map.put(name2, new Timeline(timestamp2));
 
-        TimelineAggregator instance = new TimelineAggregator(map, 6);
+        TimelineAggregator instance = new TimelineAggregator(map, 6, "2021-01-31");
         instance.aggregate(createTruthTable(), 0);
         TreeMap<DateTime, Integer> expRes = new TreeMap<>();
         Timeline exptimeline = new Timeline();

--- a/flink_jobs_v2/Timelines/src/test/java/timelines/TimelineTest.java
+++ b/flink_jobs_v2/Timelines/src/test/java/timelines/TimelineTest.java
@@ -294,7 +294,7 @@ public class TimelineTest {
         int op = 0;
         Timeline instance = new Timeline();
         instance.setExcludedInt(6);
-        instance.aggregate(second, truthTable, op );
+        instance.aggregate(second, truthTable, op);
         Set<Map.Entry<DateTime, Integer>> expResult = createMerged().entrySet();
         Set<Map.Entry<DateTime, Integer>> result = instance.getSamples();
         assertEquals(expResult, result);
@@ -326,13 +326,13 @@ public class TimelineTest {
         DateTime date = Utils.createDate("yyyy-MM-dd'T'HH:mm:ss'Z'", 2021, 0, 15, 0, 0, 0);
         Timeline instance = new Timeline();
         instance.insertDateTimeStamps(createTimestampList(), true);
-          HashMap<String,Integer> availStates = new HashMap<>();
-        availStates.put("OK",0);
-        availStates.put("WARNING",1);
-        availStates.put("UKNOWN",2);
-        availStates.put("MISSING",3);
-        availStates.put("CRITICAL",4);
-        availStates.put("DOWNTIME",5);
+        HashMap<String, Integer> availStates = new HashMap<>();
+        availStates.put("OK", 0);
+        availStates.put("WARNING", 1);
+        availStates.put("UKNOWN", 2);
+        availStates.put("MISSING", 3);
+        availStates.put("CRITICAL", 4);
+        availStates.put("DOWNTIME", 5);
 
         instance.replacePreviousDateStatus(date, availStates, true);
         // TODO review the generated test code and remove the default call to fail.
@@ -402,7 +402,7 @@ public class TimelineTest {
         periods.add(period4);
         periods.add(period5);
         for (String[] period : periods) {
-            instance.fillWithStatus(period[0],period[1], 2);
+            instance.fillWithStatus(period[0], period[1], 2);
             instance.optimize();
         }
         TreeMap<DateTime, Integer> expResult = createUnknownTimeline();
@@ -444,7 +444,7 @@ public class TimelineTest {
         instance = new Timeline();
         instance.insertDateTimeStamps(createTimestampList2(), true);
         for (String[] period : periods) {
-            instance.fillWithStatus(period[0],period[1], 2);
+            instance.fillWithStatus(period[0], period[1], 2);
             instance.optimize();
         }
 
@@ -487,7 +487,7 @@ public class TimelineTest {
         instance = new Timeline();
         instance.insertDateTimeStamps(createTimestampList2(), true);
         for (String[] period : periods) {
-           instance.fillWithStatus(period[0],period[1], 2);
+            instance.fillWithStatus(period[0], period[1], 2);
             instance.optimize();
         }
         expResult = createUnknownTimeline3();
@@ -505,7 +505,7 @@ public class TimelineTest {
         instance.insertDateTimeStamps(createTimestampList2(), true);
 
         for (String[] period : periods) {
-             instance.fillWithStatus(period[0],period[1], 2);
+            instance.fillWithStatus(period[0], period[1], 2);
             instance.optimize();
         }
         expResult = createUnknownTimeline4();
@@ -548,7 +548,7 @@ public class TimelineTest {
         instance.insertDateTimeStamps(createTimestampList4(), true);
 
         for (String[] period : periods) {
-            instance.fillWithStatus(period[0],period[1], 2);
+            instance.fillWithStatus(period[0], period[1], 2);
             instance.optimize();
         }
         expResult = createUnknownTimeline5();
@@ -642,6 +642,7 @@ public class TimelineTest {
         return map;
 //
     }
+
     private TreeMap<DateTime, Integer> createTimestampList4() throws ParseException {
         TreeMap<DateTime, Integer> map = new TreeMap<>();
         map.put(Utils.createDate("yyyy-MM-dd'T'HH:mm:ss'Z'", 2021, 0, 15, 0, 0, 0), 3);
@@ -655,6 +656,7 @@ public class TimelineTest {
         return map;
 //
     }
+
     private TreeMap<DateTime, Integer> createTimestampList() throws ParseException {
         TreeMap<DateTime, Integer> map = new TreeMap<>();
 

--- a/flink_jobs_v2/batch_status/src/main/java/argo/ar/CalcGroupAR.java
+++ b/flink_jobs_v2/batch_status/src/main/java/argo/ar/CalcGroupAR.java
@@ -10,7 +10,6 @@ import org.apache.flink.util.Collector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import argo.avro.Downtime;
 import argo.avro.GroupEndpoint;
 import argo.avro.GroupGroup;
 
@@ -28,7 +27,6 @@ import java.util.TreeMap;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.joda.time.DateTime;
 import profilesmanager.AggregationProfileManager;
-import profilesmanager.DowntimeManager;
 import profilesmanager.EndpointGroupManager;
 import profilesmanager.GroupGroupManager;
 import profilesmanager.MetricProfileManager;
@@ -60,13 +58,11 @@ public class CalcGroupAR extends RichFlatMapFunction<StatusTimeline, EndpointGro
     private List<String> ops;
     private List<GroupEndpoint> egp;
     private List<GroupGroup> ggp;
-    private List<Downtime> downtime;
     private MetricProfileManager mpsMgr;
     private AggregationProfileManager apsMgr;
     private EndpointGroupManager egpMgr;
     private GroupGroupManager ggpMgr;
     private OperationsManager opsMgr;
-    private DowntimeManager downtimeMgr;
     private ReportManager repMgr;
     private String runDate;
     //   private WeightManager weightMgr;
@@ -94,7 +90,6 @@ public class CalcGroupAR extends RichFlatMapFunction<StatusTimeline, EndpointGro
         this.ops = getRuntimeContext().getBroadcastVariable("ops");
         this.egp = getRuntimeContext().getBroadcastVariable("egp");
         this.ggp = getRuntimeContext().getBroadcastVariable("ggp");
-        this.downtime = getRuntimeContext().getBroadcastVariable("down");
         this.conf = getRuntimeContext().getBroadcastVariable("conf");
         // Initialize metric profile manager
         this.mpsMgr = new MetricProfileManager();
@@ -115,8 +110,6 @@ public class CalcGroupAR extends RichFlatMapFunction<StatusTimeline, EndpointGro
         this.ggpMgr.loadFromList(ggp);
 
         // Initialize downtime manager
-        this.downtimeMgr = new DowntimeManager();
-        this.downtimeMgr.loadFromList(downtime);
         this.repMgr = new ReportManager();
         this.repMgr.loadJsonString(conf);
 

--- a/flink_jobs_v2/batch_status/src/main/java/argo/ar/CalcServiceAR.java
+++ b/flink_jobs_v2/batch_status/src/main/java/argo/ar/CalcServiceAR.java
@@ -10,7 +10,6 @@ import org.apache.flink.util.Collector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import argo.avro.Downtime;
 import argo.avro.GroupEndpoint;
 import argo.avro.GroupGroup;
 
@@ -25,7 +24,6 @@ import java.util.TreeMap;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.joda.time.DateTime;
 import profilesmanager.AggregationProfileManager;
-import profilesmanager.DowntimeManager;
 import profilesmanager.EndpointGroupManager;
 import profilesmanager.GroupGroupManager;
 import profilesmanager.MetricProfileManager;
@@ -56,13 +54,11 @@ public class CalcServiceAR extends RichFlatMapFunction<StatusTimeline, ServiceAR
     private List<String> ops;
     private List<GroupEndpoint> egp;
     private List<GroupGroup> ggp;
-    private List<Downtime> downtime;
     private MetricProfileManager mpsMgr;
     private AggregationProfileManager apsMgr;
     private EndpointGroupManager egpMgr;
     private GroupGroupManager ggpMgr;
     private OperationsManager opsMgr;
-    private DowntimeManager downtimeMgr;
     private ReportManager repMgr;
     private String runDate;
 
@@ -84,7 +80,6 @@ public class CalcServiceAR extends RichFlatMapFunction<StatusTimeline, ServiceAR
         this.ops = getRuntimeContext().getBroadcastVariable("ops");
         this.egp = getRuntimeContext().getBroadcastVariable("egp");
         this.ggp = getRuntimeContext().getBroadcastVariable("ggp");
-        this.downtime = getRuntimeContext().getBroadcastVariable("down");
         this.conf = getRuntimeContext().getBroadcastVariable("conf");
         // Initialize metric profile manager
         this.mpsMgr = new MetricProfileManager();
@@ -103,10 +98,6 @@ public class CalcServiceAR extends RichFlatMapFunction<StatusTimeline, ServiceAR
 
         this.ggpMgr = new GroupGroupManager();
         this.ggpMgr.loadFromList(ggp);
-
-        // Initialize downtime manager
-        this.downtimeMgr = new DowntimeManager();
-        this.downtimeMgr.loadFromList(downtime);
         this.repMgr = new ReportManager();
         this.repMgr.loadJsonString(conf);
 

--- a/flink_jobs_v2/batch_status/src/main/java/argo/batch/ArgoStatusBatch.java
+++ b/flink_jobs_v2/batch_status/src/main/java/argo/batch/ArgoStatusBatch.java
@@ -258,7 +258,7 @@ public class ArgoStatusBatch {
         DataSet<StatusTimeline> statusEndpointTimeline = statusMetricTimeline.groupBy("group", "service", "hostname")
                 .reduceGroup(new CalcEndpointTimeline(params)).withBroadcastSet(mpsDS, "mps").withBroadcastSet(opsDS, "ops")
                 .withBroadcastSet(egpDS, "egp").withBroadcastSet(ggpDS, "ggp")
-                .withBroadcastSet(apsDS, "aps");
+                .withBroadcastSet(apsDS, "aps").withBroadcastSet(downDS, "down");
 
         DataSet<StatusTimeline> statusServiceTimeline = statusEndpointTimeline.groupBy("group", "service")
                 .reduceGroup(new CalcServiceTimeline(params)).withBroadcastSet(mpsDS, "mps").withBroadcastSet(opsDS, "ops")
@@ -310,17 +310,17 @@ public class ArgoStatusBatch {
             //Calculate endpoint a/r 
             DataSet<EndpointAR> endpointArDS = statusEndpointTimeline.flatMap(new CalcEndpointAR(params)).withBroadcastSet(mpsDS, "mps")
                     .withBroadcastSet(apsDS, "aps").withBroadcastSet(opsDS, "ops").withBroadcastSet(egpDS, "egp").
-                    withBroadcastSet(ggpDS, "ggp").withBroadcastSet(downDS, "down").withBroadcastSet(confDS, "conf");
+                    withBroadcastSet(ggpDS, "ggp").withBroadcastSet(confDS, "conf");
             //Calculate endpoint timeline timestamps 
 
             DataSet<ServiceAR> serviceArDS = statusServiceTimeline.flatMap(new CalcServiceAR(params)).withBroadcastSet(mpsDS, "mps")
                     .withBroadcastSet(apsDS, "aps").withBroadcastSet(opsDS, "ops").withBroadcastSet(egpDS, "egp").
-                    withBroadcastSet(ggpDS, "ggp").withBroadcastSet(downDS, "down").withBroadcastSet(confDS, "conf");
+                    withBroadcastSet(ggpDS, "ggp").withBroadcastSet(confDS, "conf");
 
             // DataSet<StatusTimeline> statusGroupTimelineAR = statusGroupTimeline.flatMap(new ExcludeGroupMetrics(params)).withBroadcastSet(recDS, "rec").withBroadcastSet(opsDS, "ops");
             DataSet<EndpointGroupAR> endpointGroupArDS = statusGroupTimeline.flatMap(new CalcGroupAR(params)).withBroadcastSet(mpsDS, "mps")
                     .withBroadcastSet(apsDS, "aps").withBroadcastSet(opsDS, "ops").withBroadcastSet(egpDS, "egp").
-                    withBroadcastSet(ggpDS, "ggp").withBroadcastSet(downDS, "down").withBroadcastSet(confDS, "conf").withBroadcastSet(weightDS, "weight").withBroadcastSet(recDS, "rec");
+                    withBroadcastSet(ggpDS, "ggp").withBroadcastSet(confDS, "conf").withBroadcastSet(weightDS, "weight").withBroadcastSet(recDS, "rec");
 
             MongoEndpointArOutput endpointARMongoOut = new MongoEndpointArOutput(dbURI, "endpoint_ar", dbMethod);
             MongoServiceArOutput serviceARMongoOut = new MongoServiceArOutput(dbURI, "service_ar", dbMethod);

--- a/flink_jobs_v2/batch_status/src/main/java/argo/batch/CalcGroupFunctionTimeline.java
+++ b/flink_jobs_v2/batch_status/src/main/java/argo/batch/CalcGroupFunctionTimeline.java
@@ -96,7 +96,7 @@ public class CalcGroupFunctionTimeline extends RichGroupReduceFunction<StatusTim
             }
         }
         String operation = functionOperations.get(function);  //for each function an operation exists , so retrieve the corresponding truth table
-        TimelineAggregator timelineAggregator = new TimelineAggregator(timelinelist,this.opsMgr.getDefaultExcludedInt());
+        TimelineAggregator timelineAggregator = new TimelineAggregator(timelinelist,this.opsMgr.getDefaultExcludedInt(), runDate);
         timelineAggregator.aggregate(this.opsMgr.getTruthTable(), this.opsMgr.getIntOperation(operation));
         
         Timeline mergedTimeline = timelineAggregator.getOutput(); //collect all timelines that correspond to the group service endpoint group , merge them in order to create one timeline

--- a/flink_jobs_v2/batch_status/src/main/java/argo/batch/CalcGroupTimeline.java
+++ b/flink_jobs_v2/batch_status/src/main/java/argo/batch/CalcGroupTimeline.java
@@ -90,7 +90,7 @@ public class CalcGroupTimeline extends RichGroupReduceFunction<StatusTimeline, S
         }
 
         String groupOperation = this.apsMgr.retrieveProfileOperation();
-        TimelineAggregator timelineAggregator = new TimelineAggregator(timelinelist,this.opsMgr.getDefaultExcludedInt());
+        TimelineAggregator timelineAggregator = new TimelineAggregator(timelinelist,this.opsMgr.getDefaultExcludedInt(), runDate);
         timelineAggregator.aggregate(this.opsMgr.getTruthTable(), this.opsMgr.getIntOperation(groupOperation));
 
         Timeline mergedTimeline = timelineAggregator.getOutput(); //collect all timelines that correspond to the group service endpoint group , merge them in order to create one timeline

--- a/flink_jobs_v2/batch_status/src/main/java/argo/batch/CalcServiceTimeline.java
+++ b/flink_jobs_v2/batch_status/src/main/java/argo/batch/CalcServiceTimeline.java
@@ -92,7 +92,7 @@ public class CalcServiceTimeline extends RichGroupReduceFunction<StatusTimeline,
             }
         }
         String operation = serviceFunctionsMap.get(service);
-        TimelineAggregator timelineAggregator = new TimelineAggregator(timelinelist,this.opsMgr.getDefaultExcludedInt());
+        TimelineAggregator timelineAggregator = new TimelineAggregator(timelinelist,this.opsMgr.getDefaultExcludedInt(),runDate);
         timelineAggregator.aggregate(this.opsMgr.getTruthTable(), this.opsMgr.getIntOperation(operation));
 
         Timeline mergedTimeline = timelineAggregator.getOutput(); //collect all timelines that correspond to the group service endpoint group , merge them in order to create one timeline


### PR DESCRIPTION
Fix Timeline calculations to include Downtime periods . 
CalcEndpointTimeline class is affected in order to calculate the downtime of a service endpoint and include it in the timeline.
CalcEndpointAR is affected as now it is not needed to calculate the downtime period
