### PR TITLE
ARGO-5713 new entries not enter when metric profile date is not today

### DIFF
--- a/flink_jobs_v2/ApiResourceManager/src/main/java/argo/amr/ApiResourceManager.java
+++ b/flink_jobs_v2/ApiResourceManager/src/main/java/argo/amr/ApiResourceManager.java
@@ -241,16 +241,18 @@ public class ApiResourceManager {
         JsonObject jRoot = jElement.getAsJsonObject();
         String mpDate = jRoot.get("date").getAsString();
         String yesterdayContent = null;
-        if (mpDate.equals(date)) {
-            DateTime yesterday = convertStringtoDate("yyyy-MM-dd", mpDate).minusDays(1);
-            String yesterdaystr = convertDateToString("yyyy-MM-dd", yesterday);
 
-            String path = "https://%s/api/v2/metric_profiles/%s?date=%s";
-            String fullURL = String.format(path, this.endpoint, this.metricID, yesterdaystr);
-
-            yesterdayContent = this.apiResponseParser.getJsonData(this.requestManager.getResource(fullURL), false);
-
+        if (!mpDate.equals(this.date)) {
+            return new MetricProfile[0];
         }
+        DateTime yesterday = convertStringtoDate("yyyy-MM-dd", mpDate).minusDays(1);
+        String yesterdaystr = convertDateToString("yyyy-MM-dd", yesterday);
+
+        String path = "https://%s/api/v2/metric_profiles/%s?date=%s";
+        String fullURL = String.format(path, this.endpoint, this.metricID, yesterdaystr);
+
+        yesterdayContent = this.apiResponseParser.getJsonData(this.requestManager.getResource(fullURL), false);
+
         List<MetricProfile> newentries = this.apiResponseParser.getListNewMetrics(content, yesterdayContent);
 
         MetricProfile[] rArr = new MetricProfile[newentries.size()];
@@ -360,7 +362,7 @@ public class ApiResourceManager {
     public void getRemoteRecomputations() throws UnknownHostException {
 
         String path = "https://%s/api/v2/recomputations?date=%s&report=%s";
-        String fullURL = String.format(path, this.endpoint, this.date,this.reportName);
+        String fullURL = String.format(path, this.endpoint, this.date, this.reportName);
         String content = this.requestManager.getResource(fullURL);
 
         this.data.put(ApiResource.RECOMPUTATIONS, this.apiResponseParser.getJsonData(content, true));


### PR DESCRIPTION
When the metric profile date is not today this means that the metric profile already existed so we dont need to check for new entries. This part was missing and because the mdate!=date the yesterdayContent was null
with the latest change to new metric profile entries , if yesterdayContent is null all metric profile data are considered new entries so all get the status unknown
this is fixed to check if the mdate!=date and at this case no new entries are searched