### PR TITLE
ARGO-4732 Investigate potential issue with downtimes end and prolongue within same day

### DIFF
--- a/flink_jobs_v2/ProfilesManager/src/main/java/profilesmanager/DowntimeManager.java
+++ b/flink_jobs_v2/ProfilesManager/src/main/java/profilesmanager/DowntimeManager.java
@@ -52,9 +52,9 @@ public class DowntimeManager {
             this.endTime = endTime;
         }
 
-        public String toString(){
-			return String.format("(%s,%s,%s,%s)",hostname,service,startTime,endTime);
-		}
+        public String toString() {
+            return String.format("(%s,%s,%s,%s)", hostname, service, startTime, endTime);
+        }
 
     }
 
@@ -76,22 +76,23 @@ public class DowntimeManager {
      * Returns the downtime period (if any) for a specific service endpoint:
      * (hostname,service)
      */
-    public ArrayList<String> getPeriod(String hostname, String service) {
+    public ArrayList<String[]> getPeriod(String hostname, String service) {
 
-        ArrayList<String> period = new ArrayList<String>();
+        ArrayList<String[]> periods = new ArrayList<String[]>();
 
         for (DowntimeItem item : this.list) {
 
             if (item.hostname.equals(hostname)) {
                 if (item.service.equals(service)) {
-                    period.add(item.startTime);
-                    period.add(item.endTime);
-                    return period;
+                    String[] period = new String[2];
+                    period[0] = item.startTime;
+                    period[1] = item.endTime;
+                    periods.add(period);
+
                 }
             }
         }
-
-        return null;
+        return periods;
 
     }
 

--- a/flink_jobs_v2/ProfilesManager/src/test/java/profilesmanager/DowntimeManagerTest.java
+++ b/flink_jobs_v2/ProfilesManager/src/test/java/profilesmanager/DowntimeManagerTest.java
@@ -7,6 +7,8 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -36,32 +38,34 @@ public class DowntimeManagerTest {
 		ArrayList<String> timePeriod = new ArrayList<String>();
 		timePeriod.add("2015-05-07T00:00:00Z");
 		timePeriod.add("2015-05-07T23:59:00Z");
-		assertEquals("Test timeperiod #1", dt.getPeriod("cream-ce01.gridpp.rl.ac.uk", "CREAM-CE"), timePeriod);
-		// test for px.ire.kharkov.ua, MyProxy
+                
+                
+		assertEquals("Test timeperiod #1", Arrays.asList(dt.getPeriod("cream-ce01.gridpp.rl.ac.uk", "CREAM-CE").get(0)), timePeriod);
+		// test for px.ire.kharkov.ua, MyProxynai 
 		timePeriod.clear();
 		timePeriod.add("2015-05-07T00:00:00Z");
 		timePeriod.add("2015-05-07T23:59:00Z");
-		assertEquals("Test timeperiod #2", dt.getPeriod("px.ire.kharkov.ua", "MyProxy"), timePeriod);
+		assertEquals("Test timeperiod #2",Arrays.asList(dt.getPeriod("px.ire.kharkov.ua", "MyProxy").get(0)), timePeriod);
 		// test for gb-ui-nki.els.sara.nl, UI
 		timePeriod.clear();
 		timePeriod.add("2015-05-07T00:00:00Z");
 		timePeriod.add("2015-05-07T23:59:00Z");
-		assertEquals("Test timeperiod #3", dt.getPeriod("gb-ui-nki.els.sara.nl", "UI"), timePeriod);
+		assertEquals("Test timeperiod #3", Arrays.asList(dt.getPeriod("gb-ui-nki.els.sara.nl", "UI").get(0)), timePeriod);
 		// test for cream-ce01.gridpp.rl.ac.uk, gLExec
 		timePeriod.clear();
 		timePeriod.add("2015-05-07T00:00:00Z");
 		timePeriod.add("2015-05-07T23:59:00Z");
-		assertEquals("Test timeperiod #4", dt.getPeriod("cream-ce01.gridpp.rl.ac.uk", "gLExec"), timePeriod);
+		assertEquals("Test timeperiod #4", Arrays.asList(dt.getPeriod("cream-ce01.gridpp.rl.ac.uk", "gLExec").get(0)), timePeriod);
 		// test for gcvmfs.cat.cbpf.br, org.squid-cache.Squid
 		timePeriod.clear();
 		timePeriod.add("2015-05-07T00:00:00Z");
 		timePeriod.add("2015-05-07T20:00:00Z");
-		assertEquals("Test timeperiod #5", dt.getPeriod("cvmfs.cat.cbpf.br", "org.squid-cache.Squid"), timePeriod);
+		assertEquals("Test timeperiod #5", Arrays.asList(dt.getPeriod("cvmfs.cat.cbpf.br", "org.squid-cache.Squid").get(0)), timePeriod);
 		// test for apel.ire.kharkov.ua, APEL
 		timePeriod.clear();
 		timePeriod.add("2015-05-07T00:00:00Z");
 		timePeriod.add("2015-05-07T23:59:00Z");
-		assertEquals("Test timeperiod #6", dt.getPeriod("apel.ire.kharkov.ua", "APEL"), timePeriod);
+		assertEquals("Test timeperiod #6", Arrays.asList(dt.getPeriod("apel.ire.kharkov.ua", "APEL").get(0)), timePeriod);
 
 	}
 

--- a/flink_jobs_v2/batch_multi/src/test/java/argo/batch/TestUtils.java
+++ b/flink_jobs_v2/batch_multi/src/test/java/argo/batch/TestUtils.java
@@ -191,7 +191,7 @@ public class TestUtils {
                 hasThr = sm.hasThr();
                 Timeline timeline = new Timeline();
                 for (TimeStatus ts : sm.getTimestamps()) {
-                    timeline.insert(new DateTime(ts.getTimestamp(),DateTimeZone.UTC), ts.getStatus());
+                    timeline.insert(new DateTime(ts.getTimestamp(), DateTimeZone.UTC), ts.getStatus());
 
                 }
                 timeline.optimize();
@@ -222,9 +222,12 @@ public class TestUtils {
 
                     initialTimeline.aggregate(timeline, opsMgr.getTruthTable(), op);
                     if (level.equals(LEVEL.HOSTNAME)) {
-                        ArrayList<String> downPeriod = downMgr.getPeriod(hostname, service);
-                        if (downPeriod != null && !downPeriod.isEmpty()) {
-                            initialTimeline.fillWithStatus(downPeriod.get(0), downPeriod.get(1), opsMgr.getDefaultDownInt(), now);
+                        ArrayList<String[]> downPeriods = downMgr.getPeriod(hostname, service);
+                        if (downPeriods != null && !downPeriods.isEmpty()) {
+                            for (String[] downPeriod : downPeriods) {
+
+                                initialTimeline.fillWithStatus(downPeriod[0], downPeriod[1], opsMgr.getDefaultDownInt(), now);
+                            }
                         }
 
                     }


### PR DESCRIPTION
In this PR included solutionn to handle multiple downtime periods for service endpoint. 
DowntimeManager getPeriods() fixed to return a list of downtime periods.
CalcEndpointTimeline changed to handle the received list and merge it to the initial timeline
Utils added a function to merge into one, the downtime periods that are continuous. 
DowntimeManagerTest change to support the implementation