### PR TITLE
ARGO-3943 Status extending current time appears in the timeline of EG…

### DIFF
--- a/flink_jobs_v2/Timelines/src/main/java/timelines/Timeline.java
+++ b/flink_jobs_v2/Timelines/src/main/java/timelines/Timeline.java
@@ -10,13 +10,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
-
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -474,14 +470,13 @@ public class Timeline {
      * periods
      *
      */
-    public void fillWithStatus(String start, String end, Integer intStatus, DateTime dtUtc) throws ParseException {
+    public void fillWithStatus(String start, String end, Integer intStatus, DateTime now) throws ParseException {
         DateTime startDay = this.date.toDateTimeAtStartOfDay();
         DateTime endDay = startDay.withTime(23, 59, 59, 0);
-
-        //for (String[] period : periods) {
+       
         DateTime startDt = Utils.convertStringtoDate("yyyy-MM-dd'T'HH:mm:ss'Z'", start);
         DateTime endDt = Utils.convertStringtoDate("yyyy-MM-dd'T'HH:mm:ss'Z'", end);
-
+       
         DateTime floor = samples.floorKey(startDt);
         DateTime ceiling = samples.ceilingKey(endDt);
 
@@ -505,17 +500,18 @@ public class Timeline {
             endFloorStatus = this.samples.get(endFloor);
 
         }
-        if ((floor == null || !floor.equals(startDt)) && !startDt.isAfter(dtUtc)) { // if start period does not match with the initial timeline's timestamp then need to add the start to the timeline with the specified status
+        if ((floor == null || !floor.equals(startDt)) && !startDt.isAfter(now)) { // if start period does not match with the initial timeline's timestamp then need to add the start to the timeline with the specified status
             this.samples.put(startDt, intStatus);                       //else the timestamp already contained and in next step its status will be replaced
         }
         //if a timestamp exists after a period  then this timestamp should be added with the initial status of that period taken from the initial timeline
         //this timestamp should not extend todays current time (in the case that the computations occur during today and before the end of the day)
-        if (addCeiling && !endDt.isAfter(dtUtc) && endDt.plusMinutes(1).isBefore(endDay)) {
+ 
+        if (addCeiling && !endDt.isAfter(now) && endDt.plusMinutes(1).isBefore(endDay)) {
             this.samples.put(endDt.plusMinutes(1), endFloorStatus);
         }
 
         for (DateTime dt : samples.keySet()) {
-            if (!dt.isAfter(dtUtc) && !dt.isBefore(startDt) && !dt.isAfter(endDt)) { //if timestamps exist between the period then replace the timestamps with the specified status
+            if (!dt.isAfter(now) && !dt.isBefore(startDt) && !dt.isAfter(endDt)) { //if timestamps exist between the period then replace the timestamps with the specified status
                 this.samples.replace(dt, intStatus);
             }
         }

--- a/flink_jobs_v2/Timelines/src/main/java/timelines/Utils.java
+++ b/flink_jobs_v2/Timelines/src/main/java/timelines/Utils.java
@@ -5,6 +5,7 @@
  */
 package timelines;
 
+import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;

--- a/flink_jobs_v2/Timelines/src/test/java/timelines/TimelineTest.java
+++ b/flink_jobs_v2/Timelines/src/test/java/timelines/TimelineTest.java
@@ -361,7 +361,7 @@ public class TimelineTest {
     @Test
     public void testFillStatus() throws ParseException {
         DateTimeFormatter dtf = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
-          DateTime dtUtc = new DateTime(DateTimeZone.UTC);
+          DateTime now = new DateTime();
       
         Timeline instance = new Timeline();
         instance.insertDateTimeStamps(createTimestampList2(), true);
@@ -399,7 +399,7 @@ public class TimelineTest {
         periods.add(period4);
         periods.add(period5);
         for (String[] period : periods) {
-            instance.fillWithStatus(period[0], period[1], 2, dtUtc);
+            instance.fillWithStatus(period[0], period[1], 2, now);
             instance.optimize();
         }
         TreeMap<DateTime, Integer> expResult = createUnknownTimeline();
@@ -441,7 +441,7 @@ public class TimelineTest {
         instance = new Timeline();
         instance.insertDateTimeStamps(createTimestampList2(), true);
         for (String[] period : periods) {
-            instance.fillWithStatus(period[0], period[1], 2, dtUtc);
+            instance.fillWithStatus(period[0], period[1], 2, now);
             instance.optimize();
         }
 
@@ -484,7 +484,7 @@ public class TimelineTest {
         instance = new Timeline();
         instance.insertDateTimeStamps(createTimestampList2(), true);
         for (String[] period : periods) {
-            instance.fillWithStatus(period[0], period[1], 2, dtUtc);
+            instance.fillWithStatus(period[0], period[1], 2, now);
             instance.optimize();
         }
         expResult = createUnknownTimeline3();
@@ -502,7 +502,7 @@ public class TimelineTest {
         instance.insertDateTimeStamps(createTimestampList2(), true);
 
         for (String[] period : periods) {
-            instance.fillWithStatus(period[0], period[1], 2, dtUtc);
+            instance.fillWithStatus(period[0], period[1], 2, now);
             instance.optimize();
         }
         expResult = createUnknownTimeline4();
@@ -545,7 +545,7 @@ public class TimelineTest {
         instance.insertDateTimeStamps(createTimestampList4(), true);
 
         for (String[] period : periods) {
-            instance.fillWithStatus(period[0], period[1], 2, dtUtc);
+            instance.fillWithStatus(period[0], period[1], 2, now);
             instance.optimize();
         }
         expResult = createUnknownTimeline5();

--- a/flink_jobs_v2/batch_multi/src/main/java/argo/ar/CalcGroupAR.java
+++ b/flink_jobs_v2/batch_multi/src/main/java/argo/ar/CalcGroupAR.java
@@ -47,8 +47,8 @@ public class CalcGroupAR extends RichFlatMapFunction<StatusTimeline, EndpointGro
 
     final ParameterTool params;
 
-    public CalcGroupAR(ParameterTool params, DateTime dtUtc) {
-        this.dtUtc = dtUtc;
+    public CalcGroupAR(ParameterTool params, DateTime now) {
+        this.now = now;
         this.params = params;
     }
 
@@ -71,7 +71,7 @@ public class CalcGroupAR extends RichFlatMapFunction<StatusTimeline, EndpointGro
     private String ggroupType;
     private RecomputationsManager recMgr;
     private List<String> rec;
-    private DateTime dtUtc;
+    private DateTime now;
 
     /**
      * Initialization method of the RichGroupReduceFunction operator
@@ -175,7 +175,7 @@ public class CalcGroupAR extends RichFlatMapFunction<StatusTimeline, EndpointGro
         if (this.recMgr.isExcluded(in.getGroup())) {
             ArrayList<Map<String, String>> periods = this.recMgr.getPeriods(in.getGroup(), this.runDate);
             for (Map<String, String> interval : periods) {
-                timeline.fillWithStatus(interval.get("start"), interval.get("end"), this.opsMgr.getDefaultUnknownInt(), dtUtc);
+                timeline.fillWithStatus(interval.get("start"), interval.get("end"), this.opsMgr.getDefaultUnknownInt(), now);
                 timeline.optimize();
             }
         }

--- a/flink_jobs_v2/batch_multi/src/main/java/argo/batch/ArgoMultiJob.java
+++ b/flink_jobs_v2/batch_multi/src/main/java/argo/batch/ArgoMultiJob.java
@@ -108,8 +108,8 @@ public class ArgoMultiJob {
         env.getConfig().setGlobalJobParameters(params);
         env.setParallelism(1);
 
-        DateTime dtUtc = new DateTime(DateTimeZone.UTC);
-
+        DateTime now = new DateTime();
+        
         if (params.get("N") != null) {
             rankNum = params.getInt("N");
         }
@@ -235,7 +235,7 @@ public class ArgoMultiJob {
 
         //Create StatusMetricTimeline dataset for endpoints
         DataSet<StatusTimeline> statusEndpointTimeline = statusMetricTimeline.groupBy("group", "service", "hostname")
-                .reduceGroup(new CalcEndpointTimeline(params, dtUtc)).withBroadcastSet(mpsDS, "mps").withBroadcastSet(opsDS, "ops")
+                .reduceGroup(new CalcEndpointTimeline(params, now)).withBroadcastSet(mpsDS, "mps").withBroadcastSet(opsDS, "ops")
                 .withBroadcastSet(egpDS, "egp").withBroadcastSet(ggpDS, "ggp")
                 .withBroadcastSet(apsDS, "aps").withBroadcastSet(downDS, "down");
 
@@ -298,7 +298,7 @@ public class ArgoMultiJob {
                     withBroadcastSet(ggpDS, "ggp").withBroadcastSet(confDS, "conf");
 
             // DataSet<StatusTimeline> statusGroupTimelineAR = statusGroupTimeline.flatMap(new ExcludeGroupMetrics(params)).withBroadcastSet(recDS, "rec").withBroadcastSet(opsDS, "ops");
-            DataSet<EndpointGroupAR> endpointGroupArDS = statusGroupTimeline.flatMap(new CalcGroupAR(params, dtUtc)).withBroadcastSet(mpsDS, "mps")
+            DataSet<EndpointGroupAR> endpointGroupArDS = statusGroupTimeline.flatMap(new CalcGroupAR(params, now)).withBroadcastSet(mpsDS, "mps")
                     .withBroadcastSet(apsDS, "aps").withBroadcastSet(opsDS, "ops").withBroadcastSet(egpDS, "egp").
                     withBroadcastSet(ggpDS, "ggp").withBroadcastSet(confDS, "conf").withBroadcastSet(weightDS, "weight").withBroadcastSet(recDS, "rec");
 

--- a/flink_jobs_v2/batch_multi/src/main/java/argo/batch/CalcEndpointTimeline.java
+++ b/flink_jobs_v2/batch_multi/src/main/java/argo/batch/CalcEndpointTimeline.java
@@ -38,9 +38,9 @@ public class CalcEndpointTimeline extends RichGroupReduceFunction<StatusTimeline
 
     final ParameterTool params;
 
-    public CalcEndpointTimeline(ParameterTool params, DateTime dtUtc) {
+    public CalcEndpointTimeline(ParameterTool params, DateTime now) {
         this.params = params;
-        this.dtUtc=dtUtc;
+        this.now=now;
     }
 
     static Logger LOG = LoggerFactory.getLogger(ArgoMultiJob.class);
@@ -55,7 +55,7 @@ public class CalcEndpointTimeline extends RichGroupReduceFunction<StatusTimeline
     private String operation;
     private DowntimeManager downtimeMgr;
     private List<Downtime> downtime;
-    private DateTime dtUtc;
+    private DateTime now;
 
     @Override
     public void open(Configuration parameters) throws IOException {
@@ -121,7 +121,7 @@ public class CalcEndpointTimeline extends RichGroupReduceFunction<StatusTimeline
      
 	
         if (downPeriod != null && !downPeriod.isEmpty()) {
-            mergedTimeline.fillWithStatus(downPeriod.get(0), downPeriod.get(1), this.opsMgr.getDefaultDownInt(), dtUtc);
+            mergedTimeline.fillWithStatus(downPeriod.get(0), downPeriod.get(1), this.opsMgr.getDefaultDownInt(), now);
         }
         ArrayList<TimeStatus> timestatuCol = new ArrayList();
         for (Map.Entry<DateTime, Integer> entry : mergedTimeline.getSamples()) {

--- a/flink_jobs_v2/batch_multi/src/main/java/argo/batch/CalcPrevStatus.java
+++ b/flink_jobs_v2/batch_multi/src/main/java/argo/batch/CalcPrevStatus.java
@@ -129,7 +129,7 @@ public class CalcPrevStatus extends RichGroupReduceFunction<StatusMetric, Status
                     out.collect(item);
                 }
             }
-
+            
             prevStatus = item.getStatus();
             prevTimestamp = item.getTimestamp();
         }

--- a/flink_jobs_v2/batch_multi/src/test/java/argo/batch/ArgoMultiJobTest.java
+++ b/flink_jobs_v2/batch_multi/src/test/java/argo/batch/ArgoMultiJobTest.java
@@ -93,7 +93,7 @@ public class ArgoMultiJobTest {
         System.setProperty("run.date", "2022-01-14");
             
         final ParameterTool params = ParameterTool.fromSystemProperties();
-        DateTime dtUtc=new DateTime(DateTimeZone.UTC);
+        DateTime now=new DateTime();
 
         ApiResourceManager amr = mockAmr();
 
@@ -265,13 +265,13 @@ public class ArgoMultiJobTest {
         //*************** Test Endpoint  Timeline
         //Create StatusMetricTimeline dataset for endpoints
         DataSet<StatusTimeline> statusEndpointTimeline = statusMetricTimeline.groupBy("group", "service", "hostname")
-                .reduceGroup(new CalcEndpointTimeline(params, dtUtc)).withBroadcastSet(mpsDS, "mps").withBroadcastSet(opsDS, "ops")
+                .reduceGroup(new CalcEndpointTimeline(params, now)).withBroadcastSet(mpsDS, "mps").withBroadcastSet(opsDS, "ops")
                 .withBroadcastSet(egpDS, "egp").withBroadcastSet(ggpDS, "ggp")
                 .withBroadcastSet(apsDS, "aps").withBroadcastSet(downDS, "down");
         ArrayList<String> aggrJson = new ArrayList();
         aggrJson.add(amr.getResourceJSON(ApiResource.AGGREGATION));
 
-        ArrayList<StatusTimeline> expEndpTimelines = TestUtils.prepareLevelTimeline(expMetricTimelines, opsJson, aggrJson, downDS.collect(), params.get("run.date"), LEVEL.HOSTNAME, dtUtc);
+        ArrayList<StatusTimeline> expEndpTimelines = TestUtils.prepareLevelTimeline(expMetricTimelines, opsJson, aggrJson, downDS.collect(), params.get("run.date"), LEVEL.HOSTNAME, now);
         Assert.assertEquals(TestUtils.compareLists(expEndpTimelines, statusEndpointTimeline.collect()), true);
 
         //*************** Test Service Timeline
@@ -279,7 +279,7 @@ public class ArgoMultiJobTest {
                 .reduceGroup(new CalcServiceTimeline(params)).withBroadcastSet(mpsDS, "mps").withBroadcastSet(opsDS, "ops")
                 .withBroadcastSet(egpDS, "egp").withBroadcastSet(ggpDS, "ggp")
                 .withBroadcastSet(apsDS, "aps");
-        ArrayList<StatusTimeline> expServTimelines = TestUtils.prepareLevelTimeline(expEndpTimelines, opsJson, aggrJson, downDS.collect(), params.get("run.date"), LEVEL.SERVICE, dtUtc);
+        ArrayList<StatusTimeline> expServTimelines = TestUtils.prepareLevelTimeline(expEndpTimelines, opsJson, aggrJson, downDS.collect(), params.get("run.date"), LEVEL.SERVICE, now);
         Assert.assertEquals(TestUtils.compareLists(expServTimelines, statusServiceTimeline.collect()), true);
 
         //*************** Test Function Timeline
@@ -288,7 +288,7 @@ public class ArgoMultiJobTest {
                 .withBroadcastSet(egpDS, "egp").withBroadcastSet(ggpDS, "ggp")
                 .withBroadcastSet(apsDS, "aps");
 
-        ArrayList<StatusTimeline> expFunctionTimelines = TestUtils.prepareLevelTimeline(expServTimelines, opsJson, aggrJson, downDS.collect(), params.get("run.date"), LEVEL.FUNCTION, dtUtc);
+        ArrayList<StatusTimeline> expFunctionTimelines = TestUtils.prepareLevelTimeline(expServTimelines, opsJson, aggrJson, downDS.collect(), params.get("run.date"), LEVEL.FUNCTION, now);
         Assert.assertEquals(TestUtils.compareLists(expFunctionTimelines, statusEndGroupFunctionTimeline.collect()), true);
 
         //*************** Test Group Timeline
@@ -296,7 +296,7 @@ public class ArgoMultiJobTest {
                 .reduceGroup(new CalcGroupTimeline(params)).withBroadcastSet(mpsDS, "mps").withBroadcastSet(opsDS, "ops")
                 .withBroadcastSet(egpDS, "egp").withBroadcastSet(ggpDS, "ggp")
                 .withBroadcastSet(apsDS, "aps");
-        ArrayList<StatusTimeline> expGroupTimelines = TestUtils.prepareLevelTimeline(expFunctionTimelines, opsJson, aggrJson, downDS.collect(), params.get("run.date"), LEVEL.GROUP, dtUtc);
+        ArrayList<StatusTimeline> expGroupTimelines = TestUtils.prepareLevelTimeline(expFunctionTimelines, opsJson, aggrJson, downDS.collect(), params.get("run.date"), LEVEL.GROUP, now);
         Assert.assertEquals(TestUtils.compareLists(expGroupTimelines, statusGroupTimeline.collect()), true);
 
         if (calcStatus) {
@@ -469,7 +469,7 @@ public class ArgoMultiJobTest {
             List<ServiceAR> expectedServAr = TestUtils.prepareServiceAR(servArData, params.get("run.date"));
 
             Assert.assertEquals(TestUtils.compareLists(expectedServAr, serviceArDS.collect()), true);
-            DataSet<EndpointGroupAR> endpointGroupArDS = statusGroupTimeline.flatMap(new CalcGroupAR(params,dtUtc)).withBroadcastSet(mpsDS, "mps")
+            DataSet<EndpointGroupAR> endpointGroupArDS = statusGroupTimeline.flatMap(new CalcGroupAR(params,now)).withBroadcastSet(mpsDS, "mps")
                     .withBroadcastSet(apsDS, "aps").withBroadcastSet(opsDS, "ops").withBroadcastSet(egpDS, "egp").
                     withBroadcastSet(ggpDS, "ggp").withBroadcastSet(downDS, "down").withBroadcastSet(cfgDS, "conf").withBroadcastSet(weightDS, "weight").withBroadcastSet(recDS, "rec");
             List<TestUtils.ArItem> groupArData = loadExpectedArData(groupExpectedData, LEVEL.GROUP, env);

--- a/flink_jobs_v2/batch_multi/src/test/java/argo/batch/TestUtils.java
+++ b/flink_jobs_v2/batch_multi/src/test/java/argo/batch/TestUtils.java
@@ -61,7 +61,7 @@ public class TestUtils {
      * @throws ParseException
      * @throws IOException
      */
-    public static ArrayList<StatusTimeline> prepareLevelTimeline(List<StatusTimeline> list, List<String> opsDS, List<String> aggrDS, List<Downtime> downDS, String runDate, LEVEL level, DateTime dtUtc) throws ParseException, IOException {
+    public static ArrayList<StatusTimeline> prepareLevelTimeline(List<StatusTimeline> list, List<String> opsDS, List<String> aggrDS, List<Downtime> downDS, String runDate, LEVEL level, DateTime now) throws ParseException, IOException {
 
         String group = "", function = "", service = "", hostname = "", metric = "";
 
@@ -162,12 +162,12 @@ public class TestUtils {
         if (!added) {
             alltimelines.add(tl);
         }
-        ArrayList<StatusTimeline> timelines = parseEndpTimelines(alltimelines, opsDS, aggrDS, downDS, runDate, level, dtUtc);
+        ArrayList<StatusTimeline> timelines = parseEndpTimelines(alltimelines, opsDS, aggrDS, downDS, runDate, level, now);
 
         return timelines;
     }
 
-    private static ArrayList<StatusTimeline> parseEndpTimelines(ArrayList<ArrayList<StatusTimeline>> timelist, List<String> opsDS, List<String> aggrDS, List<Downtime> downDS, String runDate, LEVEL level, DateTime dtUtc) throws ParseException, IOException {
+    private static ArrayList<StatusTimeline> parseEndpTimelines(ArrayList<ArrayList<StatusTimeline>> timelist, List<String> opsDS, List<String> aggrDS, List<Downtime> downDS, String runDate, LEVEL level, DateTime now) throws ParseException, IOException {
         OperationsManager opsMgr = new OperationsManager();
         opsMgr.loadJsonString(opsDS);
 
@@ -224,7 +224,7 @@ public class TestUtils {
                     if (level.equals(LEVEL.HOSTNAME)) {
                         ArrayList<String> downPeriod = downMgr.getPeriod(hostname, service);
                         if (downPeriod != null && !downPeriod.isEmpty()) {
-                            initialTimeline.fillWithStatus(downPeriod.get(0), downPeriod.get(1), opsMgr.getDefaultDownInt(), dtUtc);
+                            initialTimeline.fillWithStatus(downPeriod.get(0), downPeriod.get(1), opsMgr.getDefaultDownInt(), now);
                         }
 
                     }


### PR DESCRIPTION
…I ALL report


UTC time changed to current time as timestamps of downtime period when converted to datetime were set to the time of the local timezone. as a result compare of times was wrong