### PR TITLE
ARGO-4143 Fix parameter latest.offset to be optional

### DIFF
--- a/flink_jobs_v2/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
+++ b/flink_jobs_v2/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
@@ -242,7 +242,7 @@ public class AmsStreamStatus {
         // Establish the metric data AMS stream
         // Ingest sync avro encoded data from AMS endpoint
         String offsetDt=null;
-        if(!parameterTool.getBoolean("latest.offset")){
+        if(parameterTool.has("latest.offset") && !parameterTool.getBoolean("latest.offset")){
          offsetDt=runDate;
         }
         ArgoMessagingSource amsMetric = new ArgoMessagingSource(endpoint, port, token, project, subMetric, batch, interval, offsetDt);


### PR DESCRIPTION
There is a minor fix in AmsStreamStatus  to ensure that the parameter latest.offset  is optional, as right now if not defined at the code arises an error