### PR TITLE
ARGO-4884 Missing statuses at the beginning of day for cert validity checks

### DIFF
--- a/flink_jobs_v2/batch_multi/src/main/java/argo/batch/ArgoMultiJob.java
+++ b/flink_jobs_v2/batch_multi/src/main/java/argo/batch/ArgoMultiJob.java
@@ -321,7 +321,7 @@ public class ArgoMultiJob {
         String dbMethod = params.getRequired("mongo.method");
         
         // Create status detail data set
-        DataSet<StatusMetric> stDetailDS = mdataTotalDS.distinct("group","hostname","metric","status","timestamp").groupBy("group", "service", "hostname", "metric")
+        DataSet<StatusMetric> stDetailDS = mdataTotalDS.distinct("group","service","hostname","metric","status","timestamp").groupBy("group", "service", "hostname", "metric")
                 .sortGroup("timestamp", Order.ASCENDING).reduceGroup(new CalcPrevStatus(params))
                 .withBroadcastSet(mpsDS, "mps").withBroadcastSet(recDS, "rec").withBroadcastSet(opsDS, "ops");
 

--- a/flink_jobs_v3/batch-multi/src/main/java/argo/batch/ArgoMultiJob.java
+++ b/flink_jobs_v3/batch-multi/src/main/java/argo/batch/ArgoMultiJob.java
@@ -334,7 +334,7 @@ public class ArgoMultiJob {
 
         // Create status detail data set
 
-        DataSet<StatusMetric> stDetailDS = mdataTotalDS.distinct("group","hostname","metric","status","timestamp").groupBy("group", "service", "hostname", "metric")
+        DataSet<StatusMetric> stDetailDS = mdataTotalDS.distinct("group","service","hostname","metric","status","timestamp").groupBy("group", "service", "hostname", "metric")
                 .sortGroup("timestamp", Order.ASCENDING).reduceGroup(new CalcPrevStatus(params))
                 .withBroadcastSet(mpsDS, "mps").withBroadcastSet(recDS, "rec").withBroadcastSet(opsDS, "ops");
 


### PR DESCRIPTION
Missing field "service" from distinct() operation on dataset resulted in wrong filtering, seemed to affect the entries of existing entries to calculate timeline. as a result previous day timestamp -data seemed to be missing and MISSING status was applied in calculations