### PR TITLE
ARGO-5320 Automate the creation of operations profile for new tenant

### DIFF
--- a/automation/argo_automator.py
+++ b/automation/argo_automator.py
@@ -20,6 +20,8 @@ from init_mongo import init_mongo
 REQUEST_TIMEOUT = 30
 TOKEN_REFRESH_BUFFER = 60
 LOOP_DELAY = 0.2
+JOB_WAIT = 5
+JOB_WAIT_RETRY = 5
 
 
 logger = logging.getLogger(__name__)
@@ -208,7 +210,11 @@ class ArgoAutomator:
             )
 
             job_done = init_mongo(
-                self.config.mongodb_url, self.config.tenant_db_prefix + tenant_name
+                self.config,
+                tenant_id,
+                tenant_name,
+                self.config.mongodb_url,
+                self.config.tenant_db_prefix + tenant_name,
             )
 
             if job_done:
@@ -237,6 +243,31 @@ class ArgoAutomator:
     def job_init_compute_engine(self, tenant_id: str, tenant_name: str):
         """Job placeholder to init compute engine"""
         try:
+
+            logger.info("init_compute_engine: waiting for init_mongo to finish")
+            job_mongo = self.mon_api.get_status(
+                tenant_id, tenant_name, JobName.INIT_MONGO.value
+            )
+            retries = 0
+            while job_mongo["status"] != JobStatus.COMPLETED.value:
+                time.sleep(JOB_WAIT)
+                job_mongo = self.mon_api.get_status(
+                    tenant_id, tenant_name, JobName.INIT_MONGO.value
+                )
+                retries = retries + 1
+                if retries > JOB_WAIT_RETRY:
+                    logger.error(
+                        "init_compute_engine: exausted retries waiting for init_mongo to finish... aborting"
+                    )
+                    self.mon_api.update_status(
+                        tenant_id,
+                        tenant_name,
+                        JobName.INIT_COMPUTE_ENGINE.value,
+                        JobStatus.FAILED.value,
+                        "Initialising Compute Engine failed",
+                    )
+                    return
+
             logger.info(
                 f"job started: initialising compute engine for tenant {tenant_name} with id: {tenant_id}"
             )

--- a/automation/argo_config.py
+++ b/automation/argo_config.py
@@ -34,6 +34,7 @@ class ArgoConfig:
         self.argo_ops_email = automation.get("argo_ops_email")
         self.web_api_endpoint = automation.get("web_api_endpoint")
         self.web_api_token = automation.get("web_api_token")
+        self.default_ops_profile_file = automation.get("default_ops_profile_file")
 
     def save(self) -> None:
         """Save current configuration back to yaml file"""

