### PR TITLE
ARGO-5787 Support node-registry topology in automation

### DIFF
--- a/automation/argo_automator
+++ b/automation/argo_automator
@@ -18,6 +18,7 @@ from init_ams import init_ams
 from init_compute_engine import init_compute_engine
 from init_mongo import init_mongo
 from init_desy import init_desy
+from init_node_registry import init_node_registry
 
 REQUEST_TIMEOUT = 30
 TOKEN_REFRESH_BUFFER = 60
@@ -189,7 +190,9 @@ class ArgoAutomator:
                 self.executor.submit(self.job_init_mongo, tenant_id, tenant_name)
                 return
             if job_name == JobName.INIT_INTEGRATION_TOPO.value:
-                self.executor.submit(self.job_init_desy, tenant_id, tenant_name)
+                # we need another event prop to decide between desy and node-registry
+                feed_type=props.get("feed_type")
+                self.executor.submit(self.job_init_topo_integration, tenant_id, tenant_name, feed_type)
                 return
             if job_name == JobName.INIT_AMS.value:
                 self.executor.submit(self.job_init_ams, tenant_id, tenant_name)
@@ -297,13 +300,25 @@ class ArgoAutomator:
         except Exception as e:
             logger.exception(f"job failed for tenant {tenant_name}: {e}")
 
-    def job_init_desy(self, tenant_id: str, tenant_name: str):
+    def job_init_topo_integration(self, tenant_id: str, tenant_name: str, feed_type:str):
         """Job to initialise desy integration"""
         try:
 
-            
+            if feed_type not in ["DESY_MARKETPLACE", "NODE_REGISTRY"]:
+                self.mon_api.update_status(
+                    tenant_id,
+                    tenant_name,
+                    JobName.INIT_INTEGRATION_TOPO.value,
+                    JobStatus.FAILED.value,
+                    "Desy Marketplace topology integration failed to initialize",
+                )
+                logger.error(
+                    f"job failed: initialising topo integaration for tenant {tenant_name} - invalid feed type: {feed_type}"
+                )
+
+
             logger.info(
-                f"job started: initialising desy integration for tenant {tenant_name} with id: {tenant_id}"
+                f"job started: initialising  topo integration: {feed_type} for tenant {tenant_name} with id: {tenant_id}"
             )
 
             self.mon_api.update_status(
@@ -311,10 +326,13 @@ class ArgoAutomator:
                 tenant_name,
                 JobName.INIT_INTEGRATION_TOPO.value,
                 JobStatus.IN_PROGRESS.value,
-                "Initialising Desy Marketplace topology integration",
+                f"Initialising {feed_type} topology integration",
             )
 
