### PR TITLE
ARGO-3912 Make multijob submit compute parameter optional

### DIFF
--- a/bin/multi_job_submit.py
+++ b/bin/multi_job_submit.py
@@ -202,7 +202,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-m", "--method", metavar="KEYWORD(insert|upsert)", help="Insert or Upsert data in mongoDB", required=False, dest="method", default="insert")
     parser.add_argument(
-        "-x", "--calculate", metavar="STRING", help="Comma separated list of what to calculate (ar,status,trends)", required=True, dest="calculate", default="ar,status,trends")
+        "-x", "--calculate", metavar="STRING", help="Comma separated list of what to calculate (ar,status,trends)", required=False, dest="calculate", default=None)
     parser.add_argument(
         "-c", "--config", metavar="PATH", help="Path for the config file", dest="config")
     parser.add_argument(


### PR DESCRIPTION
Make '-x' compute cli argument optional. If not set the flink submit job does not receive any specific flags for computing ar,status,trends and instead relies on the argo-web-api to fetch the appropriate information on what to compute