--- a/automation/argo_web_api.py
+++ b/automation/argo_web_api.py
@@ -1,0 +1,170 @@
+import logging
+from typing import Dict, Optional
+
+import requests
+
+from argo_config import ArgoConfig
+
+logger = logging.getLogger(__name__)
+
+REQUEST_TIMEOUT = 30
+
+
+class ArgoWebApi:
+
+    def __init__(self, config: ArgoConfig):
+        self.config = config
+
+    def create_user(
+        self,
+        tenant_id: str,
+        tenant_name: str,
+        username: str,
+        role: str,
+    ):
+        """Http call to web-api to create a user"""
+        logger.debug(
+            f"tenant: {tenant_name} ({tenant_id}) - web-api creating user {username}..."
+        )
+
+        payload = {
+            "name": username,
+            "email": self.config.argo_ops_email,
+            "roles": [role],
+        }
+
+        url = f"https://{self.config.web_api_endpoint}/api/v2/admin/tenants/{tenant_id}/users"
+        headers = {
+            "x-api-key": self.config.web_api_token,
+            "Accept": "application/json",
+        }
+        response = requests.post(
+            url, json=payload, headers=headers, timeout=REQUEST_TIMEOUT
+        )
+        response.raise_for_status()
+
+        logger.info(
+            f"tenant: {tenant_name} ({tenant_id}) - web-api user created: {username}"
+        )
+
+        # get newly created user details by id
+        user_id = response.json().get("data").get("id")
+
+        return self.get_user(tenant_id, tenant_name, user_id)
+
+    def update_tenant_db_info(
+        self,
+        tenant_id: str,
+        tenant_name: str,
+        store: str,
+        server: str,
+        port: int,
+        database: str,
+    ):
+        """Http call to web-api to update the database conf"""
+        logger.debug(
+            f"tenant: {tenant_name} ({tenant_id}) - web-api updating db conf..."
+        )
+
+        payload = {
+            "db_conf": [
+                {
+                    "store": store,
+                    "server": server,
+                    "port": port,
+                    "database": database,
+                    "username": "",
+                    "password": "",
+                }
+            ]
+        }
+
+        url = f"https://{self.config.web_api_endpoint}/api/v2/admin/tenants/{tenant_id}/db-conf"
+        headers = {
+            "x-api-key": self.config.web_api_token,
+            "Accept": "application/json",
+        }
+        response = requests.put(
+            url, json=payload, headers=headers, timeout=REQUEST_TIMEOUT
+        )
+        response.raise_for_status()
+
+        logger.info(
+            f"tenant: {tenant_name} ({tenant_id}) - web-api updating db conf updated"
+        )
+
+    def create_ops_profile(
+        self,
+        tenant_id: str,
+        tenant_name: str,
+        tenant_access_token: str,
+        payload: object,
+    ):
+        """Http call to web-api to create ops profile"""
+        logger.debug(
+            f"tenant: {tenant_name} ({tenant_id}) - web-api creating default ops profile..."
+        )
+
+        url = f"https://{self.config.web_api_endpoint}/api/v2/operations_profiles"
+        headers = {
+            "x-api-key": tenant_access_token,
+            "Accept": "application/json",
+        }
+        try:
+            response = requests.post(
+                url, json=payload, headers=headers, timeout=REQUEST_TIMEOUT
+            )
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 409:
+                logger.warning(
+                    f"tenant: {tenant_name} ({tenant_id}) - web-api ops profile already exists"
+                )
+                return
+            else:
+                raise
+
+        logger.info(
+            f"tenant: {tenant_name} ({tenant_id}) - web-api ops profile created"
+        )
+
+    def get_username(
+        self, tenant_id: str, tenant_name: str, username: str
+    ) -> Optional[Dict]:
+        """Http call to web-api to check if a username exists"""
+        logger.debug(
+            f"tenant: {tenant_name} ({tenant_id}) - web-api checking username: {username}..."
+        )
+
+        url = f"https://{self.config.web_api_endpoint}/api/v2/admin/tenants/{tenant_id}/users"
+        headers = {
+            "x-api-key": self.config.web_api_token,
+            "Accept": "application/json",
+        }
+        response = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT)
+        response.raise_for_status()
+
+        users = response.json().get("data")
+        if users:
+            return next((user for user in users if user["name"] == username), None)
+        return None
+
+    def get_user(self, tenant_id: str, tenant_name: str, user_id: str):
+        """Http call to web-api to get a specific user of a tenant"""
+        logger.debug(
+            f"tenant: {tenant_name} ({tenant_id}) - web-api getting user {user_id}..."
+        )
+
+        url = f"https://{self.config.web_api_endpoint}/api/v2/admin/tenants/{tenant_id}/users/{user_id}"
+        headers = {
+            "x-api-key": self.config.web_api_token,
+            "Accept": "application/json",
+        }
+        response = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT)
+        response.raise_for_status()
+
+        users = response.json().get("data")
+        if users and len(users) > 0:
+            return users[0]
+
+        return None

--- a/automation/config.yml.example
+++ b/automation/config.yml.example
@@ -16,10 +16,11 @@ automation:
   web_api_endpoint: localhost:8081
   web_api_token: api-s3cr3t
 
-  mongodb_url: localhost:27017 
+  mongodb_url: mongodb://localhost:27017 
   tenant_db_prefix: argo_
 
   argo_ops_email: argo_ops@localhost
+  default_ops_profile_file: ./default.ops.json
 
 # The tenants section is automatically configured by engine - don't edit manually
 #

