### PR TITLE
ARGO-3673 Enable proxy flag in ams sink when proxy cli parameter is present

### DIFF
--- a/flink_jobs_v2/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
+++ b/flink_jobs_v2/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
@@ -179,8 +179,8 @@ public class AmsStreamStatus {
 
         // fetch
         // set params
-        if (parameterTool.has("api.proxy")) {
-            amr.setProxy(parameterTool.get("api.proxy"));
+        if (parameterTool.has("proxy")) {
+            amr.setProxy(parameterTool.get("proxy"));
         }
 
         if (parameterTool.has("api.timeout")) {
@@ -210,8 +210,8 @@ public class AmsStreamStatus {
 
         }
 
-        if (parameterTool.has("ams.proxy")) {
-            String proxyURL = parameterTool.get("ams.proxy");
+        if (parameterTool.has("proxy")) {
+            String proxyURL = parameterTool.get("proxy");
             amsMetric.setProxy(proxyURL);
         }
 
@@ -275,6 +275,10 @@ public class AmsStreamStatus {
             String projectpub = parameterTool.get("ams.project.publish");
 
             ArgoMessagingSink ams = new ArgoMessagingSink(endpoint, port, tokenpub, projectpub, topic, interval);
+            if (parameterTool.has("proxy")) {
+                String proxyURL = parameterTool.get("proxy");
+                ams.setProxy(proxyURL);
+            }
             events = events.flatMap(new TrimEvent(parameterTool, amr.getTenant(), amr.getReportName(), amr.getEgroup()));
             events.addSink(ams);
         }


### PR DESCRIPTION
-- Also: Consolidate api.proxy and ams.proxy cli parameters to one proxy parameter
### Issue:
ams sink didn't receive proxy=true flag when --ams.proxy parameter was present thus causing resolve exceptions when trying to execute the flink job

In the original version there was a check that added proxy flag=true to the amsMetric source
```java
if (parameterTool.has("ams.proxy")) {
            String proxyURL = parameterTool.get("ams.proxy");
            amsMetric.setProxy(proxyURL);
 }
```
something similar is needed for the ams sink source

Also it would be nice to consolidate `--ams.proxy` and `--api.proxy` to one cli arg `--proxy`

### Fix:
This fix enables proxy=true flag in AMS sink when --proxy parameter is present in cli args
We have consolidated --ams.proxy and --api.proxy cli arguments to one --proxy argument