### PR TITLE
ARGO-4879 Streaming job fails due to null pointer exception when argo web-api is unreachable

### DIFF
--- a/flink_jobs_v2/ApiResourceManager/src/main/java/argo/amr/ApiResourceManager.java
+++ b/flink_jobs_v2/ApiResourceManager/src/main/java/argo/amr/ApiResourceManager.java
@@ -8,17 +8,19 @@ import argo.avro.Weight;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.EnumMap;
-import java.util.List;
-import java.util.TimeZone;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
+
+import java.net.UnknownHostException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.TimeZone;
+import java.util.Date;
 
 /**
  * APIResourceManager class fetches remote argo-web-api resources such as report
@@ -63,6 +65,7 @@ public class ApiResourceManager {
         this.tenant = "";
         this.egroup = "";
         this.requestManager = new RequestManager("", this.token);
+
         this.apiResponseParser = new ApiResponseParser(this.reportName, this.metricID, this.aggregationID, this.opsID, this.threshID, this.tenant, this.egroup);
     }
 
@@ -200,7 +203,7 @@ public class ApiResourceManager {
      * Retrieves the remote report configuration based on reportID main class
      * attribute and stores the content in the enum map
      */
-    public void getRemoteConfig() {
+    public void getRemoteConfig() throws UnknownHostException {
         String path = "https://%s/api/v2/reports/%s";
         String fullURL = String.format(path, this.endpoint, this.reportID);
         String content = this.requestManager.getResource(fullURL);
@@ -212,7 +215,7 @@ public class ApiResourceManager {
      * Retrieves the metric profile content based on the metric_id attribute and
      * stores it to the enum map
      */
-    public void getRemoteMetric() {
+    public void getRemoteMetric() throws UnknownHostException {
 
         String path = "https://%s/api/v2/metric_profiles/%s?date=%s";
         String fullURL = String.format(path, this.endpoint, this.metricID, this.date);
@@ -226,7 +229,7 @@ public class ApiResourceManager {
      * Retrieves the metric profile content based on the metric_id attribute and
      * stores it to the enum map
      */
-    public MetricProfile[] getNewEntriesMetrics() throws ParseException {
+    public MetricProfile[] getNewEntriesMetrics() throws ParseException, UnknownHostException {
 
         if (this.data.get(ApiResource.METRIC) == null) {
             getRemoteMetric();
@@ -245,7 +248,7 @@ public class ApiResourceManager {
             String path = "https://%s/api/v2/metric_profiles/%s?date=%s";
             String fullURL = String.format(path, this.endpoint, this.metricID, yesterdaystr);
             yesterdayContent = this.apiResponseParser.getJsonData(this.requestManager.getResource(fullURL), false);
-          
+
         }
         List<MetricProfile> newentries = this.apiResponseParser.getListNewMetrics(content, yesterdayContent);
 
@@ -258,7 +261,7 @@ public class ApiResourceManager {
      * Retrieves the aggregation profile content based on the aggreagation_id
      * attribute and stores it to the enum map
      */
-    public void getRemoteAggregation() {
+    public void getRemoteAggregation() throws UnknownHostException {
 
         String path = "https://%s/api/v2/aggregation_profiles/%s?date=%s";
         String fullURL = String.format(path, this.endpoint, this.aggregationID, this.date);
@@ -272,7 +275,7 @@ public class ApiResourceManager {
      * Retrieves the ops profile content based on the ops_id attribute and
      * stores it to the enum map
      */
-    public void getRemoteOps() {
+    public void getRemoteOps() throws UnknownHostException {
 
         String path = "https://%s/api/v2/operations_profiles/%s?date=%s";
         String fullURL = String.format(path, this.endpoint, this.opsID, this.date);
@@ -287,7 +290,7 @@ public class ApiResourceManager {
      * Retrieves the thresholds profile content based on the thresh_id attribute
      * and stores it to the enum map
      */
-    public void getRemoteThresholds() {
+    public void getRemoteThresholds() throws UnknownHostException {
 
         String path = "https://%s/api/v2/thresholds_profiles/%s?date=%s";
         String fullURL = String.format(path, this.endpoint, this.threshID, this.date);
@@ -300,13 +303,13 @@ public class ApiResourceManager {
     /**
      * Retrieves the topology endpoint content and stores it to the enum map
      */
-    public void getRemoteTopoEndpoints() {
-        String combinedparam="";
-        if(isSourceTopoAll){
-        combinedparam="&mode=combined";
+    public void getRemoteTopoEndpoints() throws UnknownHostException {
+        String combinedparam = "";
+        if (isSourceTopoAll) {
+            combinedparam = "&mode=combined";
         }
         String path = "https://%s/api/v2/topology/endpoints/by_report/%s?date=%s";
-        String fullURL = String.format(path, this.endpoint, this.reportName, this.date+combinedparam);
+        String fullURL = String.format(path, this.endpoint, this.reportName, this.date + combinedparam);
         String content = this.requestManager.getResource(fullURL);
 
         this.data.put(ApiResource.TOPOENDPOINTS, this.apiResponseParser.getJsonData(content, true));
@@ -316,14 +319,14 @@ public class ApiResourceManager {
     /**
      * Retrieves the topology groups content and stores it to the enum map
      */
-    public void getRemoteTopoGroups() {
-        String combinedparam="";
-        if(isSourceTopoAll){
-        combinedparam="&mode=combined";
+    public void getRemoteTopoGroups() throws UnknownHostException {
+        String combinedparam = "";
+        if (isSourceTopoAll) {
+            combinedparam = "&mode=combined";
         }
-      
+
         String path = "https://%s/api/v2/topology/groups/by_report/%s?date=%s";
-        String fullURL = String.format(path, this.endpoint, this.reportName, this.date+combinedparam);
+        String fullURL = String.format(path, this.endpoint, this.reportName, this.date + combinedparam);
         String content = this.requestManager.getResource(fullURL);
 
         this.data.put(ApiResource.TOPOGROUPS, this.apiResponseParser.getJsonData(content, true));
@@ -333,7 +336,7 @@ public class ApiResourceManager {
     /**
      * Retrieves the weights content and stores it to the enum map
      */
-    public void getRemoteWeights() {
+    public void getRemoteWeights() throws UnknownHostException {
         String path = "https://%s/api/v2/weights/%s?date=%s";
         String fullURL = String.format(path, this.endpoint, this.weightsID, this.date);
         String content = this.requestManager.getResource(fullURL);
@@ -345,7 +348,7 @@ public class ApiResourceManager {
     /**
      * Retrieves the downtimes content and stores it to the enum map
      */
-    public void getRemoteDowntimes() {
+    public void getRemoteDowntimes() throws UnknownHostException {
         String path = "https://%s/api/v2/downtimes?date=%s";
         String fullURL = String.format(path, this.endpoint, this.date);
         String content = this.requestManager.getResource(fullURL);
@@ -353,7 +356,7 @@ public class ApiResourceManager {
 
     }
 
-    public void getRemoteRecomputations() {
+    public void getRemoteRecomputations() throws UnknownHostException {
         String path = "https://%s/api/v2/recomputations?date=%s";
         String fullURL = String.format(path, this.endpoint, this.date);
         String content = this.requestManager.getResource(fullURL);
@@ -366,7 +369,7 @@ public class ApiResourceManager {
      * Retrieves the remote report configuration based on reportID main class
      * attribute and stores the content in the enum map
      */
-    public void getRemoteMetricTags() {
+    public void getRemoteMetricTags() throws UnknownHostException {
         String path = "https://%s/api/v2/metrics/by_report/%s";
         String fullURL = String.format(path, this.endpoint, this.reportName);
         String content = this.requestManager.getResource(fullURL);
@@ -513,7 +516,7 @@ public class ApiResourceManager {
      * Retrieves the remote report configuration based on reportID main class
      * attribute and stores the content in the enum map
      */
-    public void getRemoteTenantFeed() {
+    public void getRemoteTenantFeed() throws UnknownHostException {
         String path = "https://%s/api/v2/feeds/data";
         String fullURL = String.format(path, this.endpoint);
         String content = this.requestManager.getResource(fullURL);
@@ -541,7 +544,7 @@ public class ApiResourceManager {
      * Executes all steps to retrieve the complete amount of the available
      * profile, topology, weights and downtime information from argo-web-api
      */
-    public void getRemoteAll() {
+    public void getRemoteAll() throws UnknownHostException {
         // Start with report and configuration
         if (isCombined) {
             this.getRemoteTenantFeed();
@@ -558,7 +561,7 @@ public class ApiResourceManager {
             this.getRemoteThresholds();
         }
         // Go to topology
-   
+
         this.getRemoteTopoEndpoints();
         this.getRemoteTopoGroups();
         // get weights
@@ -575,19 +578,19 @@ public class ApiResourceManager {
     /**
      * Retrieves the topology endpoint content and stores it to the enum map
      */
-    public void getAllRemoteTopoEndpoints() {
-        String combinedparam="";
-        if(isSourceTopoAll){
-        combinedparam="&mode=combined";
+    public void getAllRemoteTopoEndpoints() throws UnknownHostException {
+        String combinedparam = "";
+        if (isSourceTopoAll) {
+            combinedparam = "&mode=combined";
         }
         String path = "https://%s/api/v2/topology/endpoints?date=%s";
-        String fullURL = String.format(path, this.endpoint, this.date+combinedparam);
+        String fullURL = String.format(path, this.endpoint, this.date + combinedparam);
         String content = this.requestManager.getResource(fullURL);
 
         this.data.put(ApiResource.TOPOENDPOINTS, this.apiResponseParser.getJsonData(content, true));
 
     }
-    
+
     public boolean isIsCombined() {
         return isCombined;
     }
@@ -600,7 +603,6 @@ public class ApiResourceManager {
         this.isSourceTopoAll = isSourceTopoAll;
     }
 
-    
 
     public static DateTime convertStringtoDate(String format, String dateStr) throws ParseException {
 
@@ -618,4 +620,5 @@ public class ApiResourceManager {
         String dateString = date.toString(dtf);
         return dateString;
     }
+
 }

--- a/flink_jobs_v2/ApiResourceManager/src/main/java/argo/amr/RequestManager.java
+++ b/flink_jobs_v2/ApiResourceManager/src/main/java/argo/amr/RequestManager.java
@@ -6,9 +6,14 @@
 package argo.amr;
 
 import java.io.IOException;
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+
+import org.apache.commons.logging.Log;
 import org.apache.http.client.fluent.Executor;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
@@ -17,6 +22,10 @@ import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.SSLContextBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLException;
 
 /**
  *
@@ -28,6 +37,7 @@ public class RequestManager {
     private String token;
     private int timeoutSec;
     private boolean verify;
+    static Logger LOG = LoggerFactory.getLogger(RequestManager.class);
 
     public RequestManager(String proxy, String token, int timeoutSec, boolean verify) {
         this.proxy = proxy;
@@ -56,10 +66,14 @@ public class RequestManager {
      * @throws NoSuchAlgorithmException
      * @throws KeyManagementException
      */
-    public String getResource(String fullURL) {
 
-        Request r = Request.Get(fullURL).addHeader("Accept", "application/json").addHeader("Content-type",
-                "application/json").addHeader("x-api-key", this.token);
+    public String getResource(String fullURL) throws UnknownHostException {
+
+        Request r = Request.Get(fullURL)
+                .addHeader("Accept", "application/json")
+                .addHeader("Content-type", "application/json")
+                .addHeader("x-api-key", this.token);
+
         if (!this.proxy.isEmpty()) {
             r = r.viaProxy(proxy);
         }
@@ -75,16 +89,73 @@ public class RequestManager {
                 content = executor.execute(r).returnContent().asString();
                 httpClient.close();
             } else {
-
                 content = r.execute().returnContent().asString();
             }
-        } catch (KeyManagementException | NoSuchAlgorithmException | KeyStoreException | IOException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+        } catch (UnknownHostException e) {
+            // DNS resolution failure — API domain does not exist
+            LOG.error("UnknownHostException: API endpoint not found: "+fullURL, e.getMessage());
+            // Throw the exception again
+            throw new UnknownHostException("API domain not found: "+fullURL+ e.getMessage());
+        } catch (ConnectException e) {
+            // Network error or API not reachable (e.g. timeout, refused connection)
+            LOG.error("ConnectException: Could not connect to API: "+ fullURL,e.getMessage());
+        } catch (SocketTimeoutException e) {
+            // API is very slow or not responding
+            LOG.error("SocketTimeoutException: API did not respond in time: "+ fullURL,e.getMessage());
+        } catch (SSLException e) {
+            // SSL errors (certs, handshake, etc.)
+            LOG.error("SSLException: SSL error while connecting to API: "+ fullURL,e.getMessage());
+        } catch (IOException e) {
+            // General I/O error
+            LOG.error("IOException: General IO failure while accessing API: "+ fullURL,e.getMessage());
+        } catch (Exception e) {
+            // Unexpected error
+            LOG.error("Unexpected exception: "+ e.getMessage());
         }
 
         return content;
     }
+
+    //isApiUp() checks if the api is up or down
+    public boolean isApiUp(String fullURL) {
+        try {
+            Request r = Request.Head(fullURL) // Use HEAD to check availability without downloading body
+                    .connectTimeout(this.timeoutSec * 1000)
+                    .socketTimeout(this.timeoutSec * 1000)
+                    .addHeader("x-api-key", this.token);
+
+            if (!this.proxy.isEmpty()) {
+                r = r.viaProxy(proxy);
+            }
+
+            if (!this.verify) {
+                try (CloseableHttpClient httpClient = HttpClients.custom()
+                        .setSSLSocketFactory(selfSignedSSLF())
+                        .build()) {
+                    Executor executor = Executor.newInstance(httpClient);
+                    int statusCode = executor.execute(r).returnResponse().getStatusLine().getStatusCode();
+                    return statusCode >= 200 && statusCode < 300;
+                }
+            } else {
+                int statusCode = r.execute().returnResponse().getStatusLine().getStatusCode();
+                return statusCode >= 200 && statusCode < 300;
+            }
+
+        } catch (UnknownHostException e) {
+            LOG.warn("API host not found: {}", fullURL, e);
+        } catch (ConnectException e) {
+            LOG.warn("Could not connect to API: {}", fullURL, e);
+        } catch (SocketTimeoutException e) {
+            LOG.warn("API timed out: {}", fullURL, e);
+        } catch (IOException e) {
+            LOG.warn("I/O error while checking API status: {}", fullURL, e);
+        } catch (Exception e) {
+            LOG.warn("Unexpected error while checking API status: {}", fullURL, e);
+        }
+        return false;
+    }
+
+
 
     /**
      * Create an SSL Connection Socket Factory with a strategy to trust self
@@ -128,6 +199,6 @@ public class RequestManager {
     public void setVerify(boolean verify) {
         this.verify = verify;
     }
-    
-    
+
+
 }

--- a/flink_jobs_v2/ams-connector/src/main/java/ams/connector/ArgoMessagingClient.java
+++ b/flink_jobs_v2/ams-connector/src/main/java/ams/connector/ArgoMessagingClient.java
@@ -179,7 +179,7 @@ public class ArgoMessagingClient {
             result.append(rLine);
         }
         isRdr.close();
-        Log.warn("ApiStatusCode={}, ApiErrorMessage={}", statusCode, result);
+       Log.warn("ApiStatusCode={}, ApiErrorMessage={}", statusCode, result);
 
     }
 
@@ -366,7 +366,7 @@ public class ArgoMessagingClient {
             // Gather message from json
             JsonParser jsonParser = new JsonParser();
             // parse the json root object
-            Log.info("response: {}", result.toString());
+             Log.info("response: {}", result.toString());
             JsonElement jRoot = jsonParser.parse(result.toString());
 
             if (this.runDate != null) {

--- a/flink_jobs_v2/ams_ingest_metric/src/main/java/argo/streaming/AmsIngestMetric.java
+++ b/flink_jobs_v2/ams_ingest_metric/src/main/java/argo/streaming/AmsIngestMetric.java
@@ -3,8 +3,10 @@ package argo.streaming;
 import ams.connector.ArgoMessagingSource;
 import argo.amr.ApiResourceManager;
 import argo.avro.GroupEndpoint;
-import java.util.concurrent.TimeUnit;
 
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
+import com.esotericsoftware.minlog.Log;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
@@ -32,30 +34,23 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 
 import argo.avro.MetricData;
-import argo.avro.MetricProfile;
 import com.influxdb.client.write.Point;
 import influxdb.connector.InfluxDBSink;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
-import java.util.TimeZone;
+
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.functions.co.RichCoFlatMapFunction;
 import org.slf4j.MDC;
 import profilesmanager.EndpointGroupManager;
-import profilesmanager.MetricProfileManager;
 
 /**
  * Flink Job : Stream metric data from ARGO messaging to Hbase job required cli
  * parameters:
- *
+ * <p>
  * --ams.endpoint : ARGO messaging api endoint to connect to msg.example.com
  * --ams.port : ARGO messaging api port --ams.token : ARGO messaging api token
  * --ams.project : ARGO messaging api project to connect to --ams.sub : ARGO
@@ -69,7 +64,7 @@ import profilesmanager.MetricProfileManager;
  * per request to AMS service --ams.interval : interval (in ms) between AMS
  * service requests --ams.proxy : optional http proxy url --ams.verify :
  * optional turn on/off ssl verify
- *
+ * <p>
  * --proxy: optional http proxy url for api endpoint --influx.token the token to
  * the influx db --influx.port the port of the influxdb --influx.endpoint the
  * endpoint to influx db --influx.org the organisation of influx db
@@ -78,6 +73,9 @@ import profilesmanager.MetricProfileManager;
  * the tenants name for whom the performance data is generated --api.endpoint
  * the api endpoint --api.token the api token --api.interval the api interval
  * --api.timeout 1
+ * --check.api.interval: the interval to check the argo-web api connection,by default 24h. it can be * in the format of DAYS,
+ *  * HOURS, MINUTES eg. 1h, 2d, 30m to define the period . By default is 24h , if
+ *  * the parameter is not configured
  */
 public class AmsIngestMetric {
 
@@ -86,6 +84,8 @@ public class AmsIngestMetric {
 
     static Logger LOG = LoggerFactory.getLogger(AmsIngestMetric.class);
     private static String runDate;
+    private static IntervalType checkApiIntervalType = IntervalType.HOURS;
+    private static int checkApiInterval = 1;
 
     /**
      * Check if flink job has been called with ams rate params
@@ -116,7 +116,7 @@ public class AmsIngestMetric {
      */
     public static boolean hasHbaseArgs(ParameterTool paramTool) {
         String args[] = {"hbase.master", "hbase.master.port", "hbase.zk.quorum", "hbase.zk.port", "hbase.namespace",
-            "hbase.table"};
+                "hbase.table"};
         return hasArgs(args, paramTool);
     }
 
@@ -156,7 +156,11 @@ public class AmsIngestMetric {
             batch = parameterTool.getInt("ams.batch");
             interval = parameterTool.getLong("ams.interval");
         }
-
+        String checkApiIntervalParam = null;
+        if (parameterTool.has("check.api.interval")) {
+            checkApiIntervalParam = parameterTool.get("check.api.interval");
+        }
+        setCheckApiInterval(checkApiIntervalParam);
         // Initialize Input Source : ARGO Messaging Source
         String endpoint = parameterTool.getRequired("ams.endpoint");
         String port = parameterTool.get("ams.port");
@@ -289,6 +293,9 @@ public class AmsIngestMetric {
      * to the metric data message
      */
     private static class MetricDataWithGroup extends RichFlatMapFunction<MetricData, Tuple2<String, MetricData>> {
+        private boolean shouldCheckApi = false;
+        private long lastCheckTimestamp = 0L;
+        //  private long lastTopologyLoadTime = 0L; // NEW
 
         private static final long serialVersionUID = 1L;
 
@@ -297,76 +304,134 @@ public class AmsIngestMetric {
         private ApiResourceManager amr;
         private ParameterTool params;
         private String runDate;
+        private boolean firstRun = true;
 
         public MetricDataWithGroup(ParameterTool params) {
             LOG.info("Enrich Metric Data with Group Info");
             this.params = params;
         }
 
-//        /**
+        //        /**
 //         * Initializes constructs in the beginning of operation
 //         *
 //         * @param parameters Configuration parameters to initialize structures
 //         * @throws URISyntaxException
 //         */
         @Override
-        public void open(Configuration parameters) throws IOException, ParseException, URISyntaxException {
-
+        public void open(Configuration parameters) {
             this.amr = new ApiResourceManager(this.params.getRequired("api.endpoint"), this.params.getRequired("api.token"));
             this.amr.setTimeoutSec(params.getInt("api.timeout"));
 
             if (params.has("proxy")) {
                 this.amr.setProxy(params.get("proxy"));
             }
-
+            //shouldCheckApi = !this.amr.isApiUp();
         }
 
         /**
          * The main flat map function that accepts metric data and generates
          * metric data with group information
          *
-         * @param value Input metric data in base64 encoded format from AMS
-         * service
          * @param out Collection of generated Tuple2<MetricData,String> objects
          */
         @Override
-        public void flatMap(MetricData item, Collector<Tuple2<String, MetricData>> out)
-                throws IOException, ParseException {
+        public void flatMap(MetricData item, Collector<Tuple2<String, MetricData>> out) {
+            long now = System.currentTimeMillis();
 
             //set rundate from the first item's timestamp and update each time the date is changed to the next day
             //in order to update the metric profile and endpoint info
             String currTimestampDate = item.getTimestamp().split("T")[0];
-            if (this.runDate == null || !runDate.equals(currTimestampDate)) {
-                loadTopology(currTimestampDate);
+
+            // Actually loadTopology() will be executed either if runDate is null or the timestamp of the
+            //MetricData points to next day so the topology should be refreshed. Also if it is the first run to load topology.
+            // if the api is up initially and at sometime it fails this will be noticed at the next day that the topology should sync
+            //if the api is down initially and at sometime it succeeds this will be noticed the next time shouldCheckApI() is executed
+
+            if (this.runDate == null || !runDate.equals(currTimestampDate) || (shouldCheckApi(lastCheckTimestamp))) {
+                try {
+                    loadTopology(currTimestampDate);
+                    lastCheckTimestamp = now;
+                } catch (Exception ex) {
+                    lastCheckTimestamp = now;
+
+                }
             }
+            try {
 
-            ArrayList<String> groups = egp.getGroupAllTopo(item.getHostname(), item.getService());
-            if (groups.isEmpty()) {
-                loadTopology(currTimestampDate);
-                groups = egp.getGroupAllTopo(item.getHostname(), item.getService());
-            }
-            for (String groupItem : groups) {
-                Tuple2<String, MetricData> curItem = new Tuple2<String, MetricData>();
+                ArrayList<String> groups = egp.getGroupAllTopo(item.getHostname(), item.getService());
+                System.out.println(" MetricDataWithGroup size " + egp.getGroupList().size());
+                if (groups.isEmpty()) {
+                    loadTopology(currTimestampDate);
+                    groups = egp.getGroupAllTopo(item.getHostname(), item.getService());
+                }
+                for (String groupItem : groups) {
+                    Tuple2<String, MetricData> curItem = new Tuple2<String, MetricData>();
+                    curItem.f0 = groupItem;
+                    curItem.f1 = item;
 
-                curItem.f0 = groupItem;
-                curItem.f1 = item;
-
-                out.collect(curItem);
+                    out.collect(curItem);
+                }
+            } catch (Exception e) {
+                Log.error("Exception in StatusMap due to web api error connection : ", e.getMessage());
             }
 
         }
 
         private void loadTopology(String currTimestampDate) {
             this.runDate = currTimestampDate;
-            this.amr.setDate(this.runDate);
-            this.amr.getAllRemoteTopoEndpoints();
+            //  lastCheckTimestamp = System.currentTimeMillis(); // Update last load time
 
-            ArrayList<GroupEndpoint> egpList = new ArrayList<GroupEndpoint>(Arrays.asList(this.amr.getListGroupEndpoints()));
+            try {
+                this.amr.setDate(this.runDate);
+                this.amr.getAllRemoteTopoEndpoints();
 
-            egp = new EndpointGroupManager();
-            egp.loadFromList(egpList);
+                ArrayList<GroupEndpoint> egpList = new ArrayList<GroupEndpoint>(Arrays.asList(this.amr.getListGroupEndpoints()));
+                egp = new EndpointGroupManager();
+                egp.loadFromList(egpList);
+                shouldCheckApi = false;
+            } catch (UnknownHostException e) {
+                shouldCheckApi = true;
+                // DNS resolution failure — API domain does not exist
+                Log.error("UnknownHostException: API endpoint not found:", e.getMessage());
+                throw new RuntimeException("API domain not found: ", e); // Wrap in a RuntimeException
+            } catch (Exception e) {
+                shouldCheckApi = true;
+                Log.error("Exception in StatusMap due to web api error connection : ", e.getMessage());
+            }
 
         }
+
+        // this function succeeds if
+        // 1. is first run to load topology, so it forces the procedure
+        // 2. if shouldCheckApi flag is true based on the succeed or not of loadTopology()
+        //and time interval to check the api has passed
+
+        private boolean shouldCheckApi(long lastCheckTimestamp) {//should check api every time interval , regardless if
+            if (firstRun) {
+                firstRun = false;
+                return true; // force first fetch
+            }
+
+            if (!shouldCheckApi) {  //once the shouldCheckApi is false it returns.
+                return false; //so by this we succeed to check api only if it has failed and not periodicallhy
+            }
+            if (checkApiIntervalType == null) {
+                // Fallback or exception for invalid enum state
+                throw new IllegalStateException("checkApiIntervalType must not be null");
+            }
+
+            switch (checkApiIntervalType) {
+                case DAY:
+                    return TimeUnit.MILLISECONDS.toDays(System.currentTimeMillis() - lastCheckTimestamp) >= checkApiInterval;
+                case HOURS:
+                    return TimeUnit.MILLISECONDS.toHours(System.currentTimeMillis() - lastCheckTimestamp) >= checkApiInterval;
+                case MINUTES:
+                    return TimeUnit.MILLISECONDS.toMinutes(System.currentTimeMillis() - lastCheckTimestamp) >= checkApiInterval;
+                default:
+                    throw new UnsupportedOperationException("Unsupported interval type: " + checkApiIntervalType);
+            }
+        }
+
     }
 
     public static boolean hasInfluxDBArgs(ParameterTool paramTool) {
@@ -374,4 +439,13 @@ public class AmsIngestMetric {
         String influxArgs[] = {"influx.token", "influx.port", "influx.endpoint", "influx.bucket", "influx.org"};
         return hasArgs(influxArgs, paramTool);
     }
+
+    private static void setCheckApiInterval(String checkApiIntervalParam) {
+        IntervalStruct intervalStruct = IntervalStruct.parseInterval(checkApiIntervalParam);
+
+        checkApiInterval = intervalStruct.intervalValue;
+        checkApiIntervalType = intervalStruct.intervalType;
+
+    }
+
 }

--- a/flink_jobs_v2/ams_ingest_metric/src/main/java/argo/streaming/IntervalStruct.java
+++ b/flink_jobs_v2/ams_ingest_metric/src/main/java/argo/streaming/IntervalStruct.java
@@ -1,0 +1,58 @@
+package argo.streaming;
+
+import org.apache.commons.lang.StringUtils;
+
+public  class IntervalStruct {
+
+    IntervalType intervalType;
+    int intervalValue;
+
+    public IntervalStruct(IntervalType intervalType, int intervalValue) {
+        this.intervalType = intervalType;
+        this.intervalValue = intervalValue;
+    }
+
+    public IntervalType getIntervalType() {
+        return intervalType;
+    }
+
+    public void setIntervalType(IntervalType intervalType) {
+        this.intervalType = intervalType;
+    }
+
+    public int getIntervalValue() {
+        return intervalValue;
+    }
+
+    public void setIntervalValue(int intervalValue) {
+        this.intervalValue = intervalValue;
+    }
+
+    public static IntervalStruct parseInterval(String intervalParam) {
+        if (intervalParam == null) {
+            return new IntervalStruct(IntervalType.DAY, 24); // default 1 day
+        }
+
+        String regex = "\\d+(h|d|m)$";
+        if (!intervalParam.matches(regex)) {
+            return new IntervalStruct(IntervalType.DAY, 24); // default
+        }
+
+        IntervalType intervalType;
+        int intervalValue;
+
+        if (intervalParam.endsWith("h")) {
+            intervalType = IntervalType.HOURS;
+            intervalValue = Integer.parseInt(intervalParam.replace("h", "")) * 60;
+        } else if (intervalParam.endsWith("d")) {
+            intervalType = IntervalType.DAY;
+            intervalValue = Integer.parseInt(intervalParam.replace("d", "")) * 24 * 60;
+        } else { // ends with m
+            intervalType = IntervalType.MINUTES;
+            intervalValue = Integer.parseInt(intervalParam.replace("m", ""));
+        }
+
+        return new IntervalStruct(intervalType, intervalValue);
+    }
+
+}

--- a/flink_jobs_v2/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
+++ b/flink_jobs_v2/stream_status/src/main/java/argo/streaming/AmsStreamStatus.java
@@ -1,31 +1,31 @@
 package argo.streaming;
 
 import Utils.IntervalType;
-import static Utils.IntervalType.DAY;
-import static Utils.IntervalType.HOURS;
-import static Utils.IntervalType.MINUTES;
 import ams.connector.ArgoMessagingSink;
 import ams.connector.ArgoMessagingSource;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.text.ParseException;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.Properties;
-
+import argo.amr.ApiResource;
+import argo.amr.ApiResourceManager;
+import argo.avro.Downtime;
+import argo.avro.GroupEndpoint;
+import argo.avro.MetricData;
+import argo.avro.MetricProfile;
+import com.esotericsoftware.minlog.Log;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.commons.codec.binary.Base64;
-
+import org.apache.commons.lang.StringUtils;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.co.RichCoFlatMapFunction;
@@ -41,24 +41,20 @@ import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-
-import argo.amr.ApiResource;
-import argo.amr.ApiResourceManager;
-import argo.avro.Downtime;
-import argo.avro.GroupEndpoint;
-import argo.avro.MetricData;
-import argo.avro.MetricProfile;
-import org.apache.commons.lang.StringUtils;
-import org.apache.flink.api.common.JobID;
-import org.apache.flink.core.fs.FileSystem;
 import org.slf4j.MDC;
 import profilesmanager.EndpointGroupManager;
 import profilesmanager.MetricProfileManager;
 import status.StatusManager;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.text.ParseException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Properties;
 
 /**
  * Flink Job : Streaming status computation with multiple destinations (hbase,
@@ -92,24 +88,26 @@ import status.StatusManager;
  * DAYS, HOURS, MINUTES eg. 1h, 2d, 30m to define the period . Any of these
  * formats is transformed to minutes in the computations if not defined the
  * default value is 1440m
- *
+ * <p>
  * --interval.strict(Optional)interval to repeat events for CRITICAL . it can be
  * in the format of DAYS, HOURS, MINUTES eg. 1h, 2d, 30m to define the period .
  * Any of these formats is transformed to minutes in the computations if not
  * defined the default value is 1440m
- *
+ * <p>
  * -- latest.offset (Optional) boolean true/false, to define if the argo
  * messaging source should set offset at the latest or at the start of the
  * runDate. By default, if not defined , the offset should be the latest.
  * --level_group,level_service,level_endpoint, level_metric, if ON level alerts
  * are generated,if OFF level alerts are disabled.if no level is defined in
  * parameters then all levels are generated
- *
+ * <p>
  * --sync.interval(Optional) , the interval to sync with the argo web api source
  * (metric profiles, topology, downtimes) it can be * in the format of DAYS,
  * HOURS, MINUTES eg. 1h, 2d, 30m to define the period . By default is 24h , if
  * the parameter is not configured
- *
+ * --check.api.interval: the interval to check the argo-web api connection,by default 24h. it can be * in the format of DAYS,
+ *  * HOURS, MINUTES eg. 1h, 2d, 30m to define the period . By default is 24h , if
+ *  * the parameter is not configured
  */
 public class AmsStreamStatus {
     // setup logger
@@ -127,7 +125,7 @@ public class AmsStreamStatus {
      * Sets configuration parameters to streaming enviroment
      *
      * @param config A StatusConfig object that holds configuration parameters
-     * for this job
+     *               for this job
      * @return Stream execution enviroment
      */
     private static StreamExecutionEnvironment setupEnvironment(StatusConfig config) {
@@ -152,7 +150,7 @@ public class AmsStreamStatus {
 
     public static boolean hasHbaseArgs(ParameterTool paramTool) {
         String hbaseArgs[] = {"hbase.master", "hbase.master.port", "hbase.zk.quorum", "hbase.namespace",
-            "hbase.table"};
+                "hbase.table"};
         return hasArgs(hbaseArgs, paramTool);
     }
 
@@ -245,10 +243,16 @@ public class AmsStreamStatus {
         if (parameterTool.has("api.timeout")) {
             amr.setTimeoutSec(parameterTool.getInt("api.timeout"));
         }
-
-        amr.setReportID(reportID);
-        amr.getRemoteAll();
-
+        try {
+            amr.setReportID(reportID);
+            amr.getRemoteAll();
+        } catch (UnknownHostException e) {
+            // DNS resolution failure — API domain does not exist
+            Log.error("UnknownHostException: API endpoint not found: ", e.getMessage());
+            throw new RuntimeException("API domain not found: ", e); // Wrap in a RuntimeException
+        } catch (Exception e) {
+            Log.error("Exception in main due to web api error connection : ", e.getMessage());
+        }
         // set ams client batch and interval to default values
         int batch = 1;
         long interval = 100L;
@@ -267,12 +271,15 @@ public class AmsStreamStatus {
         String syncInterval = null;
         if (parameterTool.has("sync.interval")) {
             syncInterval = parameterTool.get("sync.interval");
-
         }
 
-        ArgoMessagingSource amsMetric = new ArgoMessagingSource(endpoint, port, token, project, subMetric, batch, interval, offsetDt);
-        ArgoApiSource apiSync = new ArgoApiSource(apiEndpoint, apiToken, reportID, syncInterval, apiInterval);
 
+        String checkApiInterval = null;
+        if (parameterTool.has("check.api.interval")) {
+            checkApiInterval = parameterTool.get("check.api.interval");
+        }
+        ArgoMessagingSource amsMetric = new ArgoMessagingSource(endpoint, port, token, project, subMetric, batch, interval, offsetDt);
+        ArgoApiSource apiSync = new ArgoApiSource(apiEndpoint, apiToken, reportID, syncInterval, apiInterval, checkApiInterval);
         if (parameterTool.has("ams.verify")) {
             boolean verify = parameterTool.getBoolean("ams.verify");
             amsMetric.setVerify(verify);
@@ -395,6 +402,9 @@ public class AmsStreamStatus {
 
         public StatusConfig config;
         private ApiResourceManager amr;
+        private transient Thread endpointSchedulerThread;
+        boolean isCorrectEndpoint = true;
+        private volatile boolean isRunning = true;
 
         public MetricDataWithGroup(StatusConfig config) {
             LOG.info("Created new Status map");
@@ -419,26 +429,38 @@ public class AmsStreamStatus {
             }
 
             this.amr.setReportID(config.reportID);
-            this.amr.getRemoteAll();
 
-            ArrayList<MetricProfile> mpsList = new ArrayList<MetricProfile>(Arrays.asList(this.amr.getListMetrics()));
-            ArrayList<GroupEndpoint> egpList = new ArrayList<GroupEndpoint>(Arrays.asList(this.amr.getListGroupEndpoints()));
-
-            mps = new MetricProfileManager();
-            mps.loadFromList(mpsList);
-            String validMetricProfile = mps.getProfiles().get(0);
-            ArrayList<String> validServices = mps.getProfileServices(validMetricProfile);
-
-            // Trim profile services
-            ArrayList<GroupEndpoint> egpTrim = new ArrayList<GroupEndpoint>();
-            // Use optimized Endpoint Group Manager
-            for (GroupEndpoint egpItem : egpList) {
-                if (validServices.contains(egpItem.getService())) {
-                    egpTrim.add(egpItem);
-                }
-            }
             egp = new EndpointGroupManager();
-            egp.loadFromList(egpTrim);
+            mps = new MetricProfileManager();
+
+            try {
+                this.amr.getRemoteAll();
+
+                ArrayList<MetricProfile> mpsList = new ArrayList<MetricProfile>(Arrays.asList(this.amr.getListMetrics()));
+                ArrayList<GroupEndpoint> egpList = new ArrayList<GroupEndpoint>(Arrays.asList(this.amr.getListGroupEndpoints()));
+
+                //    mps = new MetricProfileManager();
+                mps.loadFromList(mpsList);
+                String validMetricProfile = mps.getProfiles().get(0);
+                ArrayList<String> validServices = mps.getProfileServices(validMetricProfile);
+
+                // Trim profile services
+                ArrayList<GroupEndpoint> egpTrim = new ArrayList<GroupEndpoint>();
+                // Use optimized Endpoint Group Manager
+                for (GroupEndpoint egpItem : egpList) {
+                    if (validServices.contains(egpItem.getService())) {
+                        egpTrim.add(egpItem);
+                    }
+                }
+                //  egp = new EndpointGroupManager();
+                egp.loadFromList(egpTrim);
+            } catch (UnknownHostException e) {
+                // DNS resolution failure — API domain does not exist
+                Log.error("UnknownHostException: API endpoint not found:", e.getMessage());
+                throw new RuntimeException("API domain not found: ", e); // Wrap in a RuntimeException
+            } catch (Exception e) {
+                Log.error("Exception in StatusMap due to web api error connection : ", e.getMessage());
+            }
 
         }
 
@@ -447,8 +469,8 @@ public class AmsStreamStatus {
          * metric data with group information
          *
          * @param value Input metric data in base64 encoded format from AMS
-         * service
-         * @param out Collection of generated Tuple2<MetricData,String> objects
+         *              service
+         * @param out   Collection of generated Tuple2<MetricData,String> objects
          */
         @Override
         public void flatMap1(String value, Collector<Tuple2<String, MetricData>> out)
@@ -482,7 +504,7 @@ public class AmsStreamStatus {
                 curItem.f1 = item;
 
                 out.collect(curItem);
-                System.out.println("item enriched: " + curItem.toString());
+                //  System.out.println("item enriched: " + curItem.toString());
             }
 
         }
@@ -494,29 +516,35 @@ public class AmsStreamStatus {
                 // Update mps
                 ArrayList<MetricProfile> mpsList = SyncParse.parseMetricJSON(value.f1);
                 mps = new MetricProfileManager();
-                mps.loadFromList(mpsList);
+                try {
+                    mps.loadFromList(mpsList);
+                } catch (Exception e) {
+                    Log.error("Exception in MetricDataWithGroup flatMap2 loading metric profile due to web api error connection : ", e.getMessage());
+                }
+
             } else if (value.f0.equalsIgnoreCase("group_endpoints")) {
                 // Update egp
                 ArrayList<GroupEndpoint> egpList = SyncParse.parseGroupEndpointJSON(value.f1);
+
                 egp = new EndpointGroupManager();
-
-                String validMetricProfile = mps.getProfiles().get(0);
-                ArrayList<String> validServices = mps.getProfileServices(validMetricProfile);
-                // Trim profile services
-                ArrayList<GroupEndpoint> egpTrim = new ArrayList<GroupEndpoint>();
-                // Use optimized Endpoint Group Manager
-                for (GroupEndpoint egpItem : egpList) {
-                    if (validServices.contains(egpItem.getService())) {
-                        egpTrim.add(egpItem);
+                try {
+                    String validMetricProfile = mps.getProfiles().get(0);
+                    ArrayList<String> validServices = mps.getProfileServices(validMetricProfile);
+                    // Trim profile services
+                    ArrayList<GroupEndpoint> egpTrim = new ArrayList<GroupEndpoint>();
+                    // Use optimized Endpoint Group Manager
+                    for (GroupEndpoint egpItem : egpList) {
+                        if (validServices.contains(egpItem.getService())) {
+                            egpTrim.add(egpItem);
+                        }
                     }
+
+                    // load next topology into a temporary endpoint group manager
+                    egp.loadFromList(egpTrim);
+                } catch (Exception e) {
+                    Log.error("Exception in MetricDataWithGroup flatMap2 loading metric profile due to web api error connection : ", e.getMessage());
                 }
-                ArrayList<GroupEndpoint> test = egpTrim;
-
-                // load next topology into a temporary endpoint group manager
-                egp.loadFromList(egpTrim);
-
             }
-
         }
 
     }
@@ -544,6 +572,9 @@ public class AmsStreamStatus {
         boolean level_service;
         boolean level_endpoint;
         boolean level_metric;
+        private transient Thread endpointSchedulerThread;
+        boolean isCorrectEndpoint = true;
+        private volatile boolean isRunning = true;
 
         public StatusMap(StatusConfig config, int looseInterval, int strictInterval, boolean level_group, boolean level_service, boolean level_endpoint, boolean level_metric) {
             LOG.info("Created new Status map");
@@ -564,8 +595,7 @@ public class AmsStreamStatus {
          * @throws URISyntaxException
          */
         @Override
-        public void open(Configuration parameters) throws IOException, ParseException, URISyntaxException {
-
+        public void open(Configuration parameters) {
             pID = Integer.toString(getRuntimeContext().getIndexOfThisSubtask());
 
             this.amr = new ApiResourceManager(config.apiEndpoint, config.apiToken);
@@ -574,38 +604,44 @@ public class AmsStreamStatus {
             if (config.apiProxy != null) {
                 this.amr.setProxy(config.apiProxy);
             }
-
-            this.amr.setReportID(config.reportID);
-            this.amr.getRemoteAll();
-
-            String opsJSON = this.amr.getResourceJSON(ApiResource.OPS);
-            String apsJSON = this.amr.getResourceJSON(ApiResource.AGGREGATION);
-            ArrayList<String> opsList = new ArrayList();
-            opsList.add(opsJSON);
-            ArrayList<String> apsList = new ArrayList();
-            apsList.add(apsJSON);
-            ArrayList<Downtime> downList = new ArrayList<Downtime>(Arrays.asList(this.amr.getListDowntimes()));
-            ArrayList<MetricProfile> mpsList = new ArrayList<MetricProfile>(Arrays.asList(this.amr.getListMetrics()));
-            ArrayList<GroupEndpoint> egpListFull = new ArrayList<GroupEndpoint>(Arrays.asList(this.amr.getListGroupEndpoints()));
-
-            // create a new status manager
             sm = new StatusManager();
-            sm.setLooseInterval(looseInterval);
-            sm.setStrictInterval(strictInterval);
-            // sm.setTimeout(config.timeout);
-            sm.setReport(config.report);
-            sm.setGroupType(this.amr.getEgroup());
-            // load all the connector data
-            sm.loadAll(config.runDate, downList, egpListFull, mpsList, apsList, opsList);
-            sm.setLevel_group(level_group);
-            sm.setLevel_service(level_service);
-            sm.setLevel_endpoint(level_endpoint);
-            sm.setLevel_metric(level_metric);
 
-            // Set the default status as integer
-            initStatus = sm.getOps().getIntStatus(config.initStatus);
-            LOG.info("Initialized status manager:" + pID + " (with critical timeout:" + sm.getStrictInterval() + " and warning/unknown/missing timeout " + sm.getLooseInterval() + ")");
+            try {
 
+                this.amr.setReportID(config.reportID);
+                this.amr.getRemoteAll();
+
+                String opsJSON = this.amr.getResourceJSON(ApiResource.OPS);
+                String apsJSON = this.amr.getResourceJSON(ApiResource.AGGREGATION);
+                ArrayList<String> opsList = new ArrayList();
+                opsList.add(opsJSON);
+                ArrayList<String> apsList = new ArrayList();
+                apsList.add(apsJSON);
+                ArrayList<Downtime> downList = new ArrayList<Downtime>(Arrays.asList(this.amr.getListDowntimes()));
+                ArrayList<MetricProfile> mpsList = new ArrayList<MetricProfile>(Arrays.asList(this.amr.getListMetrics()));
+                ArrayList<GroupEndpoint> egpListFull = new ArrayList<GroupEndpoint>(Arrays.asList(this.amr.getListGroupEndpoints()));
+
+                sm.setStrictInterval(strictInterval);
+                // sm.setTimeout(config.timeout);
+                sm.setReport(config.report);
+                sm.setGroupType(this.amr.getEgroup());
+                // load all the connector data
+                sm.loadAll(config.runDate, downList, egpListFull, mpsList, apsList, opsList);
+                sm.setLevel_group(level_group);
+                sm.setLevel_service(level_service);
+                sm.setLevel_endpoint(level_endpoint);
+                sm.setLevel_metric(level_metric);
+
+                // Set the default status as integer
+                initStatus = sm.getOps().getIntStatus(config.initStatus);
+                LOG.info("Initialized status manager:" + pID + " (with critical timeout:" + sm.getStrictInterval() + " and warning/unknown/missing timeout " + sm.getLooseInterval() + ")");
+            } catch (UnknownHostException e) {
+                // DNS resolution failure — API domain does not exist
+                Log.error("UnknownHostException: API endpoint not found:", e.getMessage());
+                throw new RuntimeException("API domain not found: ", e); // Wrap in a RuntimeException
+            } catch (Exception e) {
+                Log.error("Exception in StatusMap due to web api error connection : ", e.getMessage());
+            }
         }
 
         /**
@@ -613,8 +649,8 @@ public class AmsStreamStatus {
          * status events
          *
          * @param value Input metric data in base64 encoded format from AMS
-         * service
-         * @param out Collection of generated status events as json strings
+         *              service
+         * @param out   Collection of generated status events as json strings
          */
         @Override
         public void flatMap1(Tuple2<String, MetricData> value, Collector<String> out)
@@ -632,76 +668,101 @@ public class AmsStreamStatus {
             String message = item.getMessage();
             String summary = item.getSummary();
             String dayStamp = tsMon.split("T")[0];
-
-            if (!sm.checkIfExistDowntime(dayStamp)) {
-                this.amr.setDate(dayStamp);
-                this.amr.getRemoteDowntimes();
-                ArrayList<Downtime> downList = new ArrayList<Downtime>(Arrays.asList(this.amr.getListDowntimes()));
-                sm.addDowntimeSet(dayStamp, downList);
-            }
-
-            // if daily generation is enable check if has day changed?
-            if (config.daily && sm.hasDayChanged(sm.getTsLatest(), tsMon)) {
-                ArrayList<String> eventsDaily = sm.dumpStatus(tsMon);
-                sm.setTsLatest(tsMon);
-                for (String event : eventsDaily) {
-                    out.collect(event);
-                    LOG.info("sm-" + pID + ": daily event produced: " + event);
+            try {
+                if (!sm.checkIfExistDowntime(dayStamp)) {
+                    this.amr.setDate(dayStamp);
+                    this.amr.getRemoteDowntimes();
+                    ArrayList<Downtime> downList = new ArrayList<Downtime>(Arrays.asList(this.amr.getListDowntimes()));
+                    sm.addDowntimeSet(dayStamp, downList);
                 }
-            }
 
-            // check if group is handled by this operator instance - if not
-            // construct the group based on sync data
-            if (!sm.hasGroup(group)) {
-                // Get start of the day to create new entries
-                Date dateTS = sm.setDate(tsMon);
-                sm.addNewGroup(group, initStatus, dateTS);
-            }
+                // if daily generation is enable check if has day changed?
+                if (config.daily && sm.hasDayChanged(sm.getTsLatest(), tsMon)) {
+                    ArrayList<String> eventsDaily = sm.dumpStatus(tsMon);
+                    sm.setTsLatest(tsMon);
+                    for (String event : eventsDaily) {
+                        out.collect(event);
+                        LOG.info("sm-" + pID + ": daily event produced: " + event);
+                    }
+                }
 
-            ArrayList<String> events = sm.setStatus(group, service, hostname, metric, status, monHost, tsMon, summary, message);
+                // check if group is handled by this operator instance - if not
+                // construct the group based on sync data
+                if (!sm.hasGroup(group)) {
+                    // Get start of the day to create new entries
+                    Date dateTS = sm.setDate(tsMon);
+                    sm.addNewGroup(group, initStatus, dateTS);
+                }
 
-            for (String event : events) {
-                out.collect(event);
-                LOG.info("sm-" + pID + ": event produced: " + item);
+                ArrayList<String> events = sm.setStatus(group, service, hostname, metric, status, monHost, tsMon, summary, message);
+
+                for (String event : events) {
+                    out.collect(event);
+                    LOG.info("sm-" + pID + ": event produced: " + item);
+                }
+            } catch (Exception e) {
+                System.out.println("error in StatusMap flatmap 1");
+
             }
         }
 
         public void flatMap2(Tuple2<String, String> value, Collector<String> out) throws IOException, ParseException {
 
             if (value.f0.equalsIgnoreCase("metric_profile")) {
+
                 // Update mps
-                ArrayList<MetricProfile> mpsList = SyncParse.parseMetricJSON(value.f1);
-                sm.mps = new MetricProfileManager();
-                sm.mps.loadFromList(mpsList);
+                try {
+                    sm.mps = new MetricProfileManager();
+
+                    ArrayList<MetricProfile> mpsList = SyncParse.parseMetricJSON(value.f1);
+                     sm.mps.loadFromList(mpsList);
+                } catch (Exception e) {
+                    System.out.println("error in statusMap flatmap2 metric profiles");
+                }
+
             } else if (value.f0.equals("group_endpoints")) {
                 // Update egp
-                ArrayList<GroupEndpoint> egpList = SyncParse.parseGroupEndpointJSON(value.f1);
 
-                String validMetricProfile = sm.mps.getProfiles().get(0);
-                ArrayList<String> validServices = sm.mps.getProfileServices(validMetricProfile);
-                // Trim profile services
-                ArrayList<GroupEndpoint> egpTrim = new ArrayList<GroupEndpoint>();
-                // Use optimized Endpoint Group Manager
-                for (GroupEndpoint egpItem : egpList) {
-                    if (validServices.contains(egpItem.getService())) {
-                        egpTrim.add(egpItem);
+                try {
+                    EndpointGroupManager egpNext = new EndpointGroupManager();
+                    ArrayList<GroupEndpoint> egpList = SyncParse.parseGroupEndpointJSON(value.f1);
+
+                    String validMetricProfile = sm.mps.getProfiles().get(0);
+                    ArrayList<String> validServices = sm.mps.getProfileServices(validMetricProfile);
+                    // Trim profile services
+                    ArrayList<GroupEndpoint> egpTrim = new ArrayList<GroupEndpoint>();
+                    // Use optimized Endpoint Group Manager
+                    for (GroupEndpoint egpItem : egpList) {
+                        if (validServices.contains(egpItem.getService())) {
+                            egpTrim.add(egpItem);
+                        }
                     }
-                }
-                // load next topology into a temporary endpoint group manager
-                EndpointGroupManager egpNext = new EndpointGroupManager();
-                egpNext.loadFromList(egpTrim);
+                    // load next topology into a temporary endpoint group manager
+                    egpNext.loadFromList(egpTrim);
 
-                // Use existing topology manager inside status manager to make a comparison
-                // with the new topology stored in the temp endpoint group manager
-                // update topology also sets the next topology manager as status manager current 
-                // topology manager only after removal of decomissioned items
-                sm.updateTopology(egpNext);
+                    // Use existing topology manager inside status manager to make a comparison
+                    // with the new topology stored in the temp endpoint group manager
+                    // update topology also sets the next topology manager as status manager current
+                    // topology manager only after removal of decomissioned items
+                    sm.updateTopology(egpNext);
+
+                } catch (Exception e) {
+                    System.out.println("error in statusMap flatmap2 endpoints");
+                }
 
             } else if (value.f0.equalsIgnoreCase("downtimes")) {
                 String pDate = Instant.now().toString().split("T")[0];
-                ArrayList<Downtime> downList = SyncParse.parseDowntimesJSON(value.f1);
-                // Update downtime cache in status manager
-                sm.addDowntimeSet(pDate, downList);
+                try {
+                    ArrayList<Downtime> downList = SyncParse.parseDowntimesJSON(value.f1);
+
+                    // Update downtime cache in status manager
+                    sm.addDowntimeSet(pDate, downList);
+
+                } catch (Exception e) {
+                    System.out.println("error in StatusMap flatmap 2 downtimes");
+                }
+
+
             }
 
         }
@@ -888,6 +949,33 @@ public class AmsStreamStatus {
             this.intervalValue = intervalValue;
         }
 
+        public static IntervalStruct parseInterval(String intervalParam) {
+            if (intervalParam == null) {
+                return new IntervalStruct(IntervalType.DAY, 24); // default 1 day
+            }
+
+            String regex = "\\d+(h|d|m)$";
+            if (!intervalParam.matches(regex)) {
+                return new IntervalStruct(IntervalType.DAY, 24); // default
+            }
+
+            IntervalType intervalType;
+            int intervalValue;
+
+            if (intervalParam.endsWith("h")) {
+                intervalType = IntervalType.HOURS;
+                intervalValue = Integer.parseInt(intervalParam.replace("h", "")) * 60;
+            } else if (intervalParam.endsWith("d")) {
+                intervalType = IntervalType.DAY;
+                intervalValue = Integer.parseInt(intervalParam.replace("d", "")) * 24 * 60;
+            } else { // ends with m
+                intervalType = IntervalType.MINUTES;
+                intervalValue = Integer.parseInt(intervalParam.replace("m", ""));
+            }
+
+            return new IntervalStruct(intervalType, intervalValue);
+        }
+
     }
 
     public static IntervalStruct parseInterval(String intervalParam) {
@@ -960,5 +1048,6 @@ public class AmsStreamStatus {
             return false;
         }
     }
+
 
 }

--- a/flink_jobs_v2/stream_status/src/main/java/argo/streaming/ArgoApiSource.java
+++ b/flink_jobs_v2/stream_status/src/main/java/argo/streaming/ArgoApiSource.java
@@ -1,52 +1,62 @@
 package argo.streaming;
+
 import Utils.IntervalType;
 import argo.amr.ApiResource;
 import argo.amr.ApiResourceManager;
+
 import java.time.Duration;
 import java.time.Instant;
 
+import com.esotericsoftware.minlog.Log;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 /**
  * Custom source to connect to ArgoWebApi service. Uses API Resource Manager
  */
-public class ArgoApiSource extends RichSourceFunction<Tuple2<String,String>> {
+public class ArgoApiSource extends RichSourceFunction<Tuple2<String, String>> {
 
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-	// setup logger
-	static Logger LOG = LoggerFactory.getLogger(ArgoApiSource.class);
+    // setup logger
+    static Logger LOG = LoggerFactory.getLogger(ArgoApiSource.class);
 
-	private String endpoint = null;
-	private String token = null;
-	private String reportID = null;
-        private int syncInterval = 24;
-        private IntervalType intervalType = IntervalType.HOURS;
-   
-	private long interval = 100L;
-	private boolean verify = true;
-	private boolean useProxy = false;
-	private String proxyURL = "";
-	private transient Object rateLck; // lock for waiting to establish rate
+    private String endpoint = null;
+    private String token = null;
+    private String reportID = null;
+    private int syncInterval = 24;
+    private IntervalType intervalType = IntervalType.HOURS;
 
-	private volatile boolean isRunning = true;
+    private long interval = 100L;
+    private boolean verify = true;
+    private boolean useProxy = false;
+    private String proxyURL = "";
+    private transient Object rateLck; // lock for waiting to establish rate
 
-        private ApiResourceManager client = null;
-	private Instant timeSnapshot = null;
-	
-    public ArgoApiSource(String endpoint, String token, String reportID, String syncInterval, Long interval) {
+    private volatile boolean isRunning = true;
+
+    private ApiResourceManager client = null;
+    private Instant timeSnapshot = null;
+    private int checkApiInterval = 1;
+    private IntervalType checkApiIntervalType = IntervalType.HOURS;
+    private boolean shouldCheckApi = false;
+    private boolean firstRun = true;
+
+
+    public ArgoApiSource(String endpoint, String token, String reportID, String syncInterval, Long interval, String checkApiInterval) {
         this.endpoint = endpoint;
         this.token = token;
         this.reportID = reportID;
         this.interval = interval;
         this.verify = true;
-        if(syncInterval!=null){
+        if (syncInterval != null) {
             setSyncUpdate(syncInterval);
         }
 
+        setCheckApiInterval(checkApiInterval);
     }
 
     private void setSyncUpdate(String syncInterval) {
@@ -62,122 +72,161 @@ public class ArgoApiSource extends RichSourceFunction<Tuple2<String,String>> {
 
     }
 
-	/**
-	 * Set verify to true or false. If set to false AMS client will be able to contact AMS endpoints that use self-signed certificates
-	 */
-	public void setVerify(boolean verify) {
-		this.verify=verify;
-	}
-	/**
-	 * Set proxy details for AMS client
-	 */
-	public void setProxy(String proxyURL) {
-		this.useProxy = true;
-		this.proxyURL = proxyURL;
-	}
-	
-	/**
-	 * Unset proxy details for AMS client
-	 */
-	public void unsetProxy(String proxyURL) {
-		this.useProxy = false;
-		this.proxyURL = "";
-	}
-	
-	
-	@Override
-	public void cancel() {
-		isRunning = false;
+    private void setCheckApiInterval(String checkApiIntervalParam) {
+        AmsStreamStatus.IntervalStruct intervalStruct = AmsStreamStatus.IntervalStruct.parseInterval(checkApiIntervalParam);
 
-	}
+        checkApiInterval = intervalStruct.intervalValue;
+        checkApiIntervalType = intervalStruct.intervalType;
+    }
 
-	@Override
-	public void run(SourceContext<Tuple2<String,String>> ctx) throws Exception {
-		// This is the main run logic
-		while (isRunning) {
-			
-			// check if interval in hours has passed to make a move
-			Instant ti = Instant.now();
-			Duration td = Duration.between(this.timeSnapshot,ti);
-			// interval has passed do consume from api
-			 if (isTimeForSync(td)) {
-                             System.out.println("update sync ");
-                        	this.timeSnapshot = ti;
-				// retrieve info from api
-				this.client.getRemoteAll();
+    /**
+     * Set verify to true or false. If set to false AMS client will be able to contact AMS endpoints that use self-signed certificates
+     */
+    public void setVerify(boolean verify) {
+        this.verify = verify;
+    }
 
-				Tuple2<String, String> mt = new Tuple2<String, String>("metric_profile",client.getResourceJSON(ApiResource.METRIC));
-				Tuple2<String, String> gt = new Tuple2<String, String>("group_endpoints",client.getResourceJSON(ApiResource.TOPOENDPOINTS));
-				Tuple2<String, String> dt = new Tuple2<String, String>("downtimes",client.getResourceJSON(ApiResource.DOWNTIMES));
-				
-				ctx.collect(mt);
-				ctx.collect(gt);
-				ctx.collect(dt);
-				
-				
+    /**
+     * Set proxy details for AMS client
+     */
+    public void setProxy(String proxyURL) {
+        this.useProxy = true;
+        this.proxyURL = proxyURL;
+    }
 
-			}
-			synchronized (rateLck) {
-				rateLck.wait(this.interval);
-			}
-
-		}
-
-	}
-
-	/**
-	 * Argo-web-api Source initialization
-	 */
-	@Override
-	public void open(Configuration parameters) throws Exception {
-		// init rate lock
-		rateLck = new Object();
-		
-		
-		this.timeSnapshot = Instant.now();
-		
-		this.client = new ApiResourceManager(this.endpoint, this.token);
-		client.setReportID(this.reportID);
-		client.setVerify(this.verify);
-		if (this.useProxy) {
-			client.setProxy(this.proxyURL);
-		}
-		
-		
-	}
-
-	@Override
-	public void close() throws Exception {
-		if (this.client != null) {
-			this.client = null;
-		}
-		synchronized (rateLck) {
-			rateLck.notify();
-		}
-	}
-       
-        private boolean isTimeForSync(Duration td) {
-        boolean isTime=false;
-        switch (this.intervalType) {
-           
-            case DAY:
-                isTime=td.toDays() > this.syncInterval;
-                return td.toDays() > this.syncInterval;
-            case HOURS:
-                
-                isTime=td.toDays() > this.syncInterval;
-                return td.toHours() > this.syncInterval;
-            case MINUTES:
-                
-                isTime=td.toDays() > this.syncInterval;
-                return td.toMinutes() > this.syncInterval;
-            default:
-                
-                 isTime=td.toDays() > this.syncInterval;
-                return td.toHours() > this.syncInterval;
-
-        }
+    /**
+     * Unset proxy details for AMS client
+     */
+    public void unsetProxy(String proxyURL) {
+        this.useProxy = false;
+        this.proxyURL = "";
     }
 
 
+    @Override
+    public void cancel() {
+        isRunning = false;
+
+    }
+
+    @Override
+    public void run(SourceContext<Tuple2<String, String>> ctx) throws Exception {
+        // This is the main run logic
+        while (isRunning) {
+
+            // check if interval in hours has passed to make a move
+            Instant ti = Instant.now();
+            Duration td = Duration.between(this.timeSnapshot, ti);
+            // interval has passed do consume from api
+            if (isTimeForSync(td) || shouldCheckApi(td)) {
+                this.timeSnapshot = ti;
+                // retrieve info from api
+                try {
+                    this.client.getRemoteAll();
+
+                    Tuple2<String, String> mt = new Tuple2<String, String>("metric_profile", client.getResourceJSON(ApiResource.METRIC));
+                    Tuple2<String, String> gt = new Tuple2<String, String>("group_endpoints", client.getResourceJSON(ApiResource.TOPOENDPOINTS));
+                    Tuple2<String, String> dt = new Tuple2<String, String>("downtimes", client.getResourceJSON(ApiResource.DOWNTIMES));
+                    ctx.collect(mt);
+
+                    ctx.collect(gt);
+                    ctx.collect(dt);
+                    shouldCheckApi = false;
+
+                    Log.info("Web api connection succeeded ");
+
+                } catch (Exception e) {
+                    shouldCheckApi = true;
+                    Log.error("Exception in ArgoApiSource due to web api error connection : ", e.getMessage());
+
+                }
+            }
+            synchronized (rateLck) {
+                rateLck.wait(this.interval);
+            }
+
+        }
+
+    }
+
+    /**
+     * Argo-web-api Source initialization
+     */
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        // init rate lock
+        rateLck = new Object();
+
+
+        this.timeSnapshot = Instant.now();
+
+        this.client = new ApiResourceManager(this.endpoint, this.token);
+        client.setReportID(this.reportID);
+        client.setVerify(this.verify);
+        if (this.useProxy) {
+            client.setProxy(this.proxyURL);
+        }
+
+        //this is code to check if web-api is up or down and set flag accordingly. if this code is removed shouldCheckApi will be always false although there maybe the case where web-api is down.
+//		if(this.client.isApiUp()){
+//			shouldCheckApi = false; // API is reachable
+//			LOG.info("Initial API connection successful");
+//		} else{
+//			shouldCheckApi = true; // API down, enter recovery mode
+//			LOG.warn("Initial web api connection failed");
+//		}
+
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (this.client != null) {
+            this.client = null;
+        }
+        synchronized (rateLck) {
+            rateLck.notify();
+        }
+    }
+
+    private boolean isTimeForSync(Duration td) {
+        switch (this.intervalType) {
+            case DAY:
+                return td.toDays() > this.syncInterval;
+            case HOURS:
+
+                return td.toHours() > this.syncInterval;
+            case MINUTES:
+
+                return td.toMinutes() > this.syncInterval;
+            default:
+                return td.toHours() > this.syncInterval;
+        }
+    }
+
+    private boolean shouldCheckApi(Duration td) {
+        if (firstRun) {
+            firstRun = false;
+            return true; // force first fetch
+        }
+
+        if (!shouldCheckApi) {
+            return false; //so by this we succeed to check api only if it has failed and not periodicallhy
+        }
+
+        if (this.checkApiIntervalType == null) {
+            // Fallback or exception for invalid enum state
+            throw new IllegalStateException("checkApiIntervalType must not be null");
+        }
+
+        switch (checkApiIntervalType) {
+            case DAY:
+                return td.toDays() >= this.checkApiInterval;
+            case HOURS:
+                return td.toHours() >= this.checkApiInterval;
+            case MINUTES:
+                return td.toMinutes() >= this.checkApiInterval;
+            default:
+                throw new UnsupportedOperationException("Unsupported interval type: " + checkApiIntervalType);
+        }
+    }
 }

--- a/flink_jobs_v2/stream_status/src/main/java/argo/streaming/StatusConfig.java
+++ b/flink_jobs_v2/stream_status/src/main/java/argo/streaming/StatusConfig.java
@@ -2,6 +2,7 @@ package argo.streaming;
 
 import java.io.Serializable;
 
+import argo.amr.ApiResourceManager;
 import org.apache.flink.api.java.utils.ParameterTool;
 
 public class StatusConfig implements Serializable {
@@ -48,6 +49,7 @@ public class StatusConfig implements Serializable {
     // Raw parameters
     public final ParameterTool pt;
 
+
     public StatusConfig(ParameterTool pt) {
         this.pt = pt;
 
@@ -93,7 +95,6 @@ public class StatusConfig implements Serializable {
         }
 
         this.daily = pt.getBoolean("daily", false);
-
     }
 
     public ParameterTool getParameters() {


### PR DESCRIPTION
This PR affects injestion job and streaming job.
a parameter --check.api.interval is given to define the interval to check the argo web-api. this is initially set to 24H if not defined
--> In injestion job during calculating performance data: 
A firstRun flag achieves to decide shouldCheckApi() as true in order to loadTopology() initially. 
if topology load successfully shouldCheckApi param is set to true and a new retry for topology will be done at the next day in as happens to sync data
if topology load fails shouldCheckApi param is set to false and a new retry for topology will happen when a check.api.interval has passed

--> in streaming job : 
In ArgoApiSource during running , a firstRun flag achieves to decide shouldCheckApi() as true in order to loadTopology() initially. 
if topology load successfully shouldCheckApi param is set to true and a new retry for topology will be done after sync.interval has passed in order to sync data, as usual
if topology load fails shouldCheckApi param is set to false and a new retry for topology will happen when a check.api.interval has passed


