### PR TITLE
ARGO-5334 Create component accounts in tenant automation

### DIFF
--- a/automation/argo_web_api.py
+++ b/automation/argo_web_api.py
@@ -21,6 +21,7 @@ class ArgoWebApi:
         tenant_name: str,
         username: str,
         role: str,
+        component: str
     ):
         """Http call to web-api to create a user"""
         logger.debug(
@@ -31,6 +32,7 @@ class ArgoWebApi:
             "name": username,
             "email": self.config.argo_ops_email,
             "roles": [role],
+            "component": component
         }
 
         url = f"https://{self.config.web_api_endpoint}/api/v2/admin/tenants/{tenant_id}/users"
@@ -128,12 +130,12 @@ class ArgoWebApi:
             f"tenant: {tenant_name} ({tenant_id}) - web-api ops profile created"
         )
 
-    def get_username(
-        self, tenant_id: str, tenant_name: str, username: str
+    def get_component_user(
+        self, tenant_id: str, tenant_name: str, component: str
     ) -> Optional[Dict]:
-        """Http call to web-api to check if a username exists"""
+        """Http call to web-api to check if a component user exists"""
         logger.debug(
-            f"tenant: {tenant_name} ({tenant_id}) - web-api checking username: {username}..."
+            f"tenant: {tenant_name} ({tenant_id}) - web-api checking user for component: {component}..."
         )
 
         url = f"https://{self.config.web_api_endpoint}/api/v2/admin/tenants/{tenant_id}/users"
@@ -146,7 +148,7 @@ class ArgoWebApi:
 
         users = response.json().get("data")
         if users:
-            return next((user for user in users if user["name"] == username), None)
+            return next((user for user in users if user.get("component") == component), None)
         return None
 
     def get_user(self, tenant_id: str, tenant_name: str, user_id: str):

--- a/automation/init_compute_engine.py
+++ b/automation/init_compute_engine.py
@@ -23,23 +23,23 @@ def init_compute_engine(
     poem_username = f"argo_poem_admin_{tenant_name}"
     poem_viewer_username = f"argo_poem_viewer_{tenant_name}"
 
-    # map users and roles and create them
-    user_roles = [
-        (engine_username, "admin"),
-        (monbox_username, "admin"),
-        (probe_username, "viewer"),
-        (ui_username, "admin_ui"),
-        (poem_username, "admin"),
-        (poem_viewer_username, "viewer"),
+    # map users roles and components
+    users_roles_comps = [
+        (engine_username, "admin", "engine"),
+        (monbox_username, "admin", "monbox"),
+        (probe_username, "viewer", "probe"),
+        (ui_username, "admin_ui", "ui"),
+        (poem_username, "admin", "poem-admin"),
+        (poem_viewer_username, "viewer", "poem-viewer"),
     ]
 
     engine_user_key = None
 
-    for username, role in user_roles:
+    for username, role, component in users_roles_comps:
 
         logger.info(f"engine tenant {tenant_name} - creating user: {username}")
-        # check if user exists already
-        user = web_api.get_username(tenant_id, tenant_name, username)
+        # check if user for specific component exists
+        user = web_api.get_component_user(tenant_id, tenant_name, username)
         if user:
             # user exists
             logger.info(f"engine tenant {tenant_name} - user: {username} exists!")
@@ -48,7 +48,7 @@ def init_compute_engine(
 
         else:
             # create the user
-            user = web_api.create_user(tenant_id, tenant_name, username, role)
+            user = web_api.create_user(tenant_id, tenant_name, username, role, component)
             if user and username == engine_username:
                 engine_user_key = user.get("api_key")
 

--- a/automation/init_mongo.py
+++ b/automation/init_mongo.py
@@ -24,6 +24,7 @@ def init_mongo(
 
     # types of indexing
     index_desc_dateint_id = [("date_integer", DESCENDING), ("id", ASCENDING)]
+    index_desc_dateint_name = [("date_integer", DESCENDING), ("name", ASCENDING)]
     index_dateint_report = [("date_integer", ASCENDING), ("report", ASCENDING)]
     index_dateint_host = [("date_integer", ASCENDING), ("host", ASCENDING)]
     index_report_dateint = [("report", ASCENDING), ("date_integer", ASCENDING)]
@@ -45,6 +46,9 @@ def init_mongo(
         ("status_services", index_report_dateint),
         ("threshold_profiles", index_desc_dateint_id),
         ("weights", index_desc_dateint_id),
+        ("topology_endpoints",index_desc_dateint_id),
+        ("topology_groups",index_desc_dateint_id),
+        ("topology_service_types",index_desc_dateint_name)
     ]
 
     for collection_name, index_type in indexes:


### PR DESCRIPTION
ARGO-5335 Add indexes to topology collections during init_mongo

### Goal
When creating a new tenant add user accounts for different integration components such as poem, monbox, internal probe etc.
Also add indexes in the topology collections when initialising mongodb

### Implementation
- [x] Update argo_web_api.py component to allow specifing component information when creating new user accounts
- [x] Update init_compute_engine.py to specify component information for each user accounts defined to be created
- [x] Update init_mongo.py component to enable indexes on topology collections