### PR TITLE
ARGO-4312 Ingest performance data to timeseries database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ conf.cfg
 .project
 .settings/
 /flink_jobs_v3/HdfsFileMerger/target/
+/flink_jobs_v2/influxdb.connector/target/

--- a/flink_jobs_v2/ams-connector/src/main/java/ams/connector/ArgoMessagingClient.java
+++ b/flink_jobs_v2/ams-connector/src/main/java/ams/connector/ArgoMessagingClient.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import java.util.Base64;
 

--- a/flink_jobs_v2/ams_ingest_metric/pom.xml
+++ b/flink_jobs_v2/ams_ingest_metric/pom.xml
@@ -59,6 +59,13 @@ language governing permissions and limitations under the License. -->
     handling. This approach is preferred and leads to much cleaner jar files. -->
 
     <dependencies>
+          <dependency>
+            <groupId>profiles.manager</groupId>
+            <artifactId>ProfilesManager</artifactId>
+            <version>2.1.2</version>
+            <type>jar</type>
+        </dependency>
+      
             
         <dependency>
             <groupId>ams.connector</groupId>
@@ -124,6 +131,24 @@ language governing permissions and limitations under the License. -->
             <version>4.5.13</version>
         </dependency>
 
+      <dependency>
+            <groupId>com.influxdb</groupId>
+            <artifactId>influxdb-client-java</artifactId>
+            <version>6.8.0</version>
+        </dependency>
+        <dependency>
+            <groupId>flink.jobs.v2</groupId>
+            <artifactId>influxdb.connector</artifactId>
+            <version>2.1.2</version>
+            <type>jar</type>
+        </dependency>
+      
+        <dependency>
+            <groupId>api.resource.manager</groupId>
+            <artifactId>ApiResourceManager</artifactId>
+            <version>2.1.2</version>
+            <type>jar</type>
+        </dependency>
 
 
 

--- a/flink_jobs_v2/ams_ingest_metric/src/main/java/argo/streaming/ArgoApiSource.java
+++ b/flink_jobs_v2/ams_ingest_metric/src/main/java/argo/streaming/ArgoApiSource.java
@@ -1,0 +1,144 @@
+package argo.streaming;
+import argo.amr.ApiResource;
+import argo.amr.ApiResourceManager;
+import java.time.Duration;
+import java.time.Instant;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+/**
+ * Custom source to connect to ArgoWebApi service. Uses API Resource Manager
+ */
+public class ArgoApiSource extends RichSourceFunction<Tuple2<String,String>> {
+
+	private static final long serialVersionUID = 1L;
+
+	// setup logger
+	static Logger LOG = LoggerFactory.getLogger(ArgoApiSource.class);
+
+	private String endpoint = null;
+	private String token = null;
+	private String reportID = null;
+	private int hourCheck = 24;
+	private long interval = 100L;
+	private boolean verify = true;
+	private boolean useProxy = false;
+	private String proxyURL = "";
+	private transient Object rateLck; // lock for waiting to establish rate
+
+	private volatile boolean isRunning = true;
+
+    private ApiResourceManager client = null;
+	private Instant timeSnapshot = null;
+	
+	
+
+
+
+	public ArgoApiSource(String endpoint, String token, String reportID, int hourCheck,  Long interval) {
+		this.endpoint = endpoint;
+		this.token = token;
+		this.reportID = reportID;
+		this.hourCheck = hourCheck;
+		this.interval = interval;
+		this.verify = true;
+
+	}
+
+	/**
+	 * Set verify to true or false. If set to false AMS client will be able to contact AMS endpoints that use self-signed certificates
+	 */
+	public void setVerify(boolean verify) {
+		this.verify=verify;
+	}
+	/**
+	 * Set proxy details for AMS client
+	 */
+	public void setProxy(String proxyURL) {
+		this.useProxy = true;
+		this.proxyURL = proxyURL;
+	}
+	
+	/**
+	 * Unset proxy details for AMS client
+	 */
+	public void unsetProxy(String proxyURL) {
+		this.useProxy = false;
+		this.proxyURL = "";
+	}
+	
+	
+	@Override
+	public void cancel() {
+		isRunning = false;
+
+	}
+
+	@Override
+	public void run(SourceContext<Tuple2<String,String>> ctx) throws Exception {
+		// This is the main run logic
+		while (isRunning) {
+			
+			// check if interval in hours has passed to make a move
+			Instant ti = Instant.now();
+			Duration td = Duration.between(this.timeSnapshot,ti);
+			// interval has passed do consume from api
+			if (td.toHours() > this.hourCheck) {
+				this.timeSnapshot = ti;
+				// retrieve info from api
+				this.client.getRemoteAll();
+
+				Tuple2<String, String> mt = new Tuple2<String, String>("metric_profile",client.getResourceJSON(ApiResource.METRIC));
+				Tuple2<String, String> gt = new Tuple2<String, String>("group_endpoints",client.getResourceJSON(ApiResource.TOPOENDPOINTS));
+				Tuple2<String, String> dt = new Tuple2<String, String>("downtimes",client.getResourceJSON(ApiResource.DOWNTIMES));
+				
+				ctx.collect(mt);
+				ctx.collect(gt);
+				ctx.collect(dt);
+				
+				
+
+			}
+			synchronized (rateLck) {
+				rateLck.wait(this.interval);
+			}
+
+		}
+
+	}
+
+	/**
+	 * Argo-web-api Source initialization
+	 */
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		// init rate lock
+		rateLck = new Object();
+		
+		
+		this.timeSnapshot = Instant.now();
+		
+		this.client = new ApiResourceManager(this.endpoint, this.token);
+		client.setReportID(this.reportID);
+		client.setVerify(this.verify);
+		if (this.useProxy) {
+			client.setProxy(this.proxyURL);
+		}
+		
+		
+	}
+
+	@Override
+	public void close() throws Exception {
+		if (this.client != null) {
+			this.client = null;
+		}
+		synchronized (rateLck) {
+			rateLck.notify();
+		}
+	}
+
+}

