### PR TITLE
ARGO-4280 Introduce basispath argument in multijob submit script

### DIFF
--- a/bin/multi_job_submit.py
+++ b/bin/multi_job_submit.py
@@ -47,6 +47,11 @@ def compose_hdfs_commands(year, month, day, args, config):
     hdfs_metric = hdfs_metric.fill(
         namenode=namenode.geturl(), hdfs_user=hdfs_user, tenant=tenant).geturl()
 
+    hdfs_tenants = config.get("HDFS", "path_tenants")
+    hdfs_tenants = hdfs_tenants.fill(
+        namenode=namenode.geturl(), hdfs_user=hdfs_user
+    ).geturl()
+
     # dictionary holding all the commands with their respective arguments' name
     hdfs_commands = dict()
 
@@ -57,6 +62,13 @@ def compose_hdfs_commands(year, month, day, args, config):
     # file location of target day's metric data (local or hdfs)
     hdfs_commands["--mdata"] = hdfs_check_path(
         hdfs_metric+"/"+args.date,  client)
+    
+    # if job will run in combined data mode then we should add the hdfs tenants path as --basispath to the jar
+    # to find out if the tenant will run in combined data mode we check if --source-data 
+    # is provided as argument and has value other than tenant
+
+    if ("source_data" in args and args.source_data != "tenant"):
+        hdfs_commands["--basispath"] = hdfs_check_path(hdfs_tenants, client)
 
     return hdfs_commands
 

--- a/conf/argo-streaming.conf
+++ b/conf/argo-streaming.conf
@@ -4,6 +4,7 @@ user= foo
 rollback_days= 3
 path_metric= hdfs://{{namenode}}/user/{{hdfs_user}}/argo/tenants/{{tenant}}/mdata
 path_sync= hdfs://{{namenode}}/user/{{hdfs_user}}/argo/tenants/{{tenant}}/sync
+path_tenants= hdfs://{{namenode}}/user/{{hdfs_user}}/argo/tenants
 writer_bin= /home/root/hdfs
 
 [STREAMING]

--- a/conf/conf.template
+++ b/conf/conf.template
@@ -9,6 +9,8 @@ rollback_days: 3
 path_metric: {{namenode}}/user/{{hdfs_user}}/argo/tenants/{{tenant}}/mdata
 # hdfs path for sync data
 path_sync: {{namenode}}/user/{{hdfs_user}}/argo/tenants/{{tenant}}/sync
+# hdfs path for root folder were argo tenants reside
+path_tenants: {{namenode}}/user/{{hdfs_user}}/argo/tenants
 
 # hdfs writer executable
 writer_bin: /path/to/binary

--- a/conf/config.schema.json
+++ b/conf/config.schema.json
@@ -14,6 +14,11 @@
       "type": "template,uri",
       "default": "hdfs://{{namenode}}/user/{{hdfs_user}}/argo/tenants/{{tenant}}/sync"
     },
+    "path_tenants": {
+      "desc": "template for constructing the hdfs root path to where all tenants reside",
+      "type": "template,uri",
+      "default": "hdfs://{{namenode}}/user/{{hdfs_user}}/argo/tenants"
+    },
     "user": {
       "desc": "name of the hdfs user",
       "type": "string",


### PR DESCRIPTION
The latest implementations for the combined reports in the multijob jar require a new argument --basispath that is used for identifying the root folder in hdfs that holds all argo tenants. This must be set up in the cli script configuration and in the multijob submit script as well

- The argument is introduced in the configuration schema file that is used to validate if our argo-streaming.conf is valid
- The argument is introduced in the sample templates
- The argument is introduced in mutijob script itself as a parameter coming from the config file. If the user has provided a `--source-data` argument different from the `tenant` value this means that the computation will run in combined mode and will need to know the root folder of argo tenants in hdfs. Thus the path_tenants parameter from the config file is compiled to a proper final value (using the namenode and user values) and added to the list of arguments (as `--basispath`) that need to be passed on the jar itself