### PR TITLE
ARGO-3837 Fix missing INFO field values from status results in mongo

### DIFF
--- a/flink_jobs_v2/batch_multi/src/main/java/argo/batch/ArgoMultiJob.java
+++ b/flink_jobs_v2/batch_multi/src/main/java/argo/batch/ArgoMultiJob.java
@@ -280,7 +280,7 @@ public class ArgoMultiJob {
 
             DataSet<StatusMetric> stEndpointDS = statusEndpointTimeline.flatMap(new CalcStatusEndpoint(params)).withBroadcastSet(mpsDS, "mps").withBroadcastSet(opsDS, "ops")
                     .withBroadcastSet(egpDS, "egp").withBroadcastSet(ggpDS, "ggp")
-                    .withBroadcastSet(apsDS, "aps");
+                    .withBroadcastSet(apsDS, "aps").withBroadcastSet(confDS, "conf");
 // Create status service data set
 
             DataSet<StatusMetric> stServiceDS = statusServiceTimeline.flatMap(new CalcStatusService(params)).withBroadcastSet(mpsDS, "mps")

--- a/flink_jobs_v2/batch_multi/src/test/java/argo/batch/ArgoMultiJobTest.java
+++ b/flink_jobs_v2/batch_multi/src/test/java/argo/batch/ArgoMultiJobTest.java
@@ -308,7 +308,7 @@ public class ArgoMultiJobTest {
 
             DataSet<StatusMetric> stEndpointDS = statusEndpointTimeline.flatMap(new CalcStatusEndpoint(params)).withBroadcastSet(mpsDS, "mps").withBroadcastSet(opsDS, "ops")
                     .withBroadcastSet(egpDS, "egp").withBroadcastSet(ggpDS, "ggp")
-                    .withBroadcastSet(apsDS, "aps");
+                    .withBroadcastSet(apsDS, "aps").withBroadcastSet(cfgDS, "conf");
 // Create status service data set
 
             URL statusendpURL = ArgoMultiJob.class.getResource("/test/statusendpoint.json");


### PR DESCRIPTION
Fixed the missing info field to appear as field in mongo db collection. Info values were not calculated during computing endpoint status results. This is fixed now 
Changes at CalcStatusEndpoint class and ArgoMultiJob class