--- a/flink_jobs_v2/ams_ingest_metric/src/main/java/argo/streaming/IntervalType.java
+++ b/flink_jobs_v2/ams_ingest_metric/src/main/java/argo/streaming/IntervalType.java
@@ -1,0 +1,12 @@
+package argo.streaming;
+
+public enum IntervalType {
+
+    DAY("d"),
+    HOURS("h"), MINUTES("m");
+    public final String value;
+
+    private IntervalType(String value) {
+        this.value = value;
+    }
+}

--- a/flink_jobs_v2/ams_ingest_metric/src/main/java/argo/streaming/PerformanceDataFlatMap.java
+++ b/flink_jobs_v2/ams_ingest_metric/src/main/java/argo/streaming/PerformanceDataFlatMap.java
@@ -1,0 +1,136 @@
+package argo.streaming;
+
+import argo.avro.MetricData;
+import com.influxdb.client.domain.WritePrecision;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple8;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+import com.influxdb.client.write.Point;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * PerformanceDataFlatMap implements a map function that creates InfluxDB
+ * Points, that keeps the information for performance, generated from the actual
+ * data MetricData includes
+ */
+public class PerformanceDataFlatMap extends RichFlatMapFunction< Tuple2<String, MetricData>, Point> {
+
+    private static final long serialVersionUID = 1L;
+    static Logger LOG = LoggerFactory.getLogger(PerformanceDataFlatMap.class);
+
+    public PerformanceDataFlatMap() {
+    }
+
+    /**
+     * Initializes constructs in the beginning of operation
+     *
+     * @param parameters Configuration parameters to initialize structures
+     * @throws URISyntaxException
+     */
+    @Override
+    public void open(Configuration parameters) throws IOException, ParseException, URISyntaxException {
+
+    }
+
+    //FlatMap to retrieve actual data from MetricData , parse them and create the Point expressing performance data , to be written in influxdb
+      @Override
+    public void flatMap(Tuple2<String, MetricData> in, Collector<Point> out) throws Exception {
+
+        ArrayList<Tuple8> tuples = parsePerformanceData(in.f0, in.f1); //parsing MetricData to retrieve actual data and the info representing performance
+        for (Tuple8<String, String, String, String, String, String, String, String> tuple : tuples) {
+
+            HashMap<String, String> tags = new HashMap<>();
+            tags.put("group", tuple.f2);
+            tags.put("service", tuple.f3);
+            tags.put("endpoint", tuple.f4);
+            tags.put("metric", tuple.f5);
+
+            HashMap<String, Object> fields = new HashMap<>();
+            fields.put("value", tuple.f6);
+            fields.put("unit", tuple.f7);
+            String format = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+
+            SimpleDateFormat sdf = new SimpleDateFormat(format);
+            sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = sdf.parse(tuple.f1);
+         
+            Point p = Point.measurement(tuple.f0).time(date.getTime(), WritePrecision.MS).addTags(tags).addFields(fields);
+            out.collect(p);
+        }
+    }
+
+    
+    private static ArrayList<Tuple8> parsePerformanceData(String group, MetricData item) {
+
+        ArrayList<Tuple8> list = new ArrayList<>();
+        String timestamp = item.getTimestamp();
+        String service = item.getService();
+        String hostname = item.getHostname();
+        String metric = item.getMetric();
+
+        String actualData = item.getActualData();
+        if(actualData==null){
+        return new ArrayList<>();
+        }
+        ArrayList<PerformanceValue> performanceValues = splitActualData(actualData);//splits the actual data string to retrieve the info about performace data
+
+        for (PerformanceValue val : performanceValues) {
+
+            Tuple8<String, String, String, String, String, String, Float, String> perfData = new Tuple8<String, String, String, String, String, String, Float, String>(
+                    val.label, timestamp, group, service, hostname, metric, val.value, val.unit);
+            list.add(perfData);
+        }
+        return list;
+    }
+
+    private static ArrayList<PerformanceValue> splitActualData(String initialString) {
+
+        //example :"time=2.227776s;;;0.000000 size=69485B;;;0"
+
+        String[] actualDataSplit = initialString.split(" "); //splits on " " to retrieve the various performance entities (e.g time,size)
+        ArrayList<PerformanceValue> perfValueList = new ArrayList<>();
+        for (String actualData : actualDataSplit) { //for each performance entity e.g time=2.227776s;;;0.000000
+            String[] labelSplit = actualData.split("="); //split on "=" to seperate the name and the values 
+            String label = labelSplit[0]; // the first part is the name of the entity e.g time
+            if(label.equals("time")){
+             String[] values = labelSplit[1].split(";"); //the second part contains the value-unit and the min,max limits e.g 2.227776s;;;0.000000. we split on ; to get the value-unit
+            String value = values[0]; //gets the value-unit e.g  2.227776s
+             
+            String unit = value.replaceAll("[^A-Za-z]", ""); //we recognize the unit by the alpharithmetic part e.g s
+            String numericVal = value.replaceAll("[^0-9]", ""); //we recognize the value by the numeric part e.g 2.227776
+            Float floatVal=Float.valueOf(numericVal);
+            PerformanceValue perfValue = new PerformanceValue(label, floatVal, unit); // we keep the performance entity as name,value,unit e.g [time,2.227776,s]
+            perfValueList.add(perfValue);
+            }
+        }
+        return perfValueList;
+
+    }
+
+  
+    private static class PerformanceValue {
+
+        private String label;
+        private Float value;
+        private String unit;
+
+        public PerformanceValue(String label, Float value, String unit) {
+            this.label = label;
+            this.value = value;
+            this.unit = unit;
+        }
+
+    }
+
+}