-            job_done = init_desy(self.config, tenant_name)
+            if feed_type == "DESY_MARKETPLACE":
+                job_done = init_desy(self.config, tenant_name)
+            else:
+                job_done = init_node_registry(self.config, tenant_name)
 
             if job_done:
                 self.mon_api.update_status(
@@ -322,10 +340,10 @@ class ArgoAutomator:
                     tenant_name,
                     JobName.INIT_INTEGRATION_TOPO.value,
                     JobStatus.COMPLETED.value,
-                    "Desy Marketplace topology integration initialised succesfully",
+                    f"{feed_type} topology integration initialised succesfully",
                 )
                 logger.info(
-                    f"job completed: initialising desy integration for tenant {tenant_name}"
+                    f"job completed: initialising {feed_type} integration for tenant {tenant_name}"
                 )
             else:
                 self.mon_api.update_status(
@@ -333,7 +351,7 @@ class ArgoAutomator:
                     tenant_name,
                     JobName.INIT_INTEGRATION_TOPO.value,
                     JobStatus.FAILED.value,
-                    "Desy Marketplace topology integration failed to initialize",
+                    f"{feed_type} topology integration failed to initialize",
                 )
                 logger.error(
                     f"job failed: initialising desy integaration for tenant {tenant_name}"

--- a/automation/argo_config.py
+++ b/automation/argo_config.py
@@ -22,6 +22,8 @@ class ArgoConfig:
         self.automation = automation
         self.tenants = tenants
         self.run = run
+        self.node_registry_url = automation.get("node_registry_url")
+        self.node_registry_token = automation.get("node_registry_token")
         self.ams_endpoint = automation.get("ams_endpoint")
         self.ams_event_token = automation.get("ams_event_token")
         self.ams_event_project = automation.get("ams_event_project")

--- a/automation/config.yml.example
+++ b/automation/config.yml.example
@@ -1,6 +1,8 @@
 ---
 
 automation:
+  node_registry_endpoint: https://node-registry.example.foo
+  node_registry_token: node-registry-s3cr3t
   ams_endpoint: localhost:8443
   ams_event_token: s3cr3t
   ams_event_project: ARGO-MON-AUTOMATION-PROJECT

--- a/automation/init_node_registry.py
+++ b/automation/init_node_registry.py
@@ -1,0 +1,276 @@
+import logging
+import os
+import uuid
+from urllib.parse import urlparse
+
+import requests
+from jinja2 import Environment, FileSystemLoader
+
+from argo_config import ArgoConfig
+from argo_web_api import ArgoWebApi, TopoItem
+
+logger = logging.getLogger(__name__)
+
+REQUEST_TIMEOUT = 30
+TEMPLATE_FILE = "node-registry.cron.j2"
+CRON_DIR = "/etc/cron.d"
+CRON_PREFIX = "argo_node_registry"
+SERVICE_TYPE = "webportal"
+
+
+
+def get_node_registry(url: str, token: str):
+    """Retrieve the list of nodes from the node registry"""
+    logger.debug(f"retrieving nodes from node registry: {url}")
+
+    headers = {"x-api-key": token, "Accept": "application/json"}
+
+    try:
+        response = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT)
+        response.raise_for_status()
+
+    except requests.exceptions.HTTPError as e:
+        if e.response is not None and e.response.status_code == 404:
+            logger.warning(f"node registry has no nodes: {url}")
+            return []
+        raise
+
+    data = response.json()
+
+    # tolerate both a bare list and a wrapped {"results": [...]} payload
+    if isinstance(data, dict):
+        for key in ("results", "data", "nodes"):
+            if isinstance(data.get(key), list):
+                return data[key]
+        return []
+
+    return data
+
+
+def get_node_capabilities(node_endpoint: str):
+    """Retrieve the capability list of a single node (unauthenticated GET)"""
+    logger.debug(f"retrieving capabilities from node endpoint: {node_endpoint}")
+
+    try:
+        response = requests.get(node_endpoint, timeout=REQUEST_TIMEOUT)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        logger.warning(f"unable to retrieve node endpoint {node_endpoint}: {e}")
+        return []
+
+    try:
+        data = response.json()
+    except ValueError:
+        logger.warning(f"node endpoint {node_endpoint} did not return valid json")
+        return []
+
+    return data.get("capabilities") or []
+
+
+def create_node_registry_cron(config: ArgoConfig, tenant_name: str) -> bool:
+    """Create cron file for node registry integration"""
+    template_dir = os.path.dirname(os.path.abspath(__file__))
+
+    env = Environment(loader=FileSystemLoader(template_dir), keep_trailing_newline=True)
+    template = env.get_template(TEMPLATE_FILE)
+    content = template.render(tenant=tenant_name)
+
+    filepath = os.path.join(CRON_DIR, f"{CRON_PREFIX}_{tenant_name}")
+    try:
+        with open(filepath, "w") as f:
+            f.write(content)
+        os.chmod(filepath, 0o644)
+        return True
+    except PermissionError:
+        logger.error(
+            "Permission error while creating node registry integration cron file"
+        )
+
+    return False
+
+
+def remove_node_registry_cron(tenant_name: str) -> bool:
+    """Remove cron file for node registry integration"""
+    filename = f"{CRON_PREFIX}_{tenant_name}"
+    logger.info(f"Attempting to remove node registry cron file: {filename}")
+
+    filepath = os.path.join(CRON_DIR, filename)
+    try:
+        os.remove(filepath)
+        logger.info(f"File removed: {filename}")
+        return True
+    except FileNotFoundError:
+        logger.info(f"File not found: {filename}")
+        return True
+    except PermissionError:
+        logger.error(
+            "Permission error while removing node registry integration cron file"
+        )
+
+    return False
+
+
+def init_node_registry(config: ArgoConfig, tenant_name: str) -> bool:
+    if config.node_registry_token and config.node_registry_token:
+        create_node_registry_cron(config, tenant_name)
+        update_node_registry_topology(config, tenant_name)
+        return True
+    return False
+
+
+def build_group(tenant_name: str, node_name: str) -> dict:
+    return {
+        "group": tenant_name,
+        "type": "PROJECT",
+        "subgroup": node_name,
+        "tags": {"monitored": "1", "scope": tenant_name},
+    }
+
+
+def build_endpoint(node_name: str, capability: dict, item_uuid: str) -> dict:
+    item_URL = capability.get("endpoint")
+    hostname = urlparse(item_URL).hostname
+
+    tags = {
+        "hostname": hostname,
+        "info_ID": item_uuid,
+        "info_URL": item_URL,
+        "monitored": "1",
+    }
+    labels=""
+    capability_type = capability.get("capability_type")
+    if capability_type:
+        tags["info_capability_type"] = capability_type
+        tags["labels"]=capability_type
+
+    protocol = capability.get("protocol")
+    if protocol:
+        tags["info_protocol"] = protocol
+
+    return {
+        "group": node_name,
+        "type": "SERVICEGROUPS",
+        "service": SERVICE_TYPE,
+        "hostname": f"{hostname}_{item_uuid}",
+        "tags": tags,
+    }
+
+
+def update_node_registry_topology(
+    config: ArgoConfig, tenant_name: str
+):
+
+    url = config.node_registry_url
+    token = config.node_registry_token
+
+    # get local tenant configuration
+    tenant = config.tenants.get(tenant_name)
+    tenant_id = tenant["id"]
+    tenant_web_api_token = tenant["web_api_token"]
+
+    # init connection to web-api
+    web_api = ArgoWebApi(config)
+
+    # get node list from the remote node registry
+    nodes = get_node_registry(url, token)
+
+    old_endpoints = web_api.get_topology(
+        tenant_id, tenant_name, tenant_web_api_token, TopoItem.ENDPOINTS
+    )
+    old_groups = web_api.get_topology(
+        tenant_id, tenant_name, tenant_web_api_token, TopoItem.GROUPS
+    )
+
+    index_old_endpoints = {}
+    index_old_groups = {}
+    new_endpoints = []
+    new_groups = []
+
+    for item in old_endpoints:
+        info_URL = item.get("tags", {}).get("info_URL")
+        if info_URL:
+            # an endpoint is identified by its group + capability url
+            index_old_endpoints[(item.get("group"), info_URL)] = item
+
+    for item in old_groups:
+        index_old_groups[item.get("subgroup")] = item
+
+    changed_endpoints = False
+    changed_groups = False
+
+    for node in nodes:
+
+        node_name = node.get("name")
+        node_endpoint = node.get("node_endpoint")
+
+        if not node_name:
+            logger.warning("node registry entry without a name - skipping")
+            continue
+
+        new_group = build_group(tenant_name, node_name)
+        new_groups.append(new_group)
+
+        old_group = index_old_groups.get(node_name)
+        if old_group:
+            # Remove date key because it is not relevant for comparison
+            old_group.pop("date", None)
+            if new_group != old_group:
+                changed_groups = True
+        else:
+            changed_groups = True
+
+        if not node_endpoint:
+            logger.warning(f"node {node_name} has no node_endpoint - skipping")
+            continue
+
+        for capability in get_node_capabilities(node_endpoint):
+
+            item_URL = capability.get("endpoint")
+            if not item_URL:
+                logger.warning(
+                    f"node {node_name} has a capability without an endpoint - skipping"
+                )
+                continue
+
+            old_endpoint = index_old_endpoints.get((node_name, item_URL))
+
+            if old_endpoint:
+                item_uuid = old_endpoint.get("tags", {}).get("info_ID")
+                if not item_uuid:
+                    item_uuid = str(uuid.uuid4())
+
+                new_endpoint = build_endpoint(node_name, capability, item_uuid)
+                new_endpoints.append(new_endpoint)
+
+                # Remove date key because it is not relevant for comparison
+                old_endpoint.pop("date", None)
+                if new_endpoint != old_endpoint:
+                    changed_endpoints = True
+            else:
+                item_uuid = str(uuid.uuid4())
+                new_endpoints.append(
+                    build_endpoint(node_name, capability, item_uuid)
+                )
+                changed_endpoints = True
+
+    if not changed_endpoints and not changed_groups:
+        if len(new_endpoints) == len(old_endpoints) and len(new_groups) == len(
+            old_groups
+        ):
+            logger.info(
+                f"Node-registry-connector: Topology for tenant {tenant_name} "
+                "remains the same - no upload"
+            )
+            return
+
+    logger.info(
+        f"Node-registry-connector: Topology changes found for tenant {tenant_name} "
+        " - will upload"
+    )
+
+    web_api.create_topology_groups(
+        tenant_id, tenant_name, tenant_web_api_token, new_groups
+    )
+    web_api.create_topology_endpoints(
+        tenant_id, tenant_name, tenant_web_api_token, new_endpoints
+    )