--- a/automation/default.ops.json
+++ b/automation/default.ops.json
@@ -1,0 +1,238 @@
+{
+    "name": "default_ops",
+    "available_states": [
+        "OK",
+        "WARNING",
+        "UNKNOWN",
+        "MISSING",
+        "CRITICAL",
+        "DOWNTIME"
+    ],
+    "defaults": {
+        "down": "DOWNTIME",
+        "missing": "MISSING",
+        "unknown": "UNKNOWN"
+    },
+    "operations": [
+        {
+            "name": "AND",
+            "truth_table": [
+                {
+                    "a": "OK",
+                    "b": "OK",
+                    "x": "OK"
+                },
+                {
+                    "a": "OK",
+                    "b": "WARNING",
+                    "x": "WARNING"
+                },
+                {
+                    "a": "OK",
+                    "b": "UNKNOWN",
+                    "x": "UNKNOWN"
+                },
+                {
+                    "a": "OK",
+                    "b": "MISSING",
+                    "x": "MISSING"
+                },
+                {
+                    "a": "OK",
+                    "b": "CRITICAL",
+                    "x": "CRITICAL"
+                },
+                {
+                    "a": "OK",
+                    "b": "DOWNTIME",
+                    "x": "DOWNTIME"
+                },
+                {
+                    "a": "WARNING",
+                    "b": "WARNING",
+                    "x": "WARNING"
+                },
+                {
+                    "a": "WARNING",
+                    "b": "UNKNOWN",
+                    "x": "UNKNOWN"
+                },
+                {
+                    "a": "WARNING",
+                    "b": "MISSING",
+                    "x": "MISSING"
+                },
+                {
+                    "a": "WARNING",
+                    "b": "CRITICAL",
+                    "x": "CRITICAL"
+                },
+                {
+                    "a": "WARNING",
+                    "b": "DOWNTIME",
+                    "x": "DOWNTIME"
+                },
+                {
+                    "a": "UNKNOWN",
+                    "b": "UNKNOWN",
+                    "x": "UNKNOWN"
+                },
+                {
+                    "a": "UNKNOWN",
+                    "b": "MISSING",
+                    "x": "MISSING"
+                },
+                {
+                    "a": "UNKNOWN",
+                    "b": "CRITICAL",
+                    "x": "CRITICAL"
+                },
+                {
+                    "a": "UNKNOWN",
+                    "b": "DOWNTIME",
+                    "x": "DOWNTIME"
+                },
+                {
+                    "a": "MISSING",
+                    "b": "MISSING",
+                    "x": "MISSING"
+                },
+                {
+                    "a": "MISSING",
+                    "b": "CRITICAL",
+                    "x": "CRITICAL"
+                },
+                {
+                    "a": "MISSING",
+                    "b": "DOWNTIME",
+                    "x": "DOWNTIME"
+                },
+                {
+                    "a": "CRITICAL",
+                    "b": "CRITICAL",
+                    "x": "CRITICAL"
+                },
+                {
+                    "a": "CRITICAL",
+                    "b": "DOWNTIME",
+                    "x": "CRITICAL"
+                },
+                {
+                    "a": "DOWNTIME",
+                    "b": "DOWNTIME",
+                    "x": "DOWNTIME"
+                }
+            ]
+        },
+        {
+            "name": "OR",
+            "truth_table": [
+                {
+                    "a": "OK",
+                    "b": "OK",
+                    "x": "OK"
+                },
+                {
+                    "a": "OK",
+                    "b": "WARNING",
+                    "x": "OK"
+                },
+                {
+                    "a": "OK",
+                    "b": "UNKNOWN",
+                    "x": "OK"
+                },
+                {
+                    "a": "OK",
+                    "b": "MISSING",
+                    "x": "OK"
+                },
+                {
+                    "a": "OK",
+                    "b": "CRITICAL",
+                    "x": "OK"
+                },
+                {
+                    "a": "OK",
+                    "b": "DOWNTIME",
+                    "x": "OK"
+                },
+                {
+                    "a": "WARNING",
+                    "b": "WARNING",
+                    "x": "WARNING"
+                },
+                {
+                    "a": "WARNING",
+                    "b": "UNKNOWN",
+                    "x": "WARNING"
+                },
+                {
+                    "a": "WARNING",
+                    "b": "MISSING",
+                    "x": "WARNING"
+                },
+                {
+                    "a": "WARNING",
+                    "b": "CRITICAL",
+                    "x": "WARNING"
+                },
+                {
+                    "a": "WARNING",
+                    "b": "DOWNTIME",
+                    "x": "WARNING"
+                },
+                {
+                    "a": "UNKNOWN",
+                    "b": "UNKNOWN",
+                    "x": "UNKNOWN"
+                },
+                {
+                    "a": "UNKNOWN",
+                    "b": "MISSING",
+                    "x": "UNKNOWN"
+                },
+                {
+                    "a": "UNKNOWN",
+                    "b": "CRITICAL",
+                    "x": "CRITICAL"
+                },
+                {
+                    "a": "UNKNOWN",
+                    "b": "DOWNTIME",
+                    "x": "UNKNOWN"
+                },
+                {
+                    "a": "MISSING",
+                    "b": "MISSING",
+                    "x": "MISSING"
+                },
+                {
+                    "a": "MISSING",
+                    "b": "CRITICAL",
+                    "x": "CRITICAL"
+                },
+                {
+                    "a": "MISSING",
+                    "b": "DOWNTIME",
+                    "x": "DOWNTIME"
+                },
+                {
+                    "a": "CRITICAL",
+                    "b": "CRITICAL",
+                    "x": "CRITICAL"
+                },
+                {
+                    "a": "CRITICAL",
+                    "b": "DOWNTIME",
+                    "x": "CRITICAL"
+                },
+                {
+                    "a": "DOWNTIME",
+                    "b": "DOWNTIME",
+                    "x": "DOWNTIME"
+                }
+            ]
+        }
+    ]
+}

