### PR TITLE
ARGO-4949 Set argo-web-api verify to false for multijob and streaming…

### DIFF
--- a/flink_jobs_v2/batch_multi/src/main/java/argo/batch/ArgoMultiJob.java
+++ b/flink_jobs_v2/batch_multi/src/main/java/argo/batch/ArgoMultiJob.java
@@ -183,6 +183,7 @@ public class ArgoMultiJob {
             amr.setTimeoutSec(params.getInt("api.timeout"));
         }
         runDate = params.getRequired("run.date");
+        amr.setVerify(false);
         amr.setIsCombined(isCombined);
         amr.setIsSourceTopoAll(isSourceAll);
         amr.setReportID(reportID);

--- a/flink_jobs_v2/stream_status/src/main/java/argo/streaming/ArgoApiSource.java
+++ b/flink_jobs_v2/stream_status/src/main/java/argo/streaming/ArgoApiSource.java
@@ -42,7 +42,7 @@ public class ArgoApiSource extends RichSourceFunction<Tuple2<String,String>> {
         this.token = token;
         this.reportID = reportID;
         this.interval = interval;
-        this.verify = true;
+        this.verify = false;
         if(syncInterval!=null){
             setSyncUpdate(syncInterval);
         }


### PR DESCRIPTION
… job

Set verify=false by default for Argo web-api clients in multijob and streaming job