### PR TITLE
Produce streaming events with friendly urls instead of encoded hostnames

### DIFF
--- a/flink_jobs_v2/ProfilesManager/src/main/java/profilesmanager/EndpointGroupManager.java
+++ b/flink_jobs_v2/ProfilesManager/src/main/java/profilesmanager/EndpointGroupManager.java
@@ -302,6 +302,26 @@ public class EndpointGroupManager implements Serializable {
 
         return null;
     }
+    
+    /**
+     * Finds in the filtered EndpointItem fList a EndpointItem with specific
+     * group, type. service, hostname and tag and returns it's value
+     *
+     * @param group a group
+     * @param type a type
+     * @param hostname a hostname
+     * @param service a service
+     * @param tag this is the tag name
+     * @return return tag value
+     **/
+    public String getTag(String group, String type, String hostname, String service, String tag) {
+    	HashMap<String, String> results = this.getGroupTags(group, type, hostname, service);
+    	if (results != null){
+    		return results.get(tag);
+    	}
+    	
+    	return null;
+    }
 
     /**
      * counts the items in the filtered list

--- a/flink_jobs_v2/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
+++ b/flink_jobs_v2/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
@@ -514,6 +514,7 @@ public class AmsStreamStatus {
             sm.setStrictInterval(strictInterval);
             // sm.setTimeout(config.timeout);
             sm.setReport(config.report);
+            sm.setGroupType(amr.getEgroup());
             // load all the connector data
             sm.loadAll(config.runDate, downList, egpListFull, mpsList, apsList, opsList);
 

--- a/flink_jobs_v2/stream_status/src/main/java/status/StatusEvent.java
+++ b/flink_jobs_v2/stream_status/src/main/java/status/StatusEvent.java
@@ -36,6 +36,7 @@ public class StatusEvent{
 	// Record all statuses of endpoint's metrics
 	private @SerializedName("metric_statuses") String metricStatuses[];
 	private @SerializedName("metric_names") String metricNames[];
+	private @SerializedName("hostname_url") String hostnameURL;
 	
 	
 	public StatusEvent() {
@@ -64,6 +65,7 @@ public class StatusEvent{
 		this.groupStatuses = new String[0];
 		this.metricStatuses = new String[0];
 		this.metricNames = new String[0];
+		this.hostnameURL = "";
 		
 	}
 	
@@ -94,6 +96,7 @@ public class StatusEvent{
 		this.groupStatuses = null;
 		this.metricStatuses = null;
 		this.metricNames = null;
+		this.hostnameURL = "";
 
 		
 	}
@@ -186,6 +189,7 @@ public class StatusEvent{
 	public String getRepeat() {return repeat;}
 	public String getSummary() {return this.summary;}
 	public String getMessage() {return this.message;}
+	public String getHostnameURL() { return this.hostnameURL;}
 
 	public void setReport(String report) {this.report = report;}	
 	public void setType(String type) {this.type = type;}
@@ -207,6 +211,7 @@ public class StatusEvent{
 	public void setStatus(String status) {this.status = status;}
 	public void setSummary(String summary) {this.summary = summary;}
 	public void setMessage (String message) {this.message = message;}
+	public void setHostnameURL (String hostnameURL) {this.hostnameURL = hostnameURL;}
 	
 	public int getDateInt() {
 		return Integer.parseInt(this.dt);


### PR DESCRIPTION
# 🎯 Goal
For tenants that endpoints are represented by full urls (and the hostnames are in encoded form) we need to pass and display the urls in notifications also. 

# 🔨 Implementation
- [x] Update ProfileManager > EndpointGroupManager class to be able to quickly query url information from the specific "info_URL" tag
- [x] Update StatusEvent object to hold information about hostname url
- [x] Update method that gathers information about all included endpoints in a group to query and use urls if available
- [x] During endpoint event creation use url information in hostname url field