### PR TITLE
ARGO-5307 Implement init compute engine automation

### DIFF
--- a/automation/argo_automator.py
+++ b/automation/argo_automator.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import enum
-import http.client
 import json
 import logging
 import threading
@@ -12,15 +10,16 @@ from datetime import datetime, timezone
 from enum import Enum
 
 import requests
-import yaml
 from argo_ams_library import ArgoMessagingService
 
+from argo_config import ArgoConfig
 from init_ams import init_ams
+from init_compute_engine import init_compute_engine
 from init_mongo import init_mongo
 
 REQUEST_TIMEOUT = 30
 TOKEN_REFRESH_BUFFER = 60
-LOOP_DELAY = 5
+LOOP_DELAY = 0.2
 
 
 logger = logging.getLogger(__name__)
@@ -29,6 +28,7 @@ logger = logging.getLogger(__name__)
 class JobName(Enum):
     INIT_MONGO = "INIT_MONGO"
     INIT_AMS = "INIT_AMS"
+    INIT_COMPUTE_ENGINE = "INIT_COMPUTE_ENGINE"
 
 
 class JobStatus(Enum):
@@ -40,31 +40,10 @@ class JobStatus(Enum):
     UNKNOWN = "UNKNOWN"
 
 
-class Config:
-    """Loads and holds the configuration from a yaml file"""
-
-    def __init__(self, path: str):
-        with open(path) as f:
-            data = yaml.safe_load(f)["automation"]
-
-        self.ams_endpoint = data.get("ams_endpoint")
-        self.ams_event_token = data.get("ams_event_token")
-        self.ams_event_project = data.get("ams_event_project")
-        self.ams_event_subscription = data.get("ams_event_subscription")
-        self.ams_admin_token = data.get("ams_admin_token")
-        self.oidc_token_url = data.get("oidc_token_url")
-        self.oidc_client_id = data.get("oidc_client_id")
-        self.oidc_client_secret = data.get("oidc_client_secret")
-        self.mon_api_endpoint = data.get("mon_api_endpoint")
-        self.mongodb_url = data.get("mongodb_url")
-        self.tenant_db_prefix = data.get("tenant_db_prefix")
-        self.argo_ops_email = data.get("argo_ops_email")
-
-
 class MonApiClient:
     """Client to do status updates to argo mon api"""
 
-    def __init__(self, config: Config):
+    def __init__(self, config: ArgoConfig):
         self.config = config
         self._access_token = None
         self._token_expires_at = 0
@@ -152,7 +131,7 @@ class MonApiClient:
             )
         except requests.HTTPError as e:
             if e.response.status_code == 404:
-                logger.warn(
+                logger.warning(
                     f"tenant: {tenant_name} ({tenant_id}) does not exist in mon api"
                 )
             else:
@@ -164,7 +143,7 @@ class MonApiClient:
 class ArgoAutomator:
     """ArgoAutomator listens to AMS for events and runs background tasks(jobs) in threads"""
 
-    def __init__(self, config: Config, max_workers: int = 10):
+    def __init__(self, config: ArgoConfig, max_workers: int = 10):
         logger.info("initialising automator...")
         self.config = config
         self.mon_api = MonApiClient(config)
@@ -199,13 +178,17 @@ class ArgoAutomator:
                 return
 
             if job_name == JobName.INIT_MONGO.value:
-                logger.debug("YO started init mongo")
                 self.executor.submit(self.job_init_mongo, tenant_id, tenant_name)
                 return
             if job_name == JobName.INIT_AMS.value:
-                logger.debug("YO starterd init ams")
                 self.executor.submit(self.job_init_ams, tenant_id, tenant_name)
                 return
+            if job_name == JobName.INIT_COMPUTE_ENGINE.value:
+                self.executor.submit(
+                    self.job_init_compute_engine, tenant_id, tenant_name
+                )
+                return
+
         except Exception as e:
             logger.exception(f"Failed to process event: {e}")
 
@@ -251,6 +234,48 @@ class ArgoAutomator:
         except Exception as e:
             logger.exception(f"job failed for tenant {tenant_name}: {e}")
 
+    def job_init_compute_engine(self, tenant_id: str, tenant_name: str):
+        """Job placeholder to init compute engine"""
+        try:
+            logger.info(
+                f"job started: initialising compute engine for tenant {tenant_name} with id: {tenant_id}"
+            )
+
+            self.mon_api.update_status(
+                tenant_id,
+                tenant_name,
+                JobName.INIT_COMPUTE_ENGINE.value,
+                JobStatus.IN_PROGRESS.value,
+                "Initialising Compute Engine",
+            )
+
+            job_done = init_compute_engine(self.config, tenant_id, tenant_name)
+
+            if job_done:
+                self.mon_api.update_status(
+                    tenant_id,
+                    tenant_name,
+                    JobName.INIT_COMPUTE_ENGINE.value,
+                    JobStatus.COMPLETED.value,
+                    "Compute engine initialised succesfully",
+                )
+                logger.info(
+                    f"job completed: initialising compute engine for tenant {tenant_name}"
+                )
+            else:
+                self.mon_api.update_status(
+                    tenant_id,
+                    tenant_name,
+                    JobName.INIT_COMPUTE_ENGINE.value,
+                    JobStatus.FAILED.value,
+                    "Compute engine failed to initialise",
+                )
+                logger.error(
+                    f"job failed: initialising compute engine for tenant {tenant_name}"
+                )
+        except Exception as e:
+            logger.exception(f"job failed for tenant {tenant_name}: {e}")
+
     def job_init_ams(self, tenant_id: str, tenant_name: str):
         """Job placeholder to init ams"""
         try:
@@ -267,10 +292,9 @@ class ArgoAutomator:
             )
 
             job_done = init_ams(
-                self.config.ams_endpoint,
-                self.config.ams_admin_token,
+                self.config,
+                tenant_id,
                 tenant_name,
-                self.config.argo_ops_email,
             )
 
             if job_done:
