### PR TITLE
ARGO-5503 Automation enable ingestion and computations for new tenant

### DIFF
--- a/automation/argo_config.py
+++ b/automation/argo_config.py
@@ -44,6 +44,7 @@ class ArgoConfig:
         self.hdfs_path = run.get("hdfs_path")
         self.hdfs_check_path = run.get("hdfs_check_path")
         self.flink_path = run.get("flink_path")
+        self.flink_url = run.get("flink_url")
         self.batch_jar_path = run.get("batch_jar_path")
         self.ingest_jar_path = run.get("ingest_jar_path")
 

--- a/automation/config.yml.example
+++ b/automation/config.yml.example
@@ -26,6 +26,7 @@ run:
   hdfs_path: hdfs://localhost:9000/user/argo/test/tenants/
   hdfs_check_path: http://localhost:50070/user/argo/test/tenants
   flink_path: /opt/flink/bin/flink
+  flink_url: http://localhost:8081
   batch_jar_path: /opt/argo/jars/multijob.jar
   ingest_jar_path: /opt/argo/jars/ingest.jar 
 

--- a/automation/default.cron.j2
+++ b/automation/default.cron.j2
@@ -1,0 +1,4 @@
+PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+0 * * * * root /root/automation/automator-venv/bin/python /root/automation/run_batch -t {{ tenant }} -r Default -c /root/automation/config.yml
+5 6 * * * root /root/automation/automator-venv/bin/python /root/automation/run_batch -t {{ tenant }} -r Default -c /root/automation/config.yml -d $(/bin/date --utc --date '-1 day' +\%Y-\%m-\%d)
+

--- a/automation/init_compute_engine.py
+++ b/automation/init_compute_engine.py
@@ -1,10 +1,37 @@
 import json
 import logging
-
+import os
+from jinja2 import Environment, FileSystemLoader
 from argo_config import ArgoConfig
 from argo_web_api import ArgoWebApi
 
+from init_ingest import run_ingest
+
 logger = logging.getLogger(__name__)