--- a/automation/node-registry.cron.j2
+++ b/automation/node-registry.cron.j2
@@ -1,0 +1,4 @@
+PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+0 * * * * root /root/automation/automator-venv/bin/python /root/automation/run_node_registry -t {{ tenant }}  -c /root/automation/config.yml
+
+

--- a/automation/run_node_registry
+++ b/automation/run_node_registry
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+ 
+import argparse
+import logging
+import sys
+import requests
+import uuid
+import json
+import os
+ 
+from urllib.parse import urlparse
+ 
+from argo_config import ArgoConfig
+from argo_web_api import ArgoWebApi, TopoItem
+from init_node_registry import (
+    update_node_registry_topology,
+    create_node_registry_cron,
+    remove_node_registry_cron,
+)
+ 
+logger = logging.getLogger(__name__)
+ 
+REQUEST_TIMEOUT = 30
+TEMPLATE_FILE = "node_registry.cron.j2"
+CRON_DIR = "/etc/cron.d"
+ 
+ 
+def main():
+    parser = argparse.ArgumentParser(
+        description="Argo Run Node Registry Integration"
+    )
+    parser.add_argument(
+        "-c",
+        "--config",
+        default="config.yml",
+        help="Path to configuration file (default: config.yml)",
+    )
+    parser.add_argument(
+        "-l",
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Set logging level (default: INFO)",
+    )
+    parser.add_argument(
+        "-t",
+        "--tenant",
+        required=True,
+        type=str,
+        help="select tenant name for integration",
+    )
+ 
+    parser.add_argument(
+        "--no-verify",
+        action="store_const",
+        const="false",
+        default="true",
+        dest="verify",
+        help="Disable verification",
+    )
+ 
+    args = parser.parse_args()
+ 
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
+ 
+    config = ArgoConfig(args.config)
+   
+   
+    if config.node_registry_url and config.node_registry_token:
+        update_node_registry_topology(
+            config, args.tenant
+        )
+    else:
+        remove_node_registry_cron(args.tenant)
+ 
+ 
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Goal
Support Node-registry integration as a topology feed in argo monitoring automation

## Implementation
- [x] Update ArgoConfig.py to accept node_registry configuration options
 - [x] Add init_node_registry.py where the full logic of the node-registry integration is implemented
 - [x] Add run-node-registry ~ a cli execution script to allow topology updates per tenant based on node-registry integration. This is also used as a the base for the cron scripts
 - [x] Add nopde-registry.cron.j2 template in order to generate node-registry cron scripts for tenants
 - [x] Update argo_automator to handle topo integration jobs for both feed types: desy-marketplace and node-registry