--- a/flink_jobs_v2/ams_ingest_metric/src/main/java/argo/streaming/StatusConfig.java
+++ b/flink_jobs_v2/ams_ingest_metric/src/main/java/argo/streaming/StatusConfig.java
@@ -1,0 +1,103 @@
+package argo.streaming;
+
+import java.io.Serializable;
+
+import org.apache.flink.api.java.utils.ParameterTool;
+
+public class StatusConfig implements Serializable {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = 1L;
+    public String runDate;
+
+    // Ams parameters
+    public String amsHost;
+    public String amsPort;
+    public String amsToken;
+    public String amsProject;
+    public String amsSub;
+
+    // Avro schema
+    public String avroSchema;
+
+    public String report;
+
+    public String apiEndpoint;
+    public String apiToken;
+    public String apiProxy;
+    public Boolean apiVerify = false;
+    public int hourCheck = 24;
+    public String reportID;
+    public long interval = 100L;
+
+    // Sync files
+    public String aps;
+    public String mps;
+    public String egp;
+    public String ops;
+    public String downtime;
+    // Parameter used in alert timeouts for notifications
+    public long timeout;
+    // Parameter used for daily event generation (not used in notifications)
+    public boolean daily;
+    // Parameter used to initialize a status to a default value (OK optimistically, MISSING pessimistically)
+    public String initStatus;
+
+    // Raw parameters
+    public final ParameterTool pt;
+
+    public StatusConfig(ParameterTool pt) {
+        this.pt = pt;
+
+        this.amsHost = pt.getRequired("ams.endpoint");
+        this.amsPort = pt.get("ams.port");
+        this.amsToken = pt.getRequired("ams.token");
+        this.amsProject = pt.getRequired("ams.project");
+        this.apiEndpoint = pt.getRequired("api.endpoint");
+
+        this.runDate = pt.get("run.date");
+        this.report = pt.getRequired("report");
+        // Optional timeout parameter
+        if (pt.has("timeout")) {
+            this.timeout = pt.getLong("timeout");
+        } else {
+            this.timeout = 86400000L;
+        }
+
+        // optional cli parameter to configure default status
+        if (pt.has("init.status")) {
+            this.initStatus = pt.get("init.status");
+        } else {
+            // by default, default initial status should be optimistically OK
+            this.initStatus = "OK";
+        }
+
+        // Optional set daily parameter
+        this.apiEndpoint = pt.getRequired("api.endpoint");
+        this.apiToken = pt.getRequired("api.token");
+        this.reportID = pt.getRequired("report.uuid");
+
+        if (pt.has("proxy")) {
+            this.apiProxy = pt.get("proxy", "");
+        }
+        if (pt.has("api.verify")) {
+            this.apiVerify = pt.getBoolean("api.verify", false);
+        }
+        if (pt.has("api.interval")) {
+            this.hourCheck = pt.getInt("api.interval", 24);
+        }
+        if (pt.has("ams.interval")) {
+            this.interval = pt.getLong("interval", 100L);
+        }
+
+        this.daily = pt.getBoolean("daily", false);
+
+    }
+
+    public ParameterTool getParameters() {
+        return this.pt;
+    }
+
+}