+
+TEMPLATE_FILE = "default.cron.j2"
+CRON_DIR = "/etc/cron.d"
+VERIFY = "false"
+
+
+def init_computations(config: ArgoConfig, tenant_name: str) -> bool:
+    """Create cron file for default computations"""
+    template_dir = os.path.dirname(os.path.abspath(__file__))
+
+    env = Environment(loader=FileSystemLoader(template_dir), keep_trailing_newline=True)
+    template = env.get_template(TEMPLATE_FILE)
+    content = template.render(tenant=tenant_name)
+
+    filepath = os.path.join(CRON_DIR, f"argo_{tenant_name}")
+    try:
+        with open(filepath, "w") as f:
+            f.write(content)
+        os.chmod(filepath, 0o644)
+        return True
+    except PermissionError:
+        logger.error("Permission error while creating computation cron file")
+
+    return False
 
 
 def init_compute_engine(
@@ -32,7 +59,7 @@ def init_compute_engine(
         (ui_username, "admin_ui", "ui"),
         (poem_username, "admin", "poem-admin"),
         (poem_viewer_username, "viewer", "poem-viewer"),
-        (connector_username,"admin","connector")
+        (connector_username, "admin", "connector"),
     ]
 
     engine_user_key = None
@@ -109,5 +136,29 @@ def init_compute_engine(
             web_api.create_topology_service_types(
                 tenant_id, tenant_name, engine_user_key, services_payload
             )
+
+    # initialize computations by establishing cron jobs
+    if not init_computations(config, tenant_name):
+        return False
+
+    # enable ingestion job
+    tenant = config.tenants.get(tenant_name, {})
+
+    if not tenant or not tenant.get("ams_token"):
+        raise ValueError(
+            f"Tenant {tenant_name} not found or missing ams_token in config"
+        )
+
+    run_result = run_ingest(
+        config=config,
+        tenant_name=tenant_name,
+        tenant_ams_token=tenant.get("ams_token"),
+        dry_run=False,
+        verify=VERIFY,
+    )
+
+    if run_result == 1:
+        logger.error("Ingestion could not be enabled")
+        return False
 
     return True

--- a/automation/init_ingest.py
+++ b/automation/init_ingest.py
@@ -1,0 +1,75 @@
+import logging
+import subprocess
+import requests
+import sys
+
+from argo_config import ArgoConfig
+
+
+logger = logging.getLogger(__name__)
+
+
+def is_ingest_running(flink_url: str, tenant_name: str) -> bool:
+    """Check if an ingest job is already running for the given tenant."""
+    pattern = f"projects/{tenant_name}/subscriptions"
+
+    jobs = requests.get(f"{flink_url}/joboverview").json().get("running", [])
+    return any(pattern in job.get("name", "") for job in jobs)
+
+
+def run_ingest(
+    config: ArgoConfig,
+    tenant_name: str,
+    tenant_ams_token: str,
+    dry_run: bool,
+    verify: str,
+):
+    """Function that composes the appropriate cli command to submit an ingest job execution in flink"""
+
+    # if ingestion job is already running skip it
+    if is_ingest_running(config.flink_url, tenant_name):
+        logger.warning(f"Ingestion job already running for tenant {tenant_name}")
+        return 0
+
+    cmd = [
+        config.flink_path,
+        "run",
+        "--detached",
+        "-c",
+        "argo.streaming.AmsIngestMetric",
+        config.ingest_jar_path,
+        "--ams.endpoint",
+        config.ams_endpoint,
+        "--ams.port",
+        "443",
+        "--ams.token",
+        tenant_ams_token,
+        "--ams.project",
+        tenant_name,
+        "--ams.sub",
+        "ingest_metric",
+        "--hdfs.path",
+        f"{config.hdfs_path}/{tenant_name}/mdata",
+        "--check.path",
+        f"{config.hdfs_path}/{tenant_name}/check",
+        "--check.interval",
+        "3000",
+        "--ams.interval",
+        "300",
+        "--ams.batch",
+        "100",
+        "--ams.verify",
+        verify,
+        "--tenant",
+        tenant_name,
+    ]
+
+    if dry_run:
+        print(("\033[92m" + " ".join(str(x) for x in cmd) + "\033[0m"))
+        return 0
+    else:
+        try:
+            subprocess.run(cmd, check=True)
+        except Exception as e:
+            logger.error(f"Batch Job Error: {e}")
+            return 1

--- a/automation/requirements.txt
+++ b/automation/requirements.txt
@@ -2,3 +2,4 @@ requests==2.32.5
 argo-ams-library==1.0.0
 PyYAML==6.0.3
 pymongo==4.16.0
+Jinja2==3.1.6

--- a/automation/run_ingest
+++ b/automation/run_ingest
@@ -2,66 +2,12 @@
 
 import argparse
 import logging
-import subprocess
 import sys
 
+from init_ingest import run_ingest
 from argo_config import ArgoConfig
 
 logger = logging.getLogger(__name__)
-
-
-def run_ingest(
-    config: ArgoConfig,
-    tenant_name: str,
-    tenant_ams_token: str,
-    dry_run: bool,
-    verify: str,
-):
-    """Function that composes the appropriate cli command to submit an ingest job execution in flink"""
-
-    cmd = [
-        config.flink_path,
-        "run",
-        "--detached",
-        "-c",
-        "argo.streaming.AmsIngestMetric",
-        config.ingest_jar_path,
-        "--ams.endpoint",
-        config.ams_endpoint,
-        "--ams.port",
-        "443",
-        "--ams.token",
-        tenant_ams_token,
-        "--ams.project",
-        tenant_name,
-        "--ams.sub",
-        "ingest_metric",
-        "--hdfs.path",
-        f"{config.hdfs_path}/{tenant_name}/mdata",
-        "--check.path",
-        f"{config.hdfs_path}/{tenant_name}/check",
-        "--check.interval",
-        "3000",
-        "--ams.interval",
-        "300",
-        "--ams.batch",
-        "100",
-        "--ams.verify",
-        verify,
-        "--tenant",
-        tenant_name,
-    ]
-
-    if dry_run:
-        print(("\033[92m" + " ".join(str(x) for x in cmd) + "\033[0m"))
-        return 0
-    else:
-        try:
-            subprocess.run(cmd, check=True)
-        except Exception as e:
-            logger.error(f"Batch Job Error: {e}")
-            return 1
-
 
 def main():
     parser = argparse.ArgumentParser(description="Argo Run Ingest")


### PR DESCRIPTION
## Goal

When a new tenant is created we want to be able to automatically start the ingestion job and also prepare the cronjobs for the default computations

## Implementation
- [x] Extend Argo config to include flink_url configuration parameter (where flink http api resides)
- [x] Move run_ingestion logic to init_ingest.py module in order to be able to use it 
- [x] Add logic to check if ingestion job already runs in cluster so to skip it 
- [x] Add cron file template using jinja2
- [x] Add logic to init_compute_engine.py to create cron scripts for tenant default computations
- [x] Call init_ingest logic in init_compute_engine to submit ingestion script when a new tenant has been created