@@ -352,7 +376,7 @@ def main():
         format="%(asctime)s - %(levelname)s - %(message)s",
     )
 
-    config = Config(args.config)
+    config = ArgoConfig(args.config)
 
     automator = ArgoAutomator(config, 10)
     automator.run()

--- a/automation/argo_config.py
+++ b/automation/argo_config.py
@@ -1,0 +1,66 @@
+import logging
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+class ArgoConfig:
+    """Loads and holds the configuration from a yaml file"""
+
+    def __init__(self, path: str):
+        with open(path) as f:
+            config_data = yaml.safe_load(f)
+            if not config_data:
+                logger.error("No configuration found - exiting")
+                exit(1)
+            automation = config_data.get("automation", {})
+            tenants = config_data.get("tenants", {})
+
+        self.path = path
+        self.automation = automation
+        self.tenants = tenants
+        self.ams_endpoint = automation.get("ams_endpoint")
+        self.ams_event_token = automation.get("ams_event_token")
+        self.ams_event_project = automation.get("ams_event_project")
+        self.ams_event_subscription = automation.get("ams_event_subscription")
+        self.ams_admin_token = automation.get("ams_admin_token")
+        self.oidc_token_url = automation.get("oidc_token_url")
+        self.oidc_client_id = automation.get("oidc_client_id")
+        self.oidc_client_secret = automation.get("oidc_client_secret")
+        self.mon_api_endpoint = automation.get("mon_api_endpoint")
+        self.mongodb_url = automation.get("mongodb_url")
+        self.tenant_db_prefix = automation.get("tenant_db_prefix")
+        self.argo_ops_email = automation.get("argo_ops_email")
+        self.web_api_endpoint = automation.get("web_api_endpoint")
+        self.web_api_token = automation.get("web_api_token")
+
+    def save(self) -> None:
+        """Save current configuration back to yaml file"""
+        with open(self.path, "w") as f:
+            data = {"automation": self.automation, "tenants": self.tenants}
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+            logger.info("engine config - saved to disk")
+
+    def set_tenant_web_api_access(self, tenant_id, tenant_name, web_api_token):
+        self.ensure_tenant(tenant_id, tenant_name)
+        self.tenants.get(tenant_name)["web_api_token"] = web_api_token
+        logger.info(f"engine config - tenant {tenant_name} web_api_token prop set")
+        self.save()
+
+    def set_tenant_ams_access(self, tenant_id, tenant_name, ams_token):
+        self.ensure_tenant(tenant_id, tenant_name)
+        self.tenants.get(tenant_name)["ams_token"] = ams_token
+        logger.info(f"engine config - tenant {tenant_name} ams_token prop set")
+        self.save()
+
+    def ensure_tenant(self, tenant_id, tenant_name):
+        cur_tenant = self.tenants.get(tenant_name)
+        if not cur_tenant:
+            self.tenants[tenant_name] = {"tenant_id": tenant_id}
+            logger.info(f"engine config - tenant {tenant_name} definition created")
+            return
+        cur_tenant_id = self.tenants.get("tenant_id")
+        if not cur_tenant_id or cur_tenant_id != tenant_id:
+            cur_tenant["tenant_id"] = tenant_id
+            logger.info(f"engine config - tenant {tenant_name} tenant_id prop set")

