### PR TITLE
ARGO-5059 Ingestion job seems to request topology from api on each data published to influx

### DIFF
--- a/flink_jobs_v2/ProfilesManager/src/main/java/profilesmanager/EndpointGroupManager.java
+++ b/flink_jobs_v2/ProfilesManager/src/main/java/profilesmanager/EndpointGroupManager.java
@@ -641,4 +641,18 @@ public class EndpointGroupManager implements Serializable {
 
     }
 
+    public ArrayList<String> getGroupAllTopo(String hostname, String service) {
+        String keyPart = hostname + "|" + service;
+
+        for (String key : topologyGrouplist.keySet()) {
+            if (key.contains(keyPart)) {
+                Map<String, EndpointItem> sublist = topologyGrouplist.get(key);
+                if (sublist != null) {
+                    return new ArrayList<String>(sublist.keySet());
+                }
+            }
+        }
+
+        return new ArrayList<String>();
+    }
 }

--- a/flink_jobs_v2/ams_ingest_metric/src/main/java/argo/streaming/AmsIngestMetric.java
+++ b/flink_jobs_v2/ams_ingest_metric/src/main/java/argo/streaming/AmsIngestMetric.java
@@ -340,10 +340,10 @@ public class AmsIngestMetric {
                 loadTopology(currTimestampDate);
             }
 
-            ArrayList<String> groups = egp.getGroup(item.getHostname(), item.getService());
+            ArrayList<String> groups = egp.getGroupAllTopo(item.getHostname(), item.getService());
             if (groups.isEmpty()) {
                 loadTopology(currTimestampDate);
-                groups = egp.getGroup(item.getHostname(), item.getService());
+                groups = egp.getGroupAllTopo(item.getHostname(), item.getService());
             }
             for (String groupItem : groups) {
                 Tuple2<String, MetricData> curItem = new Tuple2<String, MetricData>();


### PR DESCRIPTION
In the ingestion job, the full topology is retrieved (i.e., it includes items for all report types, not fetched per report). In EndpointTopologyManager, topology items are stored in a map using a composite key of type+service+hostname, and a default type is maintained.

During ingestion, when checking if a hostname+service belongs to a group, we rely on the default type. However, since the topology contains multiple types (e.g., SITES, SERVICEGROUPS), it's possible that the actual item exists under a different type than the default. For example, the default might be SITES, but the hostname+service may actually exist under SERVICEGROUPS. In such cases, the group is not found, even though the mapping exists.

When no group is found, a request is made to re-fetch the topology to ensure it's not due to a recent change.

To improve this, we added a new method that checks the keys in the topology map to see if any key contains the given hostname+service, even if the type does not match the default. This allows us to detect valid topology entries that would otherwise be missed due to type mismatch.