### PR TITLE
ARGO-3973 Change dependency versions in flink_jobs_v2 as suggested from github

### DIFF
--- a/flink_jobs_v2/batch_multi/pom.xml
+++ b/flink_jobs_v2/batch_multi/pom.xml
@@ -111,7 +111,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.2.4</version>
+            <version>2.8.9</version>
         </dependency>
 		
         <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->

--- a/flink_jobs_v2/stream_status/pom.xml
+++ b/flink_jobs_v2/stream_status/pom.xml
@@ -113,7 +113,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.7</version>
+            <version>2.8.9</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.hbase/hbase-client -->
         <dependency>
@@ -148,7 +148,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
-            <version>2.12.0</version>
+            <version>2.12.2</version>
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>


### PR DESCRIPTION
…from github

Under stream_status pom.xml dependency of xercesImpl artifact changed to v 2.12.2 , seems ok as this version does not have any vulnerabilities. Also gson artifact changes to v 2.8.9 , seems ok as it is one of the latest version of gson -could also change to the latest. 
Under batch_multi pom.xml gson artifact changes to v 2.8.9 , seems ok as it is one of the latest version of gson -could also change to the latest. 