--- a/automation/config.yml.example
+++ b/automation/config.yml.example
@@ -13,7 +13,19 @@ automation:
 
   mon_api_endpoint: localhost:9443
 
+  web_api_endpoint: localhost:8081
+  web_api_token: api-s3cr3t
+
   mongodb_url: localhost:27017 
   tenant_db_prefix: argo_
 
   argo_ops_email: argo_ops@localhost
+
+# The tenants section is automatically configured by engine - don't edit manually
+#
+# tenants:
+#  TENANTFOO:
+#    id: tenant-foo-uuid
+#    ams_token: ams_s3cr3t
+#    web_api_token: web_api_s3cr3t
+

--- a/automation/init_ams.py
+++ b/automation/init_ams.py
@@ -3,18 +3,21 @@ import logging
 from argo_ams_library import (AmsServiceException, AmsUser, AmsUserProject,
                               ArgoMessagingService)
 
+from argo_config import ArgoConfig
+
 logger = logging.getLogger(__name__)
 
 
 def init_ams(
-    ams_endpoint: str, ams_admin_token: str, tenant_name: str, argo_ops_email: str
+    config: ArgoConfig,
+    tenant_id: str,
+    tenant_name: str,
 ) -> bool:
     """Initialise project, topic and subscriptions to ams"""
-
     # create admin client for ams to create new project
     ams = ArgoMessagingService(
-        endpoint=ams_endpoint,
-        token=ams_admin_token,
+        endpoint=config.ams_endpoint,
+        token=config.ams_admin_token,
     )
 
     # Create project - skip if it exists
