### PR TITLE
ARGO-4131 Prepare v2.1.0 release

### DIFF
--- a/flink_jobs_v2/ApiResourceManager/pom.xml
+++ b/flink_jobs_v2/ApiResourceManager/pom.xml
@@ -4,9 +4,9 @@
     <parent>
         <groupId>flink.jobs.v2</groupId>
         <artifactId>flink_jobs_v2</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0</version>
     </parent>
-    <version>2.0.0</version> 
+    <version>2.1.0</version> 
     <groupId>api.resource.manager</groupId>
     <artifactId>ApiResourceManager</artifactId>
     <packaging>jar</packaging>

--- a/flink_jobs_v2/ProfilesManager/pom.xml
+++ b/flink_jobs_v2/ProfilesManager/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>flink.jobs.v2</groupId>
         <artifactId>flink_jobs_v2</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0</version>
     </parent> 
     <groupId>profiles.manager</groupId>
     <artifactId>ProfilesManager</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/flink_jobs_v2/Timelines/pom.xml
+++ b/flink_jobs_v2/Timelines/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>flink.jobs.v2</groupId>
         <artifactId>flink_jobs_v2</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0</version>
     </parent> 
     <groupId>timeline.manager</groupId>
     <artifactId>Timelines</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/flink_jobs_v2/ams-connector/pom.xml
+++ b/flink_jobs_v2/ams-connector/pom.xml
@@ -16,17 +16,17 @@
 	<parent>
         <groupId>flink.jobs.v2</groupId>
         <artifactId>flink_jobs_v2</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0</version>
     	</parent> 
     
 	<groupId>ams.connector</groupId>
-	<version>2.0.0</version>
+	<version>2.1.0</version>
 	<name>ams.connector</name>
 	<description>Connect to AMS</description>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<flink.version>1.3.1</flink.version>
+		<flink.version>1.3.2</flink.version>
 		<slf4j.version>1.7.7</slf4j.version>
 		<log4j.version>1.2.17</log4j.version>
 		<scala.binary.version>2.10</scala.binary.version>

--- a/flink_jobs_v2/ams_ingest_metric/pom.xml
+++ b/flink_jobs_v2/ams_ingest_metric/pom.xml
@@ -14,7 +14,7 @@ language governing permissions and limitations under the License. -->
 
     <groupId>argo.streaming</groupId>
     <artifactId>ams-ingest-metric</artifactId>
-    <version>0.1</version>
+    <version>2.1.0</version>
     <packaging>jar</packaging>
 
     <name>ARGO AMS Ingest Metric Data job</name>
@@ -63,7 +63,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>ams.connector</groupId>
             <artifactId>ams-connector</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.0</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/flink_jobs_v2/ams_ingest_sync/pom.xml
+++ b/flink_jobs_v2/ams_ingest_sync/pom.xml
@@ -14,13 +14,13 @@ language governing permissions and limitations under the License. -->
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>argo.streaming</groupId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>2.1.0</version>
     <name>ams-ingest-sync</name>
     <description>Stream sync data from AMS to HDFS</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <flink.version>1.3.1</flink.version>
+        <flink.version>1.3.2</flink.version>
         <slf4j.version>1.7.7</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
         <scala.binary.version>2.10</scala.binary.version>
@@ -57,7 +57,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>ams.connector</groupId>
             <artifactId>ams-connector</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.0</version>
             <type>jar</type>
         </dependency>
         <!-- Apache Flink dependencies -->

--- a/flink_jobs_v2/batch_multi/pom.xml
+++ b/flink_jobs_v2/batch_multi/pom.xml
@@ -15,7 +15,7 @@ language governing permissions and limitations under the License. -->
     <parent>
         <groupId>flink.jobs.v2</groupId>
         <artifactId>flink_jobs_v2</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0</version>
     </parent> 
     <groupId>argo.batch</groupId>
     <artifactId>ArgoMultiJob</artifactId>
@@ -175,19 +175,19 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>timeline.manager</groupId>
             <artifactId>Timelines</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.0</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>profiles.manager</groupId>
             <artifactId>ProfilesManager</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.0</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>api.resource.manager</groupId>
             <artifactId>ApiResourceManager</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.0</version>
             <type>jar</type>
         </dependency>
 

--- a/flink_jobs_v2/pom.xml
+++ b/flink_jobs_v2/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>flink.jobs.v2</groupId>
     <artifactId>flink_jobs_v2</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <packaging>pom</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/flink_jobs_v2/stream_status/pom.xml
+++ b/flink_jobs_v2/stream_status/pom.xml
@@ -14,11 +14,11 @@ language governing permissions and limitations under the License. -->
     <parent>
         <groupId>flink.jobs.v2</groupId>
         <artifactId>flink_jobs_v2</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0</version>
     </parent> 
     <groupId>argo.streaming</groupId>
     <artifactId>streaming-status</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <packaging>jar</packaging>
 
     <name>ARGO Streaming status job</name>
@@ -66,19 +66,19 @@ language governing permissions and limitations under the License. -->
          <dependency>
             <groupId>ams.connector</groupId>
             <artifactId>ams-connector</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.0</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>api.resource.manager</groupId>
             <artifactId>ApiResourceManager</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.0</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>profiles.manager</groupId>
             <artifactId>ProfilesManager</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.0</version>
             <type>jar</type>
         </dependency>
         <dependency>


### PR DESCRIPTION
**Added:**

- ARGO-3984 Make streaming job initialise by default with no run.date argument and advance the subscription to the lastest message
- Write generated alerts to Ams instead of Kafka in stream_status job
- ARGO-3904 Handle repeated events such as reminders different from normal ones

**Changed:**

- ARGO-3977 Improve logs generated by the flink jobs
- ARGO-3987 Make AMS related code common in flink jobs
- ARGO-3973 update dependencies versions in flink_jobs_v2 
- ARGO-3953 Ingestion jobs should use the header ams credential method
- Streaming job doPull, doAck requests to AMS should use the header ams credential method
- ARGO-3961 Change DateTime timezone to utc during handling timestamps in Timelines and multi_job
- ARGO-3731 upgrade mongodb connector to v3.12
- Produce streaming events with friendly urls instead of encoded hostnames