--- a/flink_jobs_v2/ams_ingest_metric/src/main/java/argo/streaming/SyncParse.java
+++ b/flink_jobs_v2/ams_ingest_metric/src/main/java/argo/streaming/SyncParse.java
@@ -1,0 +1,180 @@
+package argo.streaming;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.Map.Entry;
+
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.specific.SpecificData;
+import org.apache.avro.specific.SpecificDatumReader;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import argo.avro.Downtime;
+import argo.avro.GroupEndpoint;
+import argo.avro.MetricProfile;
+
+
+/**
+ * SyncParse is a utility class providing methods to parse specific connector data in avro format
+ */
+public class SyncParse {
+	
+	/**
+	 * Parses a byte array and decodes avro GroupEndpoint objects
+	 */
+	public static ArrayList<GroupEndpoint> parseGroupEndpoint(byte[] avroBytes) throws IOException{
+		
+		ArrayList<GroupEndpoint> result = new ArrayList<GroupEndpoint>();
+		
+		DatumReader<GroupEndpoint> avroReader = new SpecificDatumReader<GroupEndpoint>(GroupEndpoint.getClassSchema(),GroupEndpoint.getClassSchema(),new SpecificData());
+		BinaryDecoder decoder = DecoderFactory.get().binaryDecoder(avroBytes, null);
+		
+		while (!decoder.isEnd()){
+			GroupEndpoint cur = avroReader.read(null, decoder);
+			result.add(cur);
+		}
+		
+		return result;
+	}
+	
+	/**
+	 * Parses a byte array and decodes avro MetricProfile objects
+	 */
+	public static ArrayList<MetricProfile> parseMetricProfile(byte[] avroBytes) throws IOException{
+		
+		ArrayList<MetricProfile> result = new ArrayList<MetricProfile>();
+		
+		DatumReader<MetricProfile> avroReader = new SpecificDatumReader<MetricProfile>(MetricProfile.getClassSchema(),MetricProfile.getClassSchema(),new SpecificData());
+		BinaryDecoder decoder = DecoderFactory.get().binaryDecoder(avroBytes, null);
+		
+		while (!decoder.isEnd()){
+			MetricProfile cur = avroReader.read(null, decoder);
+			result.add(cur);
+		}
+		
+		return result;
+	}
+	
+	/**
+	 * Parses a byte array and decodes avro Downtime objects
+	 */
+	public static ArrayList<Downtime> parseDowntimes(byte[] avroBytes) throws IOException{
+		
+		ArrayList<Downtime> result = new ArrayList<Downtime>();
+		
+		DatumReader<Downtime> avroReader = new SpecificDatumReader<Downtime>(Downtime.getClassSchema(),Downtime.getClassSchema(),new SpecificData());
+		BinaryDecoder decoder = DecoderFactory.get().binaryDecoder(avroBytes, null);
+		
+		while (!decoder.isEnd()){
+			Downtime cur = avroReader.read(null, decoder);
+			result.add(cur);
+		}
+		
+		return result;
+	}
+	
+	/**
+	 * Parses attributes from a json attribute element
+	 */
+	public static Map<String,String> parseAttributes(JsonElement jAttr) throws IOException{
+		
+		Map<String,String> result = new HashMap<String,String>();
+		if (jAttr!=null){
+			Set<Entry<String, JsonElement>> jItems = jAttr.getAsJsonObject().entrySet();
+			
+			for (Entry<String, JsonElement> jItem : jItems){
+				result.put(jItem.getKey(), jItem.getValue().getAsString());
+			}
+		}
+		
+		return result;
+	}
+	
+	public static ArrayList<MetricProfile> parseMetricJSON(String content) {
+		ArrayList<MetricProfile> results = new ArrayList<MetricProfile>();
+
+		
+		JsonParser jsonParser = new JsonParser();
+		JsonElement jElement = jsonParser.parse(content);
+		JsonObject jRoot = jElement.getAsJsonObject();
+		String profileName = jRoot.get("name").getAsString();
+		JsonArray jElements = jRoot.get("services").getAsJsonArray();
+		for (int i = 0; i < jElements.size(); i++) {
+			JsonObject jItem= jElements.get(i).getAsJsonObject();
+			String service = jItem.get("service").getAsString();
+			JsonArray jMetrics = jItem.get("metrics").getAsJsonArray();
+			for (int j=0; j < jMetrics.size(); j++) {
+				String metric = jMetrics.get(j).getAsString();
+				
+				Map<String,String> tags = new HashMap<String,String>();
+				MetricProfile mp = new MetricProfile(profileName,service,metric,tags);
+				results.add(mp);
+			}
+			
+		}
+		
+		return results;
+	}
+	
+	public static ArrayList<Downtime> parseDowntimesJSON (String content) {
+		
+		ArrayList<Downtime> results = new ArrayList<Downtime>();
+		
+		JsonParser jsonParser = new JsonParser();
+		JsonElement jElement = jsonParser.parse(content);
+		JsonObject jRoot = jElement.getAsJsonObject();
+		JsonArray jElements = jRoot.get("endpoints").getAsJsonArray();
+		for (int i = 0; i < jElements.size(); i++) {
+			JsonObject jItem= jElements.get(i).getAsJsonObject();
+			String hostname = jItem.get("hostname").getAsString();
+			String service = jItem.get("service").getAsString();
+			String startTime = jItem.get("start_time").getAsString();
+			String endTime = jItem.get("end_time").getAsString();
+			
+			Downtime d = new Downtime(hostname,service,startTime,endTime);
+			results.add(d);
+		}
+		
+		return results;
+		
+	}
+	
+	public static ArrayList<GroupEndpoint> parseGroupEndpointJSON (String content) {
+		
+		ArrayList<GroupEndpoint> results = new ArrayList<GroupEndpoint>();
+		
+		JsonParser jsonParser = new JsonParser();
+		JsonElement jElement = jsonParser.parse(content);
+		JsonArray jRoot = jElement.getAsJsonArray();
+		for (int i = 0; i < jRoot.size(); i++) {
+			JsonObject jItem= jRoot.get(i).getAsJsonObject();
+			String group = jItem.get("group").getAsString();
+			String gType = jItem.get("type").getAsString();
+			String service = jItem.get("service").getAsString();
+			String hostname = jItem.get("hostname").getAsString();
+			JsonObject jTags = jItem.get("tags").getAsJsonObject();
+			Map<String,String> tags = new HashMap<String,String>();
+		    for ( Entry<String, JsonElement> kv : jTags.entrySet()) {
+		    	tags.put(kv.getKey(), kv.getValue().getAsString());
+		    }
+			GroupEndpoint ge = new GroupEndpoint(gType,group,service,hostname,tags);
+			results.add(ge);
+		}
+		
+		return results;
+		
+	}
+	
+	
+	
+
+}

