### PR TITLE
4282 Fix source-topo and source-data arguments to be optional

### DIFF
--- a/bin/multi_job_submit.py
+++ b/bin/multi_job_submit.py
@@ -171,11 +171,11 @@ def compose_command(config, args,  hdfs_commands, dry_run=False):
             cmd_command.append("OFF")
 
     # check if sources are defined
-    if "source_data" in args:
+    if args.source_data:
         cmd_command.append("--source-data")
         cmd_command.append(args.source_data)
 
-    if "source_topo" in args:
+    if args.source_topo:
         cmd_command.append("--source-topo")
         cmd_command.append(args.source_topo)
 

--- a/bin/test_multi_job_submit.py
+++ b/bin/test_multi_job_submit.py
@@ -36,6 +36,8 @@ class TestClass(unittest.TestCase):
         parser.add_argument('--method')
         parser.add_argument('--clear-prev-results',dest='clear_results',action='store_true')
         parser.add_argument('--calculate')
+        parser.add_argument('--source-data')
+        parser.add_argument('--source-topo')
         args = parser.parse_args(
             ['--tenant', 'TENANTA', '--date', '2018-02-11', '--report', 'report_name', '--method', 'upsert', '--sudo', '--clear-prev-results', '--calculate', 'trends'])
 


### PR DESCRIPTION
Don't pass `--source-data` and `--source-topo` arguments to the sumbit command if they are not present