### PR TITLE
Issue with topology sync during removing APEL service from metric profiles

### DIFF
--- a/flink_jobs_v2/ams-connector/src/main/java/ams/connector/ArgoMessagingClient.java
+++ b/flink_jobs_v2/ams-connector/src/main/java/ams/connector/ArgoMessagingClient.java
@@ -432,7 +432,6 @@ public class ArgoMessagingClient {
         postModifyOffset.addHeader("Accept", "application/json");
         postModifyOffset.addHeader("x-api-key", this.token);
         postModifyOffset.addHeader("Content-type", "application/json");
-        System.out.println("modify offset is :" + offset);
         String body = "{\"offset\":" + offset + "}";
 
         StringEntity postBody = new StringEntity(body);

--- a/flink_jobs_v2/stream_status/src/main/java/status/StatusManager.java
+++ b/flink_jobs_v2/stream_status/src/main/java/status/StatusManager.java
@@ -1073,7 +1073,7 @@ public class StatusManager {
             LOG.info("Downtime encountered for group:{},service:{},host:{} - events will be discarded", group, service, hostname);
             results.clear();
         }
-
+        
         return results;
 
     }


### PR DESCRIPTION
--sync.interval parameter is introduced as optional to define the interval the profiles and topology sync. 
it can be in the form of --sync.interval="1d" or "30h" or "2400m"