--- a/flink_jobs_v2/influxdb.connector/pom.xml
+++ b/flink_jobs_v2/influxdb.connector/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>flink.jobs.v2</groupId>
+        <artifactId>flink_jobs_v2</artifactId>
+        <version>2.1.2</version>
+    </parent>
+    <artifactId>influxdb.connector</artifactId>
+    <packaging>jar</packaging>
+    <properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<flink.version>1.3.2</flink.version>
+		<slf4j.version>1.7.7</slf4j.version>
+		<log4j.version>1.2.17</log4j.version>
+		<scala.binary.version>2.10</scala.binary.version>
+     
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.influxdb</groupId>
+            <artifactId>influxdb-client-java</artifactId>
+            <version>6.8.0</version>
+        </dependency>
+
+        <!-- Apache Flink dependencies -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-java</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java_2.10</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients_2.10</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/flink_jobs_v2/influxdb.connector/src/main/java/influxdb/connector/InfluxConnection.java
+++ b/flink_jobs_v2/influxdb.connector/src/main/java/influxdb/connector/InfluxConnection.java
@@ -1,0 +1,83 @@
+package influxdb.connector;
+
+import com.influxdb.client.InfluxDBClient;
+import com.influxdb.client.InfluxDBClientFactory;
+import com.influxdb.client.InfluxDBClientOptions;
+import com.influxdb.client.WriteApiBlocking;
+import com.influxdb.client.write.Point;
+import com.influxdb.exceptions.InfluxException;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.UnknownHostException;
+import javax.net.ssl.SSLSession;
+import okhttp3.OkHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author cthermolia
+ */
+public class InfluxConnection {
+
+    static Logger LOG = LoggerFactory.getLogger(InfluxConnection.class);
+
+    public InfluxConnection() {
+    }
+
+    public InfluxDBClient buildConnection(String url, String token, String org, String bucket, String proxy, int proxyport) throws UnknownHostException {
+        InfluxDBClient cl = null;
+        //try {
+        InfluxDBClientOptions options = null;
+        if (proxy != null) {
+         
+            Proxy proxyHost = new Proxy(Proxy.Type.HTTP,new InetSocketAddress(proxy, proxyport));
+            OkHttpClient.Builder okHttpBuilder = new OkHttpClient.Builder()
+                    .proxy(proxyHost);
+
+            if (okHttpBuilder == null) {
+                throw new NullPointerException();
+            }
+
+            options = InfluxDBClientOptions.builder()
+                    .url(url)
+                    .bucket(bucket)
+                    .org(org)
+                    .authenticateToken(token.toCharArray())
+                    .okHttpClient(okHttpBuilder)
+                    .build();
+            
+        } else {
+            options = InfluxDBClientOptions.builder()
+                    .url(url)
+                    .bucket(bucket)
+                    .org(org)
+                    .authenticateToken(token.toCharArray())
+                    .build();
+
+        }
+        cl = InfluxDBClientFactory.create(options);
+        
+       
+
+        if (cl == null) {
+            throw new NullPointerException("ERROR: InfluxDBClient is null ");
+        }
+        return cl;
+    }
+
+    public boolean singlePointWrite(InfluxDBClient client, Point point) {
+        boolean flag = false;
+       try {
+        WriteApiBlocking writeApi = client.getWriteApiBlocking();
+        writeApi.writePoint(point);
+        flag = true;
+        } catch (InfluxException e) {
+            LOG.error("ERROR WRITE TO INFLUX" + e.getMessage());
+        }
+        return flag;
+    }
+
+}

