### PR TITLE
api.proxy fixed to proxy

### DIFF
--- a/flink_jobs_v2/stream_status/src/main/java/argo/streaming/StatusConfig.java
+++ b/flink_jobs_v2/stream_status/src/main/java/argo/streaming/StatusConfig.java
@@ -79,8 +79,8 @@ public class StatusConfig implements Serializable {
         this.apiToken = pt.getRequired("api.token");
         this.reportID = pt.getRequired("report.uuid");
 
-        if (pt.has("api.proxy")) {
-            this.apiProxy = pt.get("api.proxy", "");
+        if (pt.has("proxy")) {
+            this.apiProxy = pt.get("proxy", "");
         }
         if (pt.has("api.verify")) {
             this.apiVerify = pt.getBoolean("api.verify", false);


### PR DESCRIPTION
api.proxy param in StatusConfig was missed from renaming, so now the change occured