@@ -32,7 +35,7 @@ def init_ams(
     # Recreate the ams client for using the specific project (ams library necessity to select new project)
 
     ams = ArgoMessagingService(
-        endpoint=ams_endpoint, token=ams_admin_token, project=tenant_name
+        endpoint=config.ams_endpoint, token=config.ams_admin_token, project=tenant_name
     )
 
     admin_username = f"{tenant_name}_admin"
@@ -53,17 +56,25 @@ def init_ams(
                 AmsUser(
                     name=username,
                     projects=[AmsUserProject(project=tenant_name, roles=[role])],
-                    email=argo_ops_email,
+                    email=config.argo_ops_email,
                 )
             )
 
             if user:
                 logger.info(f"ams project {tenant_name} - user created: {username}")
+                if role == "consumer":
+                    config.set_tenant_ams_access(tenant_id, tenant_name, user.token)
+
         except AmsServiceException as e:
             if e.code == 409:
                 logger.warning(
                     f"ams project {tenant_name} - user {username} already exists"
                 )
+                if role == "consumer":
+                    user = ams.get_user(username)
+                    if user:
+                        config.set_tenant_ams_access(tenant_id, tenant_name, user.token)
+
             else:
                 logger.error(
                     f"ams project {tenant_name} - could not set up user: {username}"

--- a/automation/init_compute_engine.py
+++ b/automation/init_compute_engine.py
@@ -1,0 +1,141 @@
+import logging
+
+import requests
+
+from argo_config import ArgoConfig
+
+logger = logging.getLogger(__name__)
+
+REQUEST_TIMEOUT = 30
+
+
+class ArgoWebApi:
+
+    def __init__(self, config: ArgoConfig):
+        self.config = config
+
+    def create_user(
+        self,
+        tenant_id: str,
+        tenant_name: str,
+        username: str,
+        role: str,
+    ):
+        """Http call to web-api to create a user"""
+        logger.debug(
+            f"tenant: {tenant_name} ({tenant_id}) - web-api creating user {username}..."
+        )
+
+        payload = {
+            "name": username,
+            "email": self.config.argo_ops_email,
+            "roles": [role],
+        }
+
+        url = f"https://{self.config.web_api_endpoint}/api/v2/admin/tenants/{tenant_id}/users"
+        headers = {
+            "x-api-key": self.config.web_api_token,
+            "Accept": "application/json",
+        }
+        response = requests.post(
+            url, json=payload, headers=headers, timeout=REQUEST_TIMEOUT
+        )
+        response.raise_for_status()
+
+        logger.info(
+            f"tenant: {tenant_name} ({tenant_id}) - web-api user created: {username}"
+        )
+
+        # get newly created user details by id
+        user_id = response.json().get("data").get("id")
+
+        return self.get_user(tenant_id, tenant_name, user_id)
+
+    def get_username(
+        self, tenant_id: str, tenant_name: str, username: str
+    ) -> dict | None:
+        """Http call to web-api to check if a username exists"""
+        logger.debug(
+            f"tenant: {tenant_name} ({tenant_id}) - web-api checking username: {username}..."
+        )
+
+        url = f"https://{self.config.web_api_endpoint}/api/v2/admin/tenants/{tenant_id}/users"
+        headers = {
+            "x-api-key": self.config.web_api_token,
+            "Accept": "application/json",
+        }
+        response = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT)
+        response.raise_for_status()
+
+        users = response.json().get("data")
+        if users:
+            return next((user for user in users if user["name"] == username), None)
+        return None
+
+    def get_user(self, tenant_id: str, tenant_name: str, user_id: str):
+        """Http call to web-api to get a specific user of a tenant"""
+        logger.debug(
+            f"tenant: {tenant_name} ({tenant_id}) - web-api getting user {user_id}..."
+        )
+
+        url = f"https://{self.config.web_api_endpoint}/api/v2/admin/tenants/{tenant_id}/users/{user_id}"
+        headers = {
+            "x-api-key": self.config.web_api_token,
+            "Accept": "application/json",
+        }
+        response = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT)
+        response.raise_for_status()
+
+        return response.json()
+
+
+def init_compute_engine(
+    config: ArgoConfig,
+    tenant_id: str,
+    tenant_name: str,
+) -> bool:
+    """Initialise compute engine users"""
+
+    web_api = ArgoWebApi(config)
+
+    engine_username = f"argo_engine_{tenant_name}"
+    monbox_username = f"monbox_{tenant_name}"
+    probe_username = f"mobnox_probe_{tenant_name}"
+    ui_username = f"argo_ui_{tenant_name}"
+    poem_username = f"argo_poem_admin_{tenant_name}"
+    poem_viewer_username = f"argo_poem_viewer_{tenant_name}"
+
+    # map users and roles and create them
+    user_roles = [
+        (engine_username, "admin"),
+        (monbox_username, "admin"),
+        (probe_username, "viewer"),
+        (ui_username, "admin_ui"),
+        (poem_username, "admin"),
+        (poem_viewer_username, "viewer"),
+    ]
+
+    for username, role in user_roles:
+
+        logger.info(f"engine tenant {tenant_name} - creating user: {username}")
+        # check if user exists already
+        user = web_api.get_username(tenant_id, tenant_name, username)
+        if user:
+            # user exists
+            logger.info(f"engine tenant {tenant_name} - user: {username} exists!")
+            if username == engine_username:
+                config.set_tenant_web_api_access(
+                    tenant_id, tenant_name, user.get("api_key")
+                )
+                config.save()
+
+        else:
+            # create the user
+            user = web_api.create_user(tenant_id, tenant_name, username, role)
+            if user and username == engine_username:
+                config.set_tenant_web_api_access(
+                    tenant_id, tenant_name, user.get("api_key")
+                )
+                config.save()
+
+    return True

--- a/automation/init_mongo.py
+++ b/automation/init_mongo.py
@@ -9,7 +9,7 @@ def init_mongo(connection_string: str, db_name: str) -> bool:
     """Initialise indexes in mongodb"""
 
     # Connect to MongoDB and get the database
-    client = MongoClient(connection_string)
+    client: MongoClient = MongoClient(connection_string)
     db = client[db_name]
 
     # types of indexing

--- a/automation/requirements.txt
+++ b/automation/requirements.txt
@@ -1,4 +1,4 @@
 requests==2.32.5
 argo-ams-library==1.0.0
 PyYAML==6.0.3
-pymongo=4.16.0
+pymongo==4.16.0


### PR DESCRIPTION
### Goal

Implement init compute engine automation which creates the appropriate users in web-api and configures the compute engine appropriately for access

### Implementation
- [x] Fix deps in requirements.txt
- [x] Move ArgoConfig to its own file and refactor to dynamically update the tenant part of the configuration and save it to disk. 
- [x] Create the init_compute_engine job implementation. Create all the required user accounts in web api. Configure compute engine accordingly
- [x] Create argo web api client with methods to create users, get user by id and get user by username. 
- [x] Process events of INIT_COMPUTE_ENGINE type
- [x] Update init_ams job so as to update configuration of compute engine for ams access