--- a/automation/init_compute_engine.py
+++ b/automation/init_compute_engine.py
@@ -1,92 +1,10 @@
+import json
 import logging
 
-import requests
-
 from argo_config import ArgoConfig
+from argo_web_api import ArgoWebApi
 
 logger = logging.getLogger(__name__)
-
-REQUEST_TIMEOUT = 30
-
-
-class ArgoWebApi:
-
-    def __init__(self, config: ArgoConfig):
-        self.config = config
-
-    def create_user(
-        self,
-        tenant_id: str,
-        tenant_name: str,
-        username: str,
-        role: str,
-    ):
-        """Http call to web-api to create a user"""
-        logger.debug(
-            f"tenant: {tenant_name} ({tenant_id}) - web-api creating user {username}..."
-        )
-
-        payload = {
-            "name": username,
-            "email": self.config.argo_ops_email,
-            "roles": [role],
-        }
-
-        url = f"https://{self.config.web_api_endpoint}/api/v2/admin/tenants/{tenant_id}/users"
-        headers = {
-            "x-api-key": self.config.web_api_token,
-            "Accept": "application/json",
-        }
-        response = requests.post(
-            url, json=payload, headers=headers, timeout=REQUEST_TIMEOUT
-        )
-        response.raise_for_status()
-
-        logger.info(
-            f"tenant: {tenant_name} ({tenant_id}) - web-api user created: {username}"
-        )
-
-        # get newly created user details by id
-        user_id = response.json().get("data").get("id")
-
-        return self.get_user(tenant_id, tenant_name, user_id)
-
-    def get_username(
-        self, tenant_id: str, tenant_name: str, username: str
-    ) -> dict | None:
-        """Http call to web-api to check if a username exists"""
-        logger.debug(
-            f"tenant: {tenant_name} ({tenant_id}) - web-api checking username: {username}..."
-        )
-
-        url = f"https://{self.config.web_api_endpoint}/api/v2/admin/tenants/{tenant_id}/users"
-        headers = {
-            "x-api-key": self.config.web_api_token,
-            "Accept": "application/json",
-        }
-        response = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT)
-        response.raise_for_status()
-
-        users = response.json().get("data")
-        if users:
-            return next((user for user in users if user["name"] == username), None)
-        return None
-
-    def get_user(self, tenant_id: str, tenant_name: str, user_id: str):
-        """Http call to web-api to get a specific user of a tenant"""
-        logger.debug(
-            f"tenant: {tenant_name} ({tenant_id}) - web-api getting user {user_id}..."
-        )
-
-        url = f"https://{self.config.web_api_endpoint}/api/v2/admin/tenants/{tenant_id}/users/{user_id}"
-        headers = {
-            "x-api-key": self.config.web_api_token,
-            "Accept": "application/json",
-        }
-        response = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT)
-        response.raise_for_status()
-
-        return response.json()
 
 
 def init_compute_engine(
@@ -99,8 +17,8 @@ def init_compute_engine(
     web_api = ArgoWebApi(config)
 
     engine_username = f"argo_engine_{tenant_name}"
-    monbox_username = f"monbox_{tenant_name}"
-    probe_username = f"mobnox_probe_{tenant_name}"
+    monbox_username = f"argo_monbox_{tenant_name}"
+    probe_username = f"argo_probe_{tenant_name}"
     ui_username = f"argo_ui_{tenant_name}"
     poem_username = f"argo_poem_admin_{tenant_name}"
     poem_viewer_username = f"argo_poem_viewer_{tenant_name}"
@@ -115,6 +33,8 @@ def init_compute_engine(
         (poem_viewer_username, "viewer"),
     ]
 
+    engine_user_key = None
+
     for username, role in user_roles:
 
         logger.info(f"engine tenant {tenant_name} - creating user: {username}")
@@ -124,18 +44,24 @@ def init_compute_engine(
             # user exists
             logger.info(f"engine tenant {tenant_name} - user: {username} exists!")
             if username == engine_username:
-                config.set_tenant_web_api_access(
-                    tenant_id, tenant_name, user.get("api_key")
-                )
-                config.save()
+                engine_user_key = user.get("api_key")
 
         else:
             # create the user
             user = web_api.create_user(tenant_id, tenant_name, username, role)
             if user and username == engine_username:
-                config.set_tenant_web_api_access(
-                    tenant_id, tenant_name, user.get("api_key")
-                )
-                config.save()
+                engine_user_key = user.get("api_key")
+
+    # if engine_user_key save it to config and create the ops profile
+
+    if engine_user_key:
+
+        config.set_tenant_web_api_access(tenant_id, tenant_name, engine_user_key)
+        config.save()
+
+        with open(config.default_ops_profile_file, "r") as f:
+
+            payload = json.load(f)
+            web_api.create_ops_profile(tenant_id, tenant_name, engine_user_key, payload)
 
     return True

--- a/automation/init_mongo.py
+++ b/automation/init_mongo.py
@@ -1,11 +1,21 @@
 import logging
 
 from pymongo import ASCENDING, DESCENDING, MongoClient
+from pymongo.uri_parser import parse_uri
+
+from argo_config import ArgoConfig
+from argo_web_api import ArgoWebApi
 
 logger = logging.getLogger(__name__)
 
 
-def init_mongo(connection_string: str, db_name: str) -> bool:
+def init_mongo(
+    config: ArgoConfig,
+    tenant_id: str,
+    tenant_name: str,
+    connection_string: str,
+    db_name: str,
+) -> bool:
     """Initialise indexes in mongodb"""
 
     # Connect to MongoDB and get the database
@@ -49,4 +59,13 @@ def init_mongo(connection_string: str, db_name: str) -> bool:
                 f"db: {db_name} failed to create index on {collection_name}: {e}"
             )
             return False
+    # if mongo was initialised correctly - update the status in argo-web-api tenant
+
+    web_api = ArgoWebApi(config)
+    parsed = parse_uri(connection_string)
+    mongo_host, mongo_port = parsed["nodelist"][0]
+    web_api.update_tenant_db_info(
+        tenant_id, tenant_name, "ar", mongo_host, mongo_port, db_name
+    )
+
     return True


### PR DESCRIPTION
## Goal
When running INIT_COMPUTE_ENGINE create also the ops profile in the designated tenant because poem doesn't handle it.

## Issue
In order to create the ops profile the INIT_MONGO job should be completed (initialise the tenant's database to drop the profile). So that makes that INIT_COMPUTE_ENGINE should wait for INIT_MONGO to finish.

## Implementation
- Extend INIT_MONGO job to update tenant's db-conf definition in web-api when database is created
- Refactor INIT_COMPUTE_ENGINE to wait for INIT_MONGO to finish 
- Refactor INIT_COMPUTE_ENGINE to create default ops profile for new tenant
- Specify default ops profile in a local file (add it as param in configuration)
