### PR TITLE
ARGO-4732 Investigate potential issue with downtimes end and prolongue within same day

### DIFF
--- a/flink_jobs_v2/ProfilesManager/src/main/java/profilesmanager/DowntimeManager.java
+++ b/flink_jobs_v2/ProfilesManager/src/main/java/profilesmanager/DowntimeManager.java
@@ -52,9 +52,9 @@ public class DowntimeManager {
             this.endTime = endTime;
         }
 
-        public String toString(){
-			return String.format("(%s,%s,%s,%s)",hostname,service,startTime,endTime);
-		}
+        public String toString() {
+            return String.format("(%s,%s,%s,%s)", hostname, service, startTime, endTime);
+        }
 
     }
 
@@ -76,22 +76,23 @@ public class DowntimeManager {
      * Returns the downtime period (if any) for a specific service endpoint:
      * (hostname,service)
      */
-    public ArrayList<String> getPeriod(String hostname, String service) {
+    public ArrayList<String[]> getPeriod(String hostname, String service) {
 
-        ArrayList<String> period = new ArrayList<String>();
+        ArrayList<String[]> periods = new ArrayList<String[]>();
 
         for (DowntimeItem item : this.list) {
 
             if (item.hostname.equals(hostname)) {
                 if (item.service.equals(service)) {
-                    period.add(item.startTime);
-                    period.add(item.endTime);
-                    return period;
+                    String[] period = new String[2];
+                    period[0] = item.startTime;
+                    period[1] = item.endTime;
+                    periods.add(period);
+
                 }
             }
         }
-
-        return null;
+        return periods;
 
     }
 
@@ -192,4 +193,5 @@ public class DowntimeManager {
     public String toString() {
         return Arrays.toString(list.toArray());
     }
+    
 }

--- a/flink_jobs_v2/ProfilesManager/src/test/java/profilesmanager/DowntimeManagerTest.java
+++ b/flink_jobs_v2/ProfilesManager/src/test/java/profilesmanager/DowntimeManagerTest.java
@@ -7,6 +7,8 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -36,32 +38,34 @@ public class DowntimeManagerTest {
 		ArrayList<String> timePeriod = new ArrayList<String>();
 		timePeriod.add("2015-05-07T00:00:00Z");
 		timePeriod.add("2015-05-07T23:59:00Z");
-		assertEquals("Test timeperiod #1", dt.getPeriod("cream-ce01.gridpp.rl.ac.uk", "CREAM-CE"), timePeriod);
-		// test for px.ire.kharkov.ua, MyProxy
+                
+                
+		assertEquals("Test timeperiod #1", Arrays.asList(dt.getPeriod("cream-ce01.gridpp.rl.ac.uk", "CREAM-CE").get(0)), timePeriod);
+		// test for px.ire.kharkov.ua, MyProxynai 
 		timePeriod.clear();
 		timePeriod.add("2015-05-07T00:00:00Z");
 		timePeriod.add("2015-05-07T23:59:00Z");
-		assertEquals("Test timeperiod #2", dt.getPeriod("px.ire.kharkov.ua", "MyProxy"), timePeriod);
+		assertEquals("Test timeperiod #2",Arrays.asList(dt.getPeriod("px.ire.kharkov.ua", "MyProxy").get(0)), timePeriod);
 		// test for gb-ui-nki.els.sara.nl, UI
 		timePeriod.clear();
 		timePeriod.add("2015-05-07T00:00:00Z");
 		timePeriod.add("2015-05-07T23:59:00Z");
-		assertEquals("Test timeperiod #3", dt.getPeriod("gb-ui-nki.els.sara.nl", "UI"), timePeriod);
+		assertEquals("Test timeperiod #3", Arrays.asList(dt.getPeriod("gb-ui-nki.els.sara.nl", "UI").get(0)), timePeriod);
 		// test for cream-ce01.gridpp.rl.ac.uk, gLExec
 		timePeriod.clear();
 		timePeriod.add("2015-05-07T00:00:00Z");
 		timePeriod.add("2015-05-07T23:59:00Z");
-		assertEquals("Test timeperiod #4", dt.getPeriod("cream-ce01.gridpp.rl.ac.uk", "gLExec"), timePeriod);
+		assertEquals("Test timeperiod #4", Arrays.asList(dt.getPeriod("cream-ce01.gridpp.rl.ac.uk", "gLExec").get(0)), timePeriod);
 		// test for gcvmfs.cat.cbpf.br, org.squid-cache.Squid
 		timePeriod.clear();
 		timePeriod.add("2015-05-07T00:00:00Z");
 		timePeriod.add("2015-05-07T20:00:00Z");
-		assertEquals("Test timeperiod #5", dt.getPeriod("cvmfs.cat.cbpf.br", "org.squid-cache.Squid"), timePeriod);
+		assertEquals("Test timeperiod #5", Arrays.asList(dt.getPeriod("cvmfs.cat.cbpf.br", "org.squid-cache.Squid").get(0)), timePeriod);
 		// test for apel.ire.kharkov.ua, APEL
 		timePeriod.clear();
 		timePeriod.add("2015-05-07T00:00:00Z");
 		timePeriod.add("2015-05-07T23:59:00Z");
-		assertEquals("Test timeperiod #6", dt.getPeriod("apel.ire.kharkov.ua", "APEL"), timePeriod);
+		assertEquals("Test timeperiod #6", Arrays.asList(dt.getPeriod("apel.ire.kharkov.ua", "APEL").get(0)), timePeriod);
 
 	}
 

--- a/flink_jobs_v2/batch_multi/src/main/java/argo/batch/CalcEndpointTimeline.java
+++ b/flink_jobs_v2/batch_multi/src/main/java/argo/batch/CalcEndpointTimeline.java
@@ -14,10 +14,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import argo.avro.MetricProfile;
+import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.TreeMap;
+import java.util.logging.Level;
 import org.joda.time.DateTimeZone;
 import profilesmanager.AggregationProfileManager;
 import profilesmanager.DowntimeManager;
@@ -26,6 +30,7 @@ import profilesmanager.OperationsManager;
 
 import timelines.Timeline;
 import timelines.TimelineAggregator;
+import utils.Utils;
 
 /**
  * Accepts a list o status metrics grouped by the fields: endpoint group,
@@ -41,7 +46,7 @@ public class CalcEndpointTimeline extends RichGroupReduceFunction<StatusTimeline
 
     public CalcEndpointTimeline(ParameterTool params, DateTime now) {
         this.params = params;
-        this.now=now;
+        this.now = now;
     }
 
     static Logger LOG = LoggerFactory.getLogger(ArgoMultiJob.class);
@@ -79,7 +84,7 @@ public class CalcEndpointTimeline extends RichGroupReduceFunction<StatusTimeline
         this.downtime = getRuntimeContext().getBroadcastVariable("down");
         this.downtimeMgr = new DowntimeManager();
         this.downtimeMgr.loadFromList(downtime);
-     
+
         this.runDate = params.getRequired("run.date");
         this.operation = this.apsMgr.getMetricOpByProfile();
 
@@ -103,7 +108,7 @@ public class CalcEndpointTimeline extends RichGroupReduceFunction<StatusTimeline
             TreeMap<DateTime, Integer> samples = new TreeMap<>();
             for (TimeStatus timestatus : timestatusList) {
 
-                samples.put(new DateTime(timestatus.getTimestamp(),DateTimeZone.UTC), timestatus.getStatus());
+                samples.put(new DateTime(timestatus.getTimestamp(), DateTimeZone.UTC), timestatus.getStatus());
             }
             Timeline timeline = new Timeline();
             timeline.insertDateTimeStamps(samples, true);
@@ -113,16 +118,19 @@ public class CalcEndpointTimeline extends RichGroupReduceFunction<StatusTimeline
                 hasThr = true;
             }
         }
+
         TimelineAggregator timelineAggregator = new TimelineAggregator(timelinelist, this.opsMgr.getDefaultExcludedInt(), runDate);
         timelineAggregator.aggregate(this.opsMgr.getTruthTable(), this.opsMgr.getIntOperation(operation));
 
         Timeline mergedTimeline = timelineAggregator.getOutput(); //collect all timelines that correspond to the group service endpoint group , merge them in order to create one timeline
 
-        ArrayList<String> downPeriod = this.downtimeMgr.getPeriod(hostname, service);
-     
-	
-        if (downPeriod != null && !downPeriod.isEmpty()) {
-            mergedTimeline.fillWithStatus(downPeriod.get(0), downPeriod.get(1), this.opsMgr.getDefaultDownInt(), now);
+        ArrayList<String[]> downPeriods = this.downtimeMgr.getPeriod(hostname, service);
+
+        if (downPeriods != null && !downPeriods.isEmpty()) { 
+            for (String[] downPeriod : downPeriods) {
+                mergedTimeline.fillWithStatus(downPeriod[0], downPeriod[1], this.opsMgr.getDefaultDownInt(), now);
+                mergedTimeline.optimize();
+            }
         }
         ArrayList<TimeStatus> timestatuCol = new ArrayList();
         for (Map.Entry<DateTime, Integer> entry : mergedTimeline.getSamples()) {
@@ -135,5 +143,7 @@ public class CalcEndpointTimeline extends RichGroupReduceFunction<StatusTimeline
         out.collect(statusTimeline);
 
     }
+
+  
 
 }

--- a/flink_jobs_v2/batch_multi/src/main/java/utils/Utils.java
+++ b/flink_jobs_v2/batch_multi/src/main/java/utils/Utils.java
@@ -7,6 +7,7 @@ package utils;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import org.apache.flink.api.java.utils.ParameterTool;
@@ -74,7 +75,7 @@ public class Utils {
         }
     }
 
-    public static boolean checkParameters(ParameterTool params,String... vars) {
+    public static boolean checkParameters(ParameterTool params, String... vars) {
 
         for (String var : vars) {
 
@@ -128,5 +129,4 @@ public class Utils {
         int minutesInt = minutes.getMinutes();
         return minutesInt;
     }
-
 }

--- a/flink_jobs_v2/batch_multi/src/test/java/argo/batch/TestUtils.java
+++ b/flink_jobs_v2/batch_multi/src/test/java/argo/batch/TestUtils.java
@@ -191,7 +191,7 @@ public class TestUtils {
                 hasThr = sm.hasThr();
                 Timeline timeline = new Timeline();
                 for (TimeStatus ts : sm.getTimestamps()) {
-                    timeline.insert(new DateTime(ts.getTimestamp(),DateTimeZone.UTC), ts.getStatus());
+                    timeline.insert(new DateTime(ts.getTimestamp(), DateTimeZone.UTC), ts.getStatus());
 
                 }
                 timeline.optimize();
@@ -222,9 +222,12 @@ public class TestUtils {
 
                     initialTimeline.aggregate(timeline, opsMgr.getTruthTable(), op);
                     if (level.equals(LEVEL.HOSTNAME)) {
-                        ArrayList<String> downPeriod = downMgr.getPeriod(hostname, service);
-                        if (downPeriod != null && !downPeriod.isEmpty()) {
-                            initialTimeline.fillWithStatus(downPeriod.get(0), downPeriod.get(1), opsMgr.getDefaultDownInt(), now);
+                        ArrayList<String[]> downPeriods = downMgr.getPeriod(hostname, service);
+                        if (downPeriods != null && !downPeriods.isEmpty()) {
+                            for (String[] downPeriod : downPeriods) {
+
+                                initialTimeline.fillWithStatus(downPeriod[0], downPeriod[1], opsMgr.getDefaultDownInt(), now);
+                            }
                         }
 
                     }

--- a/flink_jobs_v2/stream_status/src/main/java/status/StatusManager.java
+++ b/flink_jobs_v2/stream_status/src/main/java/status/StatusManager.java
@@ -41,7 +41,7 @@ public class StatusManager {
 
     // Initialize logger
     static Logger LOG = LoggerFactory.getLogger(StatusManager.class);
-    
+
     // Name of the report used
     private String report;
 
@@ -72,10 +72,10 @@ public class StatusManager {
     String tsLatest;
     int looseInterval = 1440;
     int strictInterval = 1440;
-    boolean  level_group=true;
-    boolean level_service=true;
-    boolean level_endpoint=true;
-    boolean level_metric=true;
+    boolean level_group = true;
+    boolean level_service = true;
+    boolean level_endpoint = true;
+    boolean level_metric = true;
 
     public boolean isLevel_group() {
         return level_group;
@@ -108,8 +108,6 @@ public class StatusManager {
     public void setLevel_metric(boolean level_metric) {
         this.level_metric = level_metric;
     }
-
-    
 
     public void setReport(String report) {
         this.report = report;
@@ -687,23 +685,29 @@ public class StatusManager {
 
     public boolean hasDowntime(String timestamp, String hostname, String service) {
         String dayStamp = timestamp.split("T")[0];
-        ArrayList<String> period = this.dc.getDowntimePeriod(dayStamp, hostname, service);
+        ArrayList<String[]> periods = this.dc.getDowntimePeriod(dayStamp, hostname, service);
         // if no period was found return immediately fals
-        if (period == null) {
+        if (periods == null) {
             return false;
         }
 
-        // else check if ts lower than period's start time (first element in array list)
-        if (timestamp.compareTo(period.get(0)) < 0) {
-            return false;
-        }
-        // else check if ts higher than period's end time (second element in array list)
-        if (timestamp.compareTo(period.get(1)) > 0) {
-            return false;
-        }
+        boolean isDowntime=false;
+        for (String[] period : periods) {
+           boolean noDowntime=false;
+            // else check if ts lower than period's start time (first element in array list)
+            if (timestamp.compareTo(period[0]) < 0) {
+                noDowntime=true;
+            }
+            // else check if ts higher than period's end time (second element in array list)
+            if (timestamp.compareTo(period[1]) > 0) {
+               noDowntime=true;
+            }
+            if(!noDowntime){              
+                  isDowntime=true;
+            }
 
-        // else everything is ok and timestamp belongs inside element's downtime period
-        return true;
+        }
+        return isDowntime;
     }
 
     /**
@@ -906,7 +910,7 @@ public class StatusManager {
                             if (metricNode.item.status != status || repeat) {
                                 if (repeat && metricNode.item.status == status) {
                                     isReminder = true;
-                              }
+                                }
                                 // generate event
                                 evtMetric = genEvent("metric", group, service, hostname, metric, ops.getStrStatus(status),
                                         monHost, ts, ops.getStrStatus(oldMetricStatus), oldMetricTS, repeat, summary, message, isReminder);
@@ -914,8 +918,8 @@ public class StatusManager {
                                 // Create metric status level object
                                 statusMetric = new String[]{evtMetric.getStatus(), evtMetric.getPrevStatus(), evtMetric.getTsMonitored(), evtMetric.getPrevTs()};
                                 evtMetric.setStatusMetric(statusMetric);
-                                if(level_metric){
-                                   results.add(eventToString(evtMetric));
+                                if (level_metric) {
+                                    results.add(eventToString(evtMetric));
                                 }
                                 metricNode.item.status = status;
                                 metricNode.item.timestamp = ts;
@@ -970,7 +974,7 @@ public class StatusManager {
                         Map<String, ArrayList<String>> metricStatuses = getMetricStatuses(endpointNode, ops);
                         evtEndpoint.setMetricNames(metricStatuses.get("metrics").toArray(new String[0]));
                         evtEndpoint.setMetricStatuses(metricStatuses.get("statuses").toArray(new String[0]));
-                        if(level_endpoint){
+                        if (level_endpoint) {
                             results.add(eventToString(evtEndpoint));
                         }
                         endpointNode.item.status = endpNewStatus;
@@ -1010,7 +1014,7 @@ public class StatusManager {
                     evtService.setStatusEndpoint(statusEndpoint);
                     evtService.setStatusService(statusService);
 
-                    if(level_service){
+                    if (level_service) {
                         results.add(eventToString(evtService));
                     }
                     serviceNode.item.status = servNewStatus;
@@ -1056,8 +1060,8 @@ public class StatusManager {
                 evtEgroup.setStatusEndpoint(statusEndpoint);
                 evtEgroup.setStatusService(statusService);
                 evtEgroup.setStatusEgroup(statusEgroup);
-                if(level_group){
-                     results.add(eventToString(evtEgroup));
+                if (level_group) {
+                    results.add(eventToString(evtEgroup));
                 }
                 groupNode.item.status = groupNewStatus;
                 groupNode.item.genTs = ts;
@@ -1217,7 +1221,7 @@ public class StatusManager {
         return false;
 
     }
-    
+
     public boolean checkIfExistDowntime(String timestamp) {
 
         return this.dc.getCache().keySet().contains(timestamp);

--- a/flink_jobs_v2/stream_status/src/main/java/sync/DowntimeCache.java
+++ b/flink_jobs_v2/stream_status/src/main/java/sync/DowntimeCache.java
@@ -98,11 +98,11 @@ public class DowntimeCache {
 			cache.remove(cache.firstKey());
 		}
 	}
-
+        
 	/**
 	 * Check if downtime period exists for a specific endpoint (service, hostname, timestamp)
 	 */
-	public ArrayList<String> getDowntimePeriod(String dayStamp, String hostname, String service) {
+	public ArrayList<String[]> getDowntimePeriod(String dayStamp, String hostname, String service) {
 		// If downtime manager with data exists for specific day
 		if (cache.containsKey(dayStamp)) {
 			// return the downtime period from downtime manager of specific day

--- a/flink_jobs_v2/stream_status/src/test/java/sync/DowntimeCacheTest.java
+++ b/flink_jobs_v2/stream_status/src/test/java/sync/DowntimeCacheTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 
 import argo.avro.Downtime;
 import argo.streaming.SyncParse;
+import java.util.Arrays;
 
 import org.apache.commons.codec.binary.Base64;
 import profilesmanager.DowntimeManager;
@@ -95,15 +96,43 @@ public class DowntimeCacheTest {
 		
 		// Assert that max items are 2
 		assertEquals(2,dc2.getMaxItems());
-		
-		assertEquals("[2018-05-13T00:00:00Z, 2018-05-13T23:59:00Z]",dc2.getDowntimePeriod("2018-05-13", "cluster51.knu.ac.kr", "Site-BDII").toString());
-		assertEquals("[2018-05-14T00:00:00Z, 2018-05-14T23:59:00Z]",dc2.getDowntimePeriod("2018-05-14", "cluster51.knu.ac.kr", "Site-BDII").toString());
-		assertEquals("[2018-05-13T14:00:00Z, 2018-05-13T23:59:00Z]",dc2.getDowntimePeriod("2018-05-13", "fal-pygrid-30.lancs.ac.uk", "webdav").toString());
+                
+                ArrayList<String[]> timePeriod = new ArrayList<String[]>();
+		String[] period=new String[2];
+                period[0]="2018-05-13T00:00:00Z";
+		period[1]="2018-05-13T23:59:00Z";            
+                timePeriod.add(period);
+             
+                 assertArrayEquals(dc2.getDowntimePeriod("2018-05-13", "cluster51.knu.ac.kr", "Site-BDII").toArray(), timePeriod.toArray());
+          
+                 
+                 timePeriod.clear();
+            
+                period[0]="2018-05-14T00:00:00Z";
+		period[1]="2018-05-14T23:59:00Z";            
+                timePeriod.add(period);
+             
+            
+                assertArrayEquals(dc2.getDowntimePeriod("2018-05-14", "cluster51.knu.ac.kr", "Site-BDII").toArray(),timePeriod.toArray());
+                timePeriod.clear();
+               
+                period[0]="2018-05-13T14:00:00Z";
+		period[1]="2018-05-13T23:59:00Z";            
+                timePeriod.add(period);             
+                
+                assertArrayEquals(dc2.getDowntimePeriod("2018-05-13", "fal-pygrid-30.lancs.ac.uk", "webdav").toArray(),timePeriod.toArray());
 		// Insert new element 2018-05-16 that will remove 2018-05-13
 		dc2.addFeed("2018-05-16", downtimeMap.get("2018-05-16"));
 		assertEquals(null,dc2.getDowntimePeriod("2018-05-13", "fal-pygrid-30.lancs.ac.uk", "webdav"));
 		// ..but 2018-05-14 still exists
-		assertEquals("[2018-05-14T00:00:00Z, 2018-05-14T23:59:00Z]",dc2.getDowntimePeriod("2018-05-14", "cluster51.knu.ac.kr", "Site-BDII").toString());
+		
+                timePeriod.clear();
+             
+                period[0]="2018-05-14T00:00:00Z";
+		period[1]="2018-05-14T23:59:00Z";            
+                timePeriod.add(period);
+             
+                assertArrayEquals(dc2.getDowntimePeriod("2018-05-14", "cluster51.knu.ac.kr", "Site-BDII").toArray(),timePeriod.toArray());
 		// Insert new element 2018-05-17 that will remove 2018-05-14
 		dc2.addFeed("2018-05-17", downtimeMap.get("2018-05-17"));
 		assertEquals(null,dc2.getDowntimePeriod("2018-05-14", "cluster51.knu.ac.kr", "Site-BDII"));
@@ -127,12 +156,13 @@ public class DowntimeCacheTest {
 		DowntimeManager dm15 = new DowntimeManager();
 		DowntimeManager dm17 = new DowntimeManager();
 		DowntimeManager dm18 = new DowntimeManager();
+                
 		
-		dm15.loadFromList(downtimeMap.get("2018-05-15"));
-		dm17.loadFromList(downtimeMap.get("2018-05-17"));
+		dm15.loadFromList(downtimeMap.get("2018-05-15"));		
+                dm17.loadFromList(downtimeMap.get("2018-05-17"));
 		dm18.loadFromList(downtimeMap.get("2018-05-18"));
-		
-		assertEquals(dm15.toString(),dc3.getDowntimeManager("2018-05-15").toString());
+                
+          	assertEquals(dm15.toString(),dc3.getDowntimeManager("2018-05-15").toString());
 		assertEquals(dm17.toString(),dc3.getDowntimeManager("2018-05-17").toString());
 		assertEquals(dm18.toString(),dc3.getDowntimeManager("2018-05-18").toString());
 		


### PR DESCRIPTION
In this PR included solutionn to handle multiple downtime periods for service endpoint.
DowntimeManager getPeriods() fixed to return a list of downtime periods.
CalcEndpointTimeline changed to handle the received list and merge it to the initial timeline
Utils added a function to merge into one, the downtime periods that are continuous.
DowntimeManagerTest change to support the implementation