### PR TITLE
ARGO-5016 Test Mongo results of streaming job in lot1 EOSC production

### DIFF
--- a/flink_jobs_v2/stream_status/src/main/java/argo/streaming/MongoStatusOutput.java
+++ b/flink_jobs_v2/stream_status/src/main/java/argo/streaming/MongoStatusOutput.java
@@ -50,7 +50,7 @@ public class MongoStatusOutput implements OutputFormat<String> {
     private String uri;
 
     // constructor
-    public MongoStatusOutput(String uri, String metricName, String serviceName, String endpointName, String egroupName, String method, String report) {
+    public MongoStatusOutput(String uri, String metricName, String endpointName,String serviceName,  String egroupName, String method, String report) {
 
         if (method.equalsIgnoreCase("upsert")) {
             this.method = MongoMethod.UPSERT;
@@ -76,7 +76,7 @@ public class MongoStatusOutput implements OutputFormat<String> {
     }
 
     // constructor
-    public MongoStatusOutput(String host, int port, String db, String metricName, String serviceName, String endpointName, String egroupName, MongoMethod method,
+    public MongoStatusOutput(String host, int port, String db, String metricName, String endpointName, String serviceName, String egroupName, MongoMethod method,
             String report) {
         this.mongoHost = host;
         this.mongoPort = port;
@@ -117,6 +117,7 @@ public class MongoStatusOutput implements OutputFormat<String> {
      * results than Endpoint, Service or Endpoint Group ones.
      */
     private Document prepDoc(StatusEvent record) {
+
         Document doc = new Document("report", this.report)
                 .append("endpoint_group", record.getGroup());
 

--- a/flink_jobs_v2/stream_status/src/main/java/status/StatusManager.java
+++ b/flink_jobs_v2/stream_status/src/main/java/status/StatusManager.java
@@ -932,6 +932,7 @@ public class StatusManager {
                     }
                     // If metric indeed updated -> aggregate endpoint
                     if (updMetric) {
+
                         // calculate endpoint new status
                         int endpNewStatus = aggregate("", endpointNode, ts);
                         // check if status changed
@@ -985,6 +986,7 @@ public class StatusManager {
                 }
                 // if endpoint indeed updated -> aggregate service
                 if (updEndpoint) {
+
                     // calculate service new status
                     int servNewStatus = aggregate(service, serviceNode, ts);
                     // check if status changed


### PR DESCRIPTION
fixed constructor of MongoStatusOutput to store correctly the service elements in the status_service collection and the endpoint elements to the status_endpoints collection. This was defined wrongly and stored vice versa