--- a/flink_jobs_v2/influxdb.connector/src/main/java/influxdb/connector/InfluxDBSink.java
+++ b/flink_jobs_v2/influxdb.connector/src/main/java/influxdb/connector/InfluxDBSink.java
@@ -1,0 +1,186 @@
+package influxdb.connector;
+
+import com.influxdb.client.InfluxDBClient;
+import com.influxdb.client.write.Point;
+import java.io.Serializable;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/*
+InfluxDBSink implements a sink to write streams into influx db. 
+To connect the following parameters are necessary
+
+* --influx.endpoint, the endpoint to connect to influx db
+* --influx.port, the port to connecto to influx db
+* --influx.token, the token to authorize access to influx db
+* --influx.org, the influx organisation to connect
+* --influx.bucket, the influx organisation bucket to write stream data
+* --influx.proxy(OPTIONAL), the proxy hostname to connect. If no proxy is needed the parameter can be undefined
+* --influx.proxyport(OPTIONAL) the proxy port to connect. If no proxy is needed the parameter can be undefined 
+ */
+public class InfluxDBSink extends RichSinkFunction<Point> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    // setup logger
+    static Logger LOG = LoggerFactory.getLogger(InfluxDBSink.class);
+
+    private String url = null;
+    private String endpoint = null;
+    private String port = null;
+    private String token = null;
+    private String bucket = null;
+    private String org = null;
+    private transient int batch = 1;
+    private transient long interval = 100L;
+    private transient boolean verify = true;
+    private transient boolean useProxy = false;
+    private transient String proxyURL = "";
+    private transient int proxyPORT;
+    private transient String date;
+    private transient InfluxDBClient client;
+    private transient InfluxConnection connection;
+    private ParameterTool params;
+
+    public InfluxDBSink(ParameterTool params) {
+
+        this.params = params;
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+
+        endpoint = this.params.get("influx.endpoint");
+        port = this.params.get("influx.port");
+        token = this.params.get("influx.token");
+        org = this.params.get("influx.org");
+        bucket = this.params.get("influx.bucket");
+        proxyURL = this.params.get("influx.proxy");
+        if (this.params.has("influx.proxyport")) {
+            proxyPORT = this.params.getInt("influx.proxyport");
+        }
+        url = endpoint + ":" + port;
+
+        try {
+            connection = new InfluxConnection();
+        } catch (NullPointerException e) {
+            LOG.error("influx db connection does not exist");
+        }
+
+        client = connection.buildConnection(url, token, org, bucket, proxyURL, proxyPORT);
+    }
+
+    @Override
+    public void invoke(Point in) throws Exception {
+        this.connection.singlePointWrite(client, in);
+        //  this.connection.deleteRecord(client);
+
+    }
+
+    @Override
+    public void close() throws Exception {
+
+        this.client.close();
+
+    }
+
+    public static Logger getLOG() {
+        return LOG;
+    }
+
+    public static void setLOG(Logger LOG) {
+        InfluxDBSink.LOG = LOG;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public String getPort() {
+        return port;
+    }
+
+    public void setPort(String port) {
+        this.port = port;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public String getBucket() {
+        return bucket;
+    }
+
+    public void setBucket(String bucket) {
+        this.bucket = bucket;
+    }
+
+    public String getOrg() {
+        return org;
+    }
+
+    public void setOrg(String org) {
+        this.org = org;
+    }
+
+    public int getBatch() {
+        return batch;
+    }
+
+    public void setBatch(int batch) {
+        this.batch = batch;
+    }
+
+    public long getInterval() {
+        return interval;
+    }
+
+    public void setInterval(long interval) {
+        this.interval = interval;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public void setDate(String date) {
+        this.date = date;
+    }
+
+    public InfluxDBClient getClient() {
+        return client;
+    }
+
+    public void setClient(InfluxDBClient client) {
+        this.client = client;
+    }
+
+    public InfluxConnection getConnection() {
+        return connection;
+    }
+
+    public void setConnection(InfluxConnection connection) {
+        this.connection = connection;
+    }
+
+}

--- a/flink_jobs_v2/pom.xml
+++ b/flink_jobs_v2/pom.xml
@@ -20,6 +20,7 @@
          <module>ams_ingest_metric</module>         
          <module>ams_ingest_sync</module>
         <module>ams-connector</module>
+        <module>influxdb.connector</module>
     </modules>
     <dependencyManagement>
         <dependencies>

--- a/flink_jobs_v2/stream_status/pom.xml
+++ b/flink_jobs_v2/stream_status/pom.xml
@@ -69,6 +69,8 @@ language governing permissions and limitations under the License. -->
             <version>2.1.2</version>
             <type>jar</type>
         </dependency>
+       
+       
         <dependency>
             <groupId>api.resource.manager</groupId>
             <artifactId>ApiResourceManager</artifactId>
@@ -150,7 +152,7 @@ language governing permissions and limitations under the License. -->
             <version>1.4</version>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/xerces/xercesImpl -->
+        <!-- https:/mvnrepository.com/artifact/xerces/xercesImpl -->
         <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
@@ -174,7 +176,7 @@ language governing permissions and limitations under the License. -->
             <artifactId>joda-time</artifactId>
             <version>1.6</version>
         </dependency>
-        
+         
     </dependencies>
 
     <profiles>

--- a/flink_jobs_v2/stream_status/src/main/java/argo/avro/MetricData.java
+++ b/flink_jobs_v2/stream_status/src/main/java/argo/avro/MetricData.java
@@ -5,8 +5,6 @@
  */
 package argo.avro;
 
-import org.apache.avro.specific.SpecificData;
-
 @SuppressWarnings("all")
 @org.apache.avro.specific.AvroGenerated
 public class MetricData extends org.apache.avro.specific.SpecificRecordBase implements org.apache.avro.specific.SpecificRecord {

--- a/flink_jobs_v2/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
+++ b/flink_jobs_v2/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
@@ -55,9 +55,7 @@ import org.apache.flink.core.fs.FileSystem;
 import org.slf4j.MDC;
 import profilesmanager.EndpointGroupManager;
 import profilesmanager.MetricProfileManager;
-import profilesmanager.ReportManager;
 import status.StatusManager;
-
 /**
  * Flink Job : Streaming status computation with multiple destinations (hbase,
  * kafka, fs) job required cli parameters --ams.endpoint : ARGO messaging api
@@ -142,6 +140,7 @@ public class AmsStreamStatus {
         return hasArgs(kafkaArgs, paramTool);
     }
 
+   
     public static boolean hasHbaseArgs(ParameterTool paramTool) {
         String hbaseArgs[] = {"hbase.master", "hbase.master.port", "hbase.zk.quorum", "hbase.namespace",
             "hbase.table"};
@@ -258,6 +257,8 @@ public class AmsStreamStatus {
         if(parameterTool.has("latest.offset") && !parameterTool.getBoolean("latest.offset")){
          offsetDt=runDate;
         }
+        
+       
         ArgoMessagingSource amsMetric = new ArgoMessagingSource(endpoint, port, token, project, subMetric, batch, interval, offsetDt);
         ArgoApiSource apiSync = new ArgoApiSource(apiEndpoint, apiToken, reportID, apiInterval, interval);
 
@@ -457,14 +458,15 @@ public class AmsStreamStatus {
             // generate events and get them
             String service = item.getService();
             String hostname = item.getHostname();
-
+            
             ArrayList<String> groups = egp.getGroup(hostname, service);
             //System.out.println(egp.getList());
-
             for (String groupItem : groups) {
                 Tuple2<String, MetricData> curItem = new Tuple2<String, MetricData>();
+                
                 curItem.f0 = groupItem;
                 curItem.f1 = item;
+                 
                 out.collect(curItem);
                 System.out.println("item enriched: " + curItem.toString());
             }
@@ -898,4 +900,6 @@ public class AmsStreamStatus {
         }
     }
 
-}
+        
+        
+    }


### PR DESCRIPTION
Containing influxdb connector, creating a sink to the influxdb
Creating performance data from actual data, of the MetricData stream and writing them as Points to influxdb

This PR is tested on a local instance of InfluxDB, so it remains as work in progress until we test to the [timeseriesdb.devel.argo.grnet.gr](http://timeseriesdb.devel.argo.grnet.gr/)