### PR TITLE
ARGO-4337 Handle issue for not existing service in Aggregation Profiles

### DIFF
--- a/flink_jobs_v2/batch_multi/src/main/java/argo/batch/ArgoMultiJob.java
+++ b/flink_jobs_v2/batch_multi/src/main/java/argo/batch/ArgoMultiJob.java
@@ -303,7 +303,8 @@ public class ArgoMultiJob {
         // Use yesterday's latest statuses and todays data to find the missing ones and add them to the mix
         DataSet<StatusMetric> fillMissDS = allMetricData.reduceGroup(new FillMissing(params))
                 .withBroadcastSet(mpsDS, "mps").withBroadcastSet(egpDS, "egp").withBroadcastSet(ggpDS, "ggp")
-                .withBroadcastSet(opsDS, "ops").withBroadcastSet(confDS, "conf").withBroadcastSet(nempsDS, "nemps");
+                .withBroadcastSet(opsDS, "ops").withBroadcastSet(confDS, "conf").withBroadcastSet(nempsDS, "nemps")
+                .withBroadcastSet(apsDS, "aps");
 
         // Discard unused data and attach endpoint group as information
         DataSet<StatusMetric> mdataTrimDS = allMetricData.flatMap(new PickEndpoints(params))

--- a/flink_jobs_v2/batch_multi/src/main/java/argo/batch/CalcServiceTimeline.java
+++ b/flink_jobs_v2/batch_multi/src/main/java/argo/batch/CalcServiceTimeline.java
@@ -72,14 +72,14 @@ public class CalcServiceTimeline extends RichGroupReduceFunction<StatusTimeline,
         String service = "";
         String endpointGroup = "";
         String function = "";
-        HashMap<String, Timeline> timelinelist = new HashMap<String,Timeline>();
+        HashMap<String, Timeline> timelinelist = new HashMap<String, Timeline>();
         boolean hasThr = false;
         for (StatusTimeline item : in) {
             service = item.getService();
             endpointGroup = item.getGroup();
             function = item.getFunction();
             ArrayList<TimeStatus> timestatusList = item.getTimestamps();
-            TreeMap<DateTime, Integer> samples = new TreeMap<DateTime,Integer>();
+            TreeMap<DateTime, Integer> samples = new TreeMap<DateTime, Integer>();
             for (TimeStatus timestatus : timestatusList) {
                 DateTime dt = new DateTime(timestatus.getTimestamp(), DateTimeZone.UTC);
                 samples.put(dt, timestatus.getStatus());
@@ -92,9 +92,14 @@ public class CalcServiceTimeline extends RichGroupReduceFunction<StatusTimeline,
                 hasThr = true;
             }
         }
-         
+
         String operation = serviceFunctionsMap.get(service);
-        TimelineAggregator timelineAggregator = new TimelineAggregator(timelinelist,this.opsMgr.getDefaultExcludedInt(),runDate);
+        if (operation == null) {
+            throw new RuntimeException("Operation for group:" + endpointGroup + " service: " + service + " does not exist. Check Aggregation Profiles");
+
+        }
+
+        TimelineAggregator timelineAggregator = new TimelineAggregator(timelinelist, this.opsMgr.getDefaultExcludedInt(), runDate);
         timelineAggregator.aggregate(this.opsMgr.getTruthTable(), this.opsMgr.getIntOperation(operation));
 
         Timeline mergedTimeline = timelineAggregator.getOutput(); //collect all timelines that correspond to the group service endpoint group , merge them in order to create one timeline

--- a/flink_jobs_v2/batch_multi/src/test/java/argo/batch/ArgoMultiJobTest.java
+++ b/flink_jobs_v2/batch_multi/src/test/java/argo/batch/ArgoMultiJobTest.java
@@ -193,7 +193,8 @@ public class ArgoMultiJobTest {
         //***************************Test FillMIssing
         DataSet<StatusMetric> fillMissDS = mdataPrevTotalDS.reduceGroup(new FillMissing(params))
                 .withBroadcastSet(mpsDS, "mps").withBroadcastSet(egpDS, "egp").withBroadcastSet(ggpDS, "ggp")
-                .withBroadcastSet(opsDS, "ops").withBroadcastSet(cfgDS, "conf").withBroadcastSet(nempsDS, "nemps");
+                .withBroadcastSet(opsDS, "ops").withBroadcastSet(cfgDS, "conf").withBroadcastSet(nempsDS, "nemps")
+                .withBroadcastSet(apsDS, "aps");
 
         URL expFillMissdataURL = ArgoMultiJobTest.class.getResource("/test/fillmissing.json");
         DataSet<String> fillMissString = env.readTextFile(expFillMissdataURL.toString());


### PR DESCRIPTION
This PR includes a fix for the issue arising for not finding services in aggregation profile, as a result of a mismatch between metric and aggregation profiles
We try catch the null exception , for null operation of the service not found in aggregation profiles and